### PR TITLE
Generic middleware stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Patron is a framework for creating microservices, originally created by Sotiris 
 
 `Patron` is french for `template` or `pattern`, but it means also `boss` which we found out later (no pun intended).
 
-The entry point of the framework is the `Service`. The `Service` uses `Components` to handle the processing of sync and async requests. The `Service` starts by default a `HTTP Component` which hosts the debug, health and metric endpoints. Any other endpoints will be added to the default `HTTP Component` as `Routes`. The service set's up by default logging with `zerolog`, tracing and metrics with `jaeger` and `prometheus`.
+The entry point of the framework is the `Service`. The `Service` uses `Components` to handle the processing of sync and async requests. The `Service` starts by default a `HTTP Component` which hosts the debug, health and metric endpoints. Any other endpoints will be added to the default `HTTP Component` as `Routes`. Alongside `Routes` one can specify middleware functions to be applied ordered to all routes as `MiddlewareFunc`. The service set's up by default logging with `zerolog`, tracing and metrics with `jaeger` and `prometheus`.
 
 `Patron` provides abstractions for the following functionality of the framework:
 
@@ -116,11 +116,29 @@ The following component implementations are available:
 
 Adding to the above list is as easy as implementing a `Component` and a `Processor` for that component.
 
+### Middleware
+
+A `MiddlewareFunc` preserves the default net/http middleware pattern.
+You can create new middleware functions and pass them to Service to be chained on all routes in the default Http Component.
+
+```go
+type MiddlewareFunc func(next http.HandlerFunc) http.HandlerFunc
+
+// Setup a simple middleware for CORS
+newMiddleware := func(h http.HandlerFunc) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Add("Access-Control-Allow-Origin", "*")
+        // Next
+        h(w, r)
+    }
+}
+```
+
 ## Examples
 
 Detailed examples can be found in the [examples](/examples) folder with the following components involved:
 
-- [HTTP Component, HTTP Tracing](/examples/first/main.go)
+- [HTTP Component, HTTP Tracing, HTTP middleware](/examples/first/main.go)
 - [Kafka Component, HTTP Component, HTTP Authentication, Kafka Tracing](/examples/second/main.go)
 - [Kafka Component, AMQP Tracing](/examples/third/main.go)
 - [AMQP Component](/examples/fourth/main.go)

--- a/examples/first/main.go
+++ b/examples/first/main.go
@@ -46,6 +46,16 @@ func main() {
 		patronhttp.NewPostRoute("/", first, true),
 	}
 
+	// Setup a simple CORS middleware
+	middlewareCors := func(h http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Access-Control-Allow-Origin", "*")
+			w.Header().Add("Access-Control-Allow-Methods", "GET, POST")
+			w.Header().Add("Access-Control-Allow-Headers", "Origin, Authorization, Content-Type")
+			w.Header().Add("Access-Control-Allow-Credentials", "Allow")
+			h(w, r)
+		}
+	}
 	sig := patron.SIGHUP(func() {
 		fmt.Println("exit gracefully...")
 		os.Exit(0)
@@ -55,6 +65,7 @@ func main() {
 		name,
 		version,
 		patron.Routes(routes),
+		patron.Middlewares(middlewareCors),
 		sig,
 	)
 	if err != nil {

--- a/option.go
+++ b/option.go
@@ -23,10 +23,10 @@ func Routes(rr []http.Route) OptionFunc {
 }
 
 // Middlewares option for adding generic middlewares to the default HTTP component.
-func Middlewares(mm []http.MiddlewareFunc) OptionFunc {
+func Middlewares(mm ...http.MiddlewareFunc) OptionFunc {
 	return func(s *Service) error {
 		if len(mm) == 0 {
-			return nil
+			return errors.New("middlewares are required")
 		}
 		s.middlewares = mm
 		log.Info("middleware options are set")

--- a/option.go
+++ b/option.go
@@ -22,6 +22,18 @@ func Routes(rr []http.Route) OptionFunc {
 	}
 }
 
+// Middlewares option for adding generic middlewares to the default HTTP component.
+func Middlewares(mm []http.MiddlewareFunc) OptionFunc {
+	return func(s *Service) error {
+		if len(mm) == 0 {
+			return nil
+		}
+		s.middlewares = mm
+		log.Info("middleware options are set")
+		return nil
+	}
+}
+
 // HealthCheck option for overriding the default health check of the default HTTP component.
 func HealthCheck(hcf http.HealthCheckFunc) OptionFunc {
 	return func(s *Service) error {

--- a/option_test.go
+++ b/option_test.go
@@ -1,25 +1,25 @@
 package patron
 
 import (
-	http2 "net/http"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/thebeatapp/patron/sync/http"
+	phttp "github.com/thebeatapp/patron/sync/http"
 )
 
 func TestRoutes(t *testing.T) {
 	type args struct {
-		rr []http.Route
+		rr []phttp.Route
 	}
 	tests := []struct {
 		name    string
 		args    args
 		wantErr bool
 	}{
-		{"failure due to empty routes", args{rr: []http.Route{}}, true},
+		{"failure due to empty routes", args{rr: []phttp.Route{}}, true},
 		{"failure due to nil routes", args{rr: nil}, true},
-		{"success", args{rr: []http.Route{http.NewRoute("/", "GET", nil, true, nil)}}, false},
+		{"success", args{rr: []phttp.Route{phttp.NewRoute("/", "GET", nil, true, nil)}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -36,27 +36,28 @@ func TestRoutes(t *testing.T) {
 }
 
 func TestMiddlewares(t *testing.T) {
-	middleware := func(h http2.HandlerFunc) http2.HandlerFunc {
-		return func(w http2.ResponseWriter, r *http2.Request) {
+	middleware := func(h http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
 			h(w, r)
 		}
 	}
 	type args struct {
-		mm []http.MiddlewareFunc
+		mm []phttp.MiddlewareFunc
 	}
 	tests := []struct {
 		name    string
 		args    args
 		wantErr bool
 	}{
-		{"success", args{mm: []http.MiddlewareFunc{middleware}}, false},
-		{"success", args{mm: []http.MiddlewareFunc{}}, false},
+		{"success", args{mm: []phttp.MiddlewareFunc{middleware}}, false},
+		{"failure because empty", args{mm: []phttp.MiddlewareFunc{}}, true},
+		{"failure because nil", args{mm: nil}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s, err := New("test", "1.0.0")
 			assert.NoError(t, err)
-			err = Middlewares(tt.args.mm)(s)
+			err = Middlewares(tt.args.mm...)(s)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -68,7 +69,7 @@ func TestMiddlewares(t *testing.T) {
 
 func TestHealthCheck(t *testing.T) {
 	type args struct {
-		hcf http.HealthCheckFunc
+		hcf phttp.HealthCheckFunc
 	}
 	tests := []struct {
 		name    string
@@ -76,7 +77,7 @@ func TestHealthCheck(t *testing.T) {
 		wantErr bool
 	}{
 		{"failure due to nil health check", args{hcf: nil}, true},
-		{"success", args{hcf: http.DefaultHealthCheck}, false},
+		{"success", args{hcf: phttp.DefaultHealthCheck}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/option_test.go
+++ b/option_test.go
@@ -16,8 +16,8 @@ func TestRoutes(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"failure due to empty routes", args{rr: []http.Route{}}, true},
-		{"failure due to nil routes", args{rr: nil}, true},
+		//{"failure due to empty routes", args{rr: []http.Route{}}, true},
+		//{"failure due to nil routes", args{rr: nil}, true},
 		{"success", args{rr: []http.Route{http.NewRoute("/", "GET", nil, true, nil)}}, false},
 	}
 	for _, tt := range tests {

--- a/service_test.go
+++ b/service_test.go
@@ -3,20 +3,20 @@ package patron
 import (
 	"context"
 	"math/rand"
-	http2 "net/http"
+	"net/http"
 	"os"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/thebeatapp/patron/errors"
-	"github.com/thebeatapp/patron/sync/http"
+	phttp "github.com/thebeatapp/patron/sync/http"
 )
 
 func TestNewServer(t *testing.T) {
-	route := http.NewRoute("/", "GET", nil, true, nil)
-	middleware := func(h http2.HandlerFunc) http2.HandlerFunc {
-		return func(w http2.ResponseWriter, r *http2.Request) {
+	route := phttp.NewRoute("/", "GET", nil, true, nil)
+	middleware := func(h http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
 			h(w, r)
 		}
 	}
@@ -29,10 +29,10 @@ func TestNewServer(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"success", args{name: "test", opt: []OptionFunc{Routes([]http.Route{route}), Middlewares([]http.MiddlewareFunc{middleware})}}, false},
-		{"success empty middlewares", args{name: "test", opt: []OptionFunc{Routes([]http.Route{route}), Middlewares([]http.MiddlewareFunc{})}}, false},
-		{"failed missing name", args{name: "", opt: []OptionFunc{Routes([]http.Route{route})}}, true},
-		{"failed missing routes", args{name: "test", opt: []OptionFunc{Routes([]http.Route{})}}, true},
+		{"success", args{name: "test", opt: []OptionFunc{Routes([]phttp.Route{route}), Middlewares(middleware)}}, false},
+		{"failed empty middlewares", args{name: "test", opt: []OptionFunc{Routes([]phttp.Route{route}), Middlewares([]phttp.MiddlewareFunc{}...)}}, true},
+		{"failed missing name", args{name: "", opt: []OptionFunc{Routes([]phttp.Route{route})}}, true},
+		{"failed missing routes", args{name: "test", opt: []OptionFunc{Routes([]phttp.Route{})}}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/sync/http/component.go
+++ b/sync/http/component.go
@@ -31,9 +31,10 @@ type Component struct {
 	httpWriteTimeout time.Duration
 	info             map[string]interface{}
 	sync.Mutex
-	routes   []Route
-	certFile string
-	keyFile  string
+	routes      []Route
+	middlewares []MiddlewareFunc
+	certFile    string
+	keyFile     string
 }
 
 // New returns a new component.
@@ -44,6 +45,7 @@ func New(oo ...OptionFunc) (*Component, error) {
 		httpReadTimeout:  httpReadTimeout,
 		httpWriteTimeout: httpWriteTimeout,
 		routes:           []Route{},
+		middlewares:      []MiddlewareFunc{},
 		info:             make(map[string]interface{}),
 	}
 
@@ -73,7 +75,8 @@ func (c *Component) Run(ctx context.Context) error {
 	c.Lock()
 	log.Debug("applying tracing to routes")
 	for i := 0; i < len(c.routes); i++ {
-		c.routes[i].Handler = Middleware(c.routes[i].Trace, c.routes[i].Auth, c.routes[i].Pattern, c.routes[i].Handler)
+		c.routes[i].Handler = DefaultMiddlewares(c.routes[i].Trace, c.routes[i].Auth, c.routes[i].Pattern, c.routes[i].Handler)
+		c.routes[i].Handler = ChainMiddlewares(c.routes[i].Handler, c.middlewares...)
 	}
 	chFail := make(chan error)
 	srv := c.createHTTPServer()

--- a/sync/http/component.go
+++ b/sync/http/component.go
@@ -75,8 +75,8 @@ func (c *Component) Run(ctx context.Context) error {
 	c.Lock()
 	log.Debug("applying tracing to routes")
 	for i := 0; i < len(c.routes); i++ {
-		c.routes[i].Handler = DefaultMiddlewares(c.routes[i].Trace, c.routes[i].Auth, c.routes[i].Pattern, c.routes[i].Handler)
-		c.routes[i].Handler = ChainMiddlewares(c.routes[i].Handler, c.middlewares...)
+		c.routes[i].Handler = MiddlewareDefaults(c.routes[i].Trace, c.routes[i].Auth, c.routes[i].Pattern, c.routes[i].Handler)
+		c.routes[i].Handler = MiddlewareChain(c.routes[i].Handler, c.middlewares...)
 	}
 	chFail := make(chan error)
 	srv := c.createHTTPServer()

--- a/sync/http/middleware.go
+++ b/sync/http/middleware.go
@@ -52,19 +52,28 @@ func (w *responseWriter) WriteHeader(code int) {
 	w.statusHeaderWritten = true
 }
 
-// Middleware which returns all selected middlewares.
-func Middleware(trace bool, auth auth.Authenticator, path string, next http.HandlerFunc) http.HandlerFunc {
-	if trace {
-		if auth == nil {
-			return tracingMiddleware(path, recoveryMiddleware(next))
-		}
-		return tracingMiddleware(path, authMiddleware(auth, recoveryMiddleware(next)))
+// ChainMiddlewares chains middlewares to a handler func.
+func ChainMiddlewares(f http.HandlerFunc, mm ...MiddlewareFunc) http.HandlerFunc {
+	for i:=len(mm)-1; i>=0; i-- {
+		f = mm[i](f)
 	}
-	if auth == nil {
-		return recoveryMiddleware(next)
-	}
-	return authMiddleware(auth, recoveryMiddleware(next))
+	return f
 }
+
+// DefaultMiddlewares chains all default middlewares handler function and returns the handler func.
+func DefaultMiddlewares(trace bool, auth auth.Authenticator, path string, next http.HandlerFunc) http.HandlerFunc {
+	next = recoveryMiddleware(next)
+	if auth != nil {
+		next = authMiddleware(auth, next)
+	}
+	if trace {
+		next = tracingMiddleware(path, next)
+	}
+	return next
+}
+
+// MiddlewareFunc type declaration of middleware func.
+type MiddlewareFunc func(next http.HandlerFunc) http.HandlerFunc
 
 func tracingMiddleware(path string, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/sync/http/middleware.go
+++ b/sync/http/middleware.go
@@ -52,16 +52,16 @@ func (w *responseWriter) WriteHeader(code int) {
 	w.statusHeaderWritten = true
 }
 
-// ChainMiddlewares chains middlewares to a handler func.
-func ChainMiddlewares(f http.HandlerFunc, mm ...MiddlewareFunc) http.HandlerFunc {
-	for i:=len(mm)-1; i>=0; i-- {
+// MiddlewareChain chains middlewares to a handler func.
+func MiddlewareChain(f http.HandlerFunc, mm ...MiddlewareFunc) http.HandlerFunc {
+	for i := len(mm) - 1; i >= 0; i-- {
 		f = mm[i](f)
 	}
 	return f
 }
 
-// DefaultMiddlewares chains all default middlewares handler function and returns the handler func.
-func DefaultMiddlewares(trace bool, auth auth.Authenticator, path string, next http.HandlerFunc) http.HandlerFunc {
+// MiddlewareDefaults chains all default middlewares to handler function and returns the handler func.
+func MiddlewareDefaults(trace bool, auth auth.Authenticator, path string, next http.HandlerFunc) http.HandlerFunc {
 	next = recoveryMiddleware(next)
 	if auth != nil {
 		next = authMiddleware(auth, next)

--- a/sync/http/middleware_test.go
+++ b/sync/http/middleware_test.go
@@ -51,7 +51,7 @@ func TestMiddleware(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resp := httptest.NewRecorder()
-			Middleware(tt.args.trace, tt.args.auth, "path", tt.args.next)(resp, r)
+			DefaultMiddlewares(tt.args.trace, tt.args.auth, "path", tt.args.next)(resp, r)
 			assert.Equal(t, tt.expectedCode, resp.Code)
 		})
 	}

--- a/sync/http/middleware_test.go
+++ b/sync/http/middleware_test.go
@@ -26,7 +26,17 @@ func testPanicHandleInt(w http.ResponseWriter, r *http.Request) {
 	panic(1000)
 }
 
-func TestMiddleware(t *testing.T) {
+// A middleware generator that tags resp for assertions
+func tagMiddleware(tag string) MiddlewareFunc {
+	return func(h http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(tag))
+			h(w, r)
+		}
+	}
+}
+
+func TestMiddlewareDefaults(t *testing.T) {
 	r, err := http.NewRequest("POST", "/test", nil)
 	assert.NoError(t, err)
 
@@ -51,8 +61,42 @@ func TestMiddleware(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resp := httptest.NewRecorder()
-			DefaultMiddlewares(tt.args.trace, tt.args.auth, "path", tt.args.next)(resp, r)
+			MiddlewareDefaults(tt.args.trace, tt.args.auth, "path", tt.args.next)(resp, r)
 			assert.Equal(t, tt.expectedCode, resp.Code)
+		})
+	}
+}
+
+func TestMiddlewareChain(t *testing.T) {
+	r, err := http.NewRequest("POST", "/test", nil)
+	assert.NoError(t, err)
+
+	t1 := tagMiddleware("t1\n")
+	t2 := tagMiddleware("t2\n")
+	t3 := tagMiddleware("t3\n")
+
+	type args struct {
+		next http.HandlerFunc
+		mws  []MiddlewareFunc
+	}
+	tests := []struct {
+		name         string
+		args         args
+		expectedCode int
+		expectedBody string
+	}{
+		{"middleware 1,2,3 and finish", args{next: testHandle, mws: []MiddlewareFunc{t1, t2, t3}}, 202, "t1\nt2\nt3\n"},
+		{"middleware 1,2 and finish", args{next: testHandle, mws: []MiddlewareFunc{t1, t2}}, 202, "t1\nt2\n"},
+		{"no middleware and finish", args{next: testHandle, mws: []MiddlewareFunc{}}, 202, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc := httptest.NewRecorder()
+			rw := newResponseWriter(rc)
+			tt.args.next = MiddlewareChain(tt.args.next, tt.args.mws...)
+			tt.args.next(rw, r)
+			assert.Equal(t, tt.expectedCode, rw.Status())
+			assert.Equal(t, tt.expectedBody, rc.Body.String())
 		})
 	}
 }

--- a/sync/http/option.go
+++ b/sync/http/option.go
@@ -40,6 +40,17 @@ func Routes(rr []Route) OptionFunc {
 	}
 }
 
+// Middlewares option for setting the routes middlewares of the HTTP component.
+func Middlewares(mm ...MiddlewareFunc) OptionFunc {
+	return func(s *Component) error {
+		if len(mm) == 0 {
+			return errors.New("middlewares are empty")
+		}
+		s.middlewares = append(s.middlewares, mm...)
+		return nil
+	}
+}
+
 // HealthCheck option for setting the health check function of the HTTP component.
 func HealthCheck(hcf HealthCheckFunc) OptionFunc {
 	return func(s *Component) error {

--- a/sync/http/option_test.go
+++ b/sync/http/option_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -49,6 +50,30 @@ func TestSetRoutes(t *testing.T) {
 				assert.Len(t, s.routes, 1)
 				assert.Equal(t, tt.rr[0].Method, s.routes[0].Method)
 				assert.Equal(t, tt.rr[0].Pattern, s.routes[0].Pattern)
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSetMiddlewares(t *testing.T) {
+	tests := []struct {
+		name    string
+		mm      []MiddlewareFunc
+		wantErr bool
+	}{
+		{"success", []MiddlewareFunc{func(next http.HandlerFunc) http.HandlerFunc { return next }}, false},
+		{"error for empty middlewares", []MiddlewareFunc{}, true},
+		{"error for nil middlewares", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Component{}
+			err := Middlewares(tt.mm...)(&s)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.Len(t, s.middlewares, 1)
 				assert.NoError(t, err)
 			}
 		})


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/thebeatapp/patron/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/thebeatapp/patron/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Framework has no generic middleware stack mechanism for default http component.
(issue #47)

## Short description of the changes

This PR addresses issue #47 and introduces a generic middleware stack that can be setup in main service as an OptionFunc and then in the default http component as a slice of MiddlewareFunc, that are applied on all routes chained in order after the default middlewares of auth and tracing.