### PR TITLE
Update Producer Message to include key, closes #85

### DIFF
--- a/trace/kafka/kafka.go
+++ b/trace/kafka/kafka.go
@@ -29,6 +29,10 @@ func NewMessage(t string, b []byte) *Message {
 	return &Message{topic: t, body: b}
 }
 
+func NewMessageWithKey(t string, b []byte, k *string) *Message {
+	return &Message{topic: t, body: b, key: k}
+}
+
 // NewJSONMessage creates a new message with a JSON encoded body.
 func NewJSONMessage(t string, d interface{}) (*Message, error) {
 	b, err := json.Encode(d)
@@ -36,6 +40,15 @@ func NewJSONMessage(t string, d interface{}) (*Message, error) {
 		return nil, errors.Wrap(err, "failed to JSON encode")
 	}
 	return &Message{topic: t, body: b}, nil
+}
+
+// NewJSONMessageWithKey creates a new message with a JSON encoded body and a message key
+func NewJSONMessageWithKey(t string, d interface{}, k *string) (*Message, error) {
+	b, err := json.Encode(d)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to JSON encode")
+	}
+	return &Message{topic: t, body: b, key: k}, nil
 }
 
 // Producer interface for Kafka.

--- a/trace/kafka/kafka.go
+++ b/trace/kafka/kafka.go
@@ -23,8 +23,11 @@ func NewMessage(t string, b []byte) *Message {
 	return &Message{topic: t, body: b}
 }
 
-func NewMessageWithKey(t string, b []byte, k *string) *Message {
-	return &Message{topic: t, body: b, key: k}
+func NewMessageWithKey(t string, b []byte, k string) (*Message, error) {
+	if k == "" {
+		return nil, errors.New("key string can not be null")
+	}
+	return &Message{topic: t, body: b, key: &k}, nil
 }
 
 // NewJSONMessage creates a new message with a JSON encoded body.
@@ -37,12 +40,15 @@ func NewJSONMessage(t string, d interface{}) (*Message, error) {
 }
 
 // NewJSONMessageWithKey creates a new message with a JSON encoded body and a message key
-func NewJSONMessageWithKey(t string, d interface{}, k *string) (*Message, error) {
+func NewJSONMessageWithKey(t string, d interface{}, k string) (*Message, error) {
+	if k == "" {
+		return nil, errors.New("key string can not be null")
+	}
 	b, err := json.Encode(d)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to JSON encode")
 	}
-	return &Message{topic: t, body: b, key: k}, nil
+	return &Message{topic: t, body: b, key: &k}, nil
 }
 
 // Producer interface for Kafka.

--- a/trace/kafka/kafka.go
+++ b/trace/kafka/kafka.go
@@ -18,12 +18,6 @@ type Message struct {
 	key   *string
 }
 
-// SetKey sets the key of the message
-func (m *Message) SetKey(k *string) *Message {
-	m.key = k
-	return m
-}
-
 // NewMessage creates a new message.
 func NewMessage(t string, b []byte) *Message {
 	return &Message{topic: t, body: b}

--- a/trace/kafka/kafka_test.go
+++ b/trace/kafka/kafka_test.go
@@ -110,7 +110,6 @@ func TestAsyncProducer_SendMessage_Close(t *testing.T) {
 func TestAsyncProducer_SendMessage_WithKey(t *testing.T) {
 	testKey := "TEST"
 	msg, err := NewJSONMessageWithKey("TOPIC", "TEST",&testKey)
-	msg.SetKey(&testKey)
 	assert.Equal(t, testKey, *msg.key)
 	assert.NoError(t, err)
 	seed := createKafkaBroker(t, true)

--- a/trace/kafka/kafka_test.go
+++ b/trace/kafka/kafka_test.go
@@ -17,11 +17,11 @@ func TestNewMessage(t *testing.T) {
 }
 
 func TestNewMessageWithKey(t *testing.T) {
-	key:="TEST"
-	m := NewMessageWithKey("TOPIC", []byte("TEST"),&key)
+	key := "TEST"
+	m := NewMessageWithKey("TOPIC", []byte("TEST"), &key)
 	assert.Equal(t, "TOPIC", m.topic)
 	assert.Equal(t, []byte("TEST"), m.body)
-	assert.Equal(t,key,*m.key)
+	assert.Equal(t, key, *m.key)
 }
 func TestNewJSONMessage(t *testing.T) {
 	tests := []struct {
@@ -45,20 +45,20 @@ func TestNewJSONMessage(t *testing.T) {
 		})
 	}
 }
-func TestNewJSONMessageWithKey(t *testing.T){
-	key:="TEST"
+func TestNewJSONMessageWithKey(t *testing.T) {
+	key := "TEST"
 	tests := []struct {
 		name    string
 		data    interface{}
 		key     *string
 		wantErr bool
 	}{
-		{name: "failure due to invalid data", data: make(chan bool),key:&key, wantErr: true},
-		{name: "success", data: "TEST",key:&key},
+		{name: "failure due to invalid data", data: make(chan bool), key: &key, wantErr: true},
+		{name: "success", data: "TEST", key: &key},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewJSONMessageWithKey("TOPIC", tt.data,tt.key)
+			got, err := NewJSONMessageWithKey("TOPIC", tt.data, tt.key)
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.Nil(t, got)
@@ -69,8 +69,6 @@ func TestNewJSONMessageWithKey(t *testing.T){
 		})
 	}
 }
-
-
 
 func TestNewSyncProducer_Failure(t *testing.T) {
 	got, err := NewAsyncProducer([]string{})
@@ -109,7 +107,7 @@ func TestAsyncProducer_SendMessage_Close(t *testing.T) {
 
 func TestAsyncProducer_SendMessage_WithKey(t *testing.T) {
 	testKey := "TEST"
-	msg, err := NewJSONMessageWithKey("TOPIC", "TEST",&testKey)
+	msg, err := NewJSONMessageWithKey("TOPIC", "TEST", &testKey)
 	assert.Equal(t, testKey, *msg.key)
 	assert.NoError(t, err)
 	seed := createKafkaBroker(t, true)

--- a/trace/kafka/kafka_test.go
+++ b/trace/kafka/kafka_test.go
@@ -16,6 +16,13 @@ func TestNewMessage(t *testing.T) {
 	assert.Equal(t, []byte("TEST"), m.body)
 }
 
+func TestNewMessageWithKey(t *testing.T) {
+	key:="TEST"
+	m := NewMessageWithKey("TOPIC", []byte("TEST"),&key)
+	assert.Equal(t, "TOPIC", m.topic)
+	assert.Equal(t, []byte("TEST"), m.body)
+	assert.Equal(t,key,*m.key)
+}
 func TestNewJSONMessage(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -38,6 +45,32 @@ func TestNewJSONMessage(t *testing.T) {
 		})
 	}
 }
+func TestNewJSONMessageWithKey(t *testing.T){
+	key:="TEST"
+	tests := []struct {
+		name    string
+		data    interface{}
+		key     *string
+		wantErr bool
+	}{
+		{name: "failure due to invalid data", data: make(chan bool),key:&key, wantErr: true},
+		{name: "success", data: "TEST",key:&key},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewJSONMessageWithKey("TOPIC", tt.data,tt.key)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, got)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, got)
+			}
+		})
+	}
+}
+
+
 
 func TestNewSyncProducer_Failure(t *testing.T) {
 	got, err := NewAsyncProducer([]string{})
@@ -76,7 +109,7 @@ func TestAsyncProducer_SendMessage_Close(t *testing.T) {
 
 func TestAsyncProducer_SendMessage_WithKey(t *testing.T) {
 	testKey := "TEST"
-	msg, err := NewJSONMessage("TOPIC", "TEST")
+	msg, err := NewJSONMessageWithKey("TOPIC", "TEST",&testKey)
 	msg.SetKey(&testKey)
 	assert.Equal(t, testKey, *msg.key)
 	assert.NoError(t, err)


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
This PR adds the ability to include a key in kafka messages.

## Short description of the changes

In kafka package, in the Message struct a private nilable string pointer was added along with a SetKey setter method on the Message Struct. This way a Message has the ability to also define a key, or not without breaking any backwards compability. The createProducerMessage now also handles the appropriate transformation of the message to a sarama.Message. 