### PR TITLE
Split tracing agent address into host & port

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The service has some default settings which can be changed via environment varia
 - Log level, for setting zerolog with `INFO` log level with `PATRON_LOG_LEVEL`
 - Tracing, for setting up jaeger tracing with
   - agent host `0.0.0.0` with `PATRON_JAEGER_AGENT_HOST`
-  - agent port `6831` with `PATRON_JAEGER_AGENT_POST`
+  - agent port `6831` with `PATRON_JAEGER_AGENT_PORT`
   - sampler type `probabilistic`with `PATRON_JAEGER_SAMPLER_TYPE`
   - sampler param `0.1` with `PATRON_JAEGER_SAMPLER_PARAM`
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ The service has some default settings which can be changed via environment varia
 - Service HTTP port, for setting the default HTTP components port to `50000` with `PATRON_HTTP_DEFAULT_PORT`
 - Log level, for setting zerolog with `INFO` log level with `PATRON_LOG_LEVEL`
 - Tracing, for setting up jaeger tracing with
-  - agent address `0.0.0.0:6831` with `PATRON_JAEGER_AGENT`
+  - agent host `0.0.0.0` with `PATRON_JAEGER_AGENT_HOST`
+  - agent port `6831` with `PATRON_JAEGER_AGENT_POST`
   - sampler type `probabilistic`with `PATRON_JAEGER_SAMPLER_TYPE`
   - sampler param `0.1` with `PATRON_JAEGER_SAMPLER_PARAM`
 

--- a/service.go
+++ b/service.go
@@ -158,10 +158,15 @@ func Setup(name, version string) error {
 func (s *Service) setupDefaultTracing(name, version string) error {
 	var err error
 
-	agent, ok := os.LookupEnv("PATRON_JAEGER_AGENT")
+	host, ok := os.LookupEnv("PATRON_JAEGER_AGENT_HOST")
 	if !ok {
-		agent = "0.0.0.0:6831"
+		host = "0.0.0.0"
 	}
+	port, ok := os.LookupEnv("PATRON_JAEGER_AGENT_PORT")
+	if !ok {
+		port = "6831"
+	}
+	agent := host + ":" + port
 	info.UpsertConfig("jaeger-agent", agent)
 	tp, ok := os.LookupEnv("PATRON_JAEGER_SAMPLER_TYPE")
 	if !ok {

--- a/service_test.go
+++ b/service_test.go
@@ -73,6 +73,36 @@ func TestServer_Run_Shutdown(t *testing.T) {
 	}
 }
 
+func TestServer_SetupTracing(t *testing.T) {
+	tests := []struct {
+		name    string
+		cp      Component
+		host    string
+		port    string
+	}{
+		{name: "success w/ empty tracing vars", cp: &testComponent{}},
+		{name: "success w/ empty tracing host", cp: &testComponent{}, port: "6831"},
+		{name: "success w/ empty tracing port", cp: &testComponent{}, host: "127.0.0.1"},
+		{name: "success", cp: &testComponent{}, host: "127.0.0.1", port:"6831"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.host != "" {
+				err := os.Setenv("PATRON_JAEGER_AGENT_HOST", tt.host)
+				assert.NoError(t, err)
+			}
+			if tt.port != "" {
+				err := os.Setenv("PATRON_JAEGER_AGENT_PORT", tt.port)
+				assert.NoError(t, err)
+			}
+			s, err := New("test", "", Components(tt.cp, tt.cp, tt.cp))
+			assert.NoError(t, err)
+			err = s.Run()
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func getRandomPort() string {
 	rnd := 50000 + rand.Int63n(10000)
 	return strconv.FormatInt(rnd, 10)


### PR DESCRIPTION
Signed-off-by: Sotiris Poulias <str.poulias@gmail.com>

<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

<!-- REQUIRED -->
Solves #59 

## Short description of the changes

<!-- REQUIRED -->
Splitting env var of jaeger agent address into host and port, helps the dynamic configuration under k8s management.