### PR TITLE
Remove concurrency from consumers on message arrived

### DIFF
--- a/async/component.go
+++ b/async/component.go
@@ -124,7 +124,7 @@ func (c *Component) processing(ctx context.Context) error {
 				failCh <- cns.Close()
 			case msg := <-chMsg:
 				log.Debug("New message from consumer arrived")
-				go c.processMessage(msg, failCh)
+				c.processMessage(msg, failCh)
 			case errMsg := <-chErr:
 				failCh <- errors.Wrap(errMsg, "an error occurred during message consumption")
 				return


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

https://github.com/beatlabs/patron/issues/94

## Short description of the changes

Remove the concurrency from `c.processMessage(msg, failCh)`
