### PR TITLE
fix: kafka initializer in cmd generator

### DIFF
--- a/cmd/patron/main.go
+++ b/cmd/patron/main.go
@@ -40,7 +40,7 @@ var patronPackages = map[string]component{
 	},
 	"kafka": component{
 		Import: "\"github.com/beatlabs/patron/async\"\n\t\"github.com/beatlabs/patron/async/kafka\"",
-		Code: `kafkaCf, err := kafka.New(name, "json.Type", "TOPIC", []string{"BROKER"})
+		Code: `kafkaCf, err := kafka.New(name, "json.Type", "TOPIC", "GROUP", []string{"BROKER"})
 		if err != nil {
 			log.Fatalf("failed to create kafka consumer factory: %v", err)
 		}


### PR DESCRIPTION
Signed-off-by: Mohamed Osama <mohamed.o.alnagdy@gmail.com>

<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

When generating a new patron codebase, the kafka initializer is expecting a consumer group which was not provided

## Short description of the changes

Added a consumer group argument to the Kafka initializer
