### PR TITLE
Handle case where kafka returns 0 partitions

### DIFF
--- a/async/kafka/kafka.go
+++ b/async/kafka/kafka.go
@@ -158,7 +158,12 @@ func (c *consumer) Consume(ctx context.Context) (<-chan async.Message, <-chan er
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to get partitions")
 	}
-	log.Infof("consuming messages for topic '%s'", c.topic)
+	// When kafka cluster is not fully initialized, we may get 0 partions.
+	if len(pcs) == 0 {
+		return nil, nil, errors.New("got 0 partitions")
+	}
+
+	log.Infof("consuming messages for topic '%s' from %d partitions", c.topic, len(pcs))
 	chMsg := make(chan async.Message, c.buffer)
 	chErr := make(chan error, c.buffer)
 


### PR DESCRIPTION
## The issue:
Most of the times our service seems connected to Kafka but does not consume messages.
That happened in a docker-compose environment when trying to connect to kafka-zookeeper image, while it was starting. After restarting our service the message consumption worked as expected.
 
Here are the logs before the fix (Note: I did edit the logging of library for debugging purposes):
```
{"lvl":"error","host":"****","srv":"periscope","ver":"0.0.0","time":"2019-02-21T19:19:17.70551471Z","src":"async/component.go:88","msg":"failed run, retry 0/30 with 10s wait: failed to get consumer channels: failed to get partitions: failed to create consumer: kafka: client has run out of available brokers to talk to (Is your cluster reachable?)"}
{"lvl":"error","host":"****","srv":"periscope","ver":"0.0.0","time":"2019-02-21T19:19:28.471916011Z","src":"async/component.go:88","msg":"failed run, retry 1/30 with 10s wait: failed to get consumer channels: failed to get partitions: failed to create consumer: kafka: client has run out of available brokers to talk to (Is your cluster reachable?)"}
{"lvl":"error","host":"****","srv":"periscope","ver":"0.0.0","time":"2019-02-21T19:19:39.27044811Z","src":"async/component.go:88","msg":"failed run, retry 2/30 with 10s wait: failed to get consumer channels: failed to get partitions: failed to create consumer: kafka: client has run out of available brokers to talk to (Is your cluster reachable?)"}
{"lvl":"info","host":"****","srv":"periscope","ver":"0.0.0","time":"2019-02-21T19:19:55.052441379Z","src":"kafka/kafka.go:162","msg":"consuming messages for topic '****' from 0 partitions"}```

It turns out, `sarama.NewConsumer(c.brokers, c.cfg).Partitions(c.topic)` return an empty list of partitions without an error. This maybe fixed in newer release of sarama (need to check).

In my PR I provide a quick workaround to the issue, which is critical for us.

I have tested the fix in the same environment and it works as expected, here are the logs:  
```{"lvl":"error","host":"periscope","srv":"****","ver":"0.0.0","time":"2019-02-21T19:52:01.426472888Z","src":"async/component.go:88","msg":"failed run, retry 0/30 with 10s wait: failed to get consumer channels: failed to get partitions: failed to create consumer: kafka: client has run out of available brokers to talk to (Is your cluster reachable?)"}
{"lvl":"error","host":"periscope","srv":"****","ver":"0.0.0","time":"2019-02-21T19:52:12.210451966Z","src":"async/component.go:88","msg":"failed run, retry 1/30 with 10s wait: failed to get consumer channels: failed to get partitions: failed to create consumer: kafka: client has run out of available brokers to talk to (Is your cluster reachable?)"}
{"lvl":"error","host":"periscope","srv":"****","ver":"0.0.0","time":"2019-02-21T19:52:23.007198404Z","src":"async/component.go:88","msg":"failed run, retry 2/30 with 10s wait: failed to get consumer channels: failed to get partitions: failed to create consumer: kafka: client has run out of available brokers to talk to (Is your cluster reachable?)"}
{"lvl":"error","host":"periscope","srv":"****","ver":"0.0.0","time":"2019-02-21T19:52:36.560782099Z","src":"async/component.go:88","msg":"failed run, retry 3/30 with 10s wait: failed to get consumer channels: got 0 partitions"}
{"lvl":"info","host":"periscope","srv":"****","ver":"0.0.0","time":"2019-02-21T19:52:46.905905917Z","src":"kafka/kafka.go:166","msg":"consuming messages for topic '****' from 1 partitions"}```
