### PR TITLE
Patron CLI: Added generation of a .gitignore

### DIFF
--- a/assets/template.gitignore
+++ b/assets/template.gitignore
@@ -1,0 +1,32 @@
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.DS_Store
+*.dylib
+debug/
+
+# JetBrains
+.idea/*
+*.iws
+out/
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# VS Code
+*.vscode
+.vscode/*
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/cmd/patron/main.go
+++ b/cmd/patron/main.go
@@ -364,7 +364,15 @@ func readmeContent(gd *genData) []byte {
 	return []byte(fmt.Sprintf("# %s", gd.Name))
 }
 
-func copyFile(src, dst string) (int64, error) {
+func copyFile(src, dst string) (result int64, rerr error) {
+	type funcWithErr func() error
+	withErrorHandling := func(f funcWithErr) {
+		err := f()
+		if err != nil {
+			rerr = err
+		}
+	}
+
 	sourceFileStat, err := os.Stat(src)
 	if err != nil {
 		return 0, err
@@ -378,13 +386,14 @@ func copyFile(src, dst string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer source.Close()
+	defer withErrorHandling(source.Close)
 
 	destination, err := os.Create(dst)
 	if err != nil {
 		return 0, err
 	}
-	defer destination.Close()
+	defer withErrorHandling(destination.Close)
+
 	nBytes, err := io.Copy(destination, source)
 	return nBytes, err
 }

--- a/cmd/patron/main.go
+++ b/cmd/patron/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -97,6 +98,11 @@ func main() {
 		log.Fatalf("failed to create main: %v", err)
 	}
 
+	err = createGitIgnore()
+	if err != nil {
+		log.Fatalf("failed to create .gitignore: %v", err)
+	}
+
 	err = createDockerfile(gd)
 	if err != nil {
 		log.Fatalf("failed to create Dockerfile: %v", err)
@@ -182,6 +188,16 @@ func packagesFromFlag(packages *string) ([]component, error) {
 func setupGit() error {
 	log.Printf("creating git repository")
 	return exec.Command("git", "init").Run()
+}
+
+func createGitIgnore() error {
+	log.Printf("copying .gitignore")
+	_, err := copyFile("../assets/template.gitignore", ".gitignore")
+
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func createDockerfile(gd *genData) error {
@@ -346,4 +362,29 @@ func main() {
 
 func readmeContent(gd *genData) []byte {
 	return []byte(fmt.Sprintf("# %s", gd.Name))
+}
+
+func copyFile(src, dst string) (int64, error) {
+	sourceFileStat, err := os.Stat(src)
+	if err != nil {
+		return 0, err
+	}
+
+	if !sourceFileStat.Mode().IsRegular() {
+		return 0, fmt.Errorf("%s is not a regular file", src)
+	}
+
+	source, err := os.Open(src)
+	if err != nil {
+		return 0, err
+	}
+	defer source.Close()
+
+	destination, err := os.Create(dst)
+	if err != nil {
+		return 0, err
+	}
+	defer destination.Close()
+	nBytes, err := io.Copy(destination, source)
+	return nBytes, err
 }

--- a/cmd/patron/main.go
+++ b/cmd/patron/main.go
@@ -194,10 +194,7 @@ func createGitIgnore() error {
 	log.Printf("copying .gitignore")
 	_, err := copyFile("../assets/template.gitignore", ".gitignore")
 
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func createDockerfile(gd *genData) error {


### PR DESCRIPTION
## Which problem is this PR solving?

New projects normally require a `.gitignore` file to avoid committing local project files or test output. This would be nice if patron generated it OOB.

## Short description of the changes

- Added a template `.gitignore`
- Copy a template to a generated project
