### PR TITLE
Introduce readiness handler option for async component #19

### DIFF
--- a/async/component.go
+++ b/async/component.go
@@ -17,6 +17,7 @@ type Component struct {
 	name         string
 	proc         ProcessorFunc
 	failStrategy FailStrategy
+	readiness    func()
 	cf           ConsumerFactory
 	retries      int
 	retryWait    time.Duration
@@ -44,6 +45,7 @@ func New(name string, p ProcessorFunc, cf ConsumerFactory, oo ...OptionFunc) (*C
 		proc:         p,
 		cf:           cf,
 		failStrategy: NackExitStrategy,
+		readiness:    func() {},
 		retries:      0,
 		retryWait:    0,
 		info:         make(map[string]interface{}),
@@ -124,6 +126,9 @@ func (c *Component) processing(ctx context.Context) error {
 			}
 		}
 	}()
+
+	c.readiness()
+
 	return <-failCh
 }
 

--- a/async/option.go
+++ b/async/option.go
@@ -64,3 +64,12 @@ func ConsumerRetry(retries int, retryWait time.Duration) OptionFunc {
 		return nil
 	}
 }
+
+// ReadinessHandler option set's a func to be called when an async component is consider ready.
+func ReadinessHandler(handler func()) OptionFunc {
+	return func(c *Component) error {
+		c.readiness = handler
+		log.Info("readiness handler set")
+		return nil
+	}
+}

--- a/async/option_test.go
+++ b/async/option_test.go
@@ -81,3 +81,11 @@ func TestConsumerRetry(t *testing.T) {
 		})
 	}
 }
+
+func TestReadinessHandler(t *testing.T) {
+	proc := mockProcessor{}
+	c, err := New("test", proc.Process, &mockConsumerFactory{})
+	assert.NoError(t, err)
+	err = ReadinessHandler(func() {})(c)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Which problem is this PR solving?

This PR is a proposed solution for #19 issue.

## Short description of the changes

This PR adds a new option that set's a readiness handler.

Readiness handler is called when the underlying async component is able to connect without errors.
If the option is not provided, it defaults to an empty/noop function.