### PR TITLE
Parse DSN to populate Connection Information

### DIFF
--- a/trace/sql/sql.go
+++ b/trace/sql/sql.go
@@ -127,10 +127,7 @@ func Open(driverName, dataSourceName string) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	info, err := ParseDSN(dataSourceName)
-	if err != nil {
-		return nil, err
-	}
+	info := ParseDSN(dataSourceName)
 
 	return &DB{connInfo: connInfo{info.DBName, info.User}, db: db}, nil
 }

--- a/trace/sql/sql.go
+++ b/trace/sql/sql.go
@@ -25,9 +25,9 @@ type Conn struct {
 	conn *sql.Conn
 }
 
-// DSNData contains information extracted from a valid
+// DSNInfo contains information extracted from a valid
 // connection string. Additional parameters provided are discarded
-type DSNData struct {
+type DSNInfo struct {
 	DBName   string
 	Address  string
 	User     string
@@ -391,8 +391,8 @@ func (tx *Tx) Stmt(ctx context.Context, stmt *Stmt) *Stmt {
 }
 
 // ParseDSN unpacks the connections string to the relevant struct
-func ParseDSN(dsn string) (DSNData, error) {
-	res := DSNData{}
+func ParseDSN(dsn string) DSNInfo {
+	res := DSNInfo{}
 
 	dsnPattern := regexp.MustCompile(
 		`^(?:(?P<username>.*?)(?::(?P<passwd>.*))?@)?` + // [user[:password]@]
@@ -418,5 +418,5 @@ func ParseDSN(dsn string) (DSNData, error) {
 		}
 	}
 
-	return res, nil
+	return res
 }

--- a/trace/sql/sql.go
+++ b/trace/sql/sql.go
@@ -28,6 +28,7 @@ type Conn struct {
 // DSNInfo contains information extracted from a valid
 // connection string. Additional parameters provided are discarded
 type DSNInfo struct {
+	Driver   string
 	DBName   string
 	Address  string
 	User     string
@@ -392,7 +393,7 @@ func ParseDSN(dsn string) DSNInfo {
 	res := DSNInfo{}
 
 	dsnPattern := regexp.MustCompile(
-		`^(?:(?P<username>.*?)(?::(?P<passwd>.*))?@)?` + // [user[:password]@]
+		`^(?P<driver>.*:\/\/)?(?:(?P<username>.*?)(?::(?P<passwd>.*))?@)?` + // [driver://][user[:password]@]
 			`(?:(?P<protocol>[^\(]*)(?:\((?P<address>[^\)]*)\))?)?` + // [net[(addr)]]
 			`\/(?P<dbname>.*?)` + // /dbname
 			`(?:\?(?P<params>[^\?]*))?$`) // [?param1=value1&paramN=valueN]
@@ -402,6 +403,8 @@ func ParseDSN(dsn string) DSNInfo {
 
 	for i, match := range matches {
 		switch fields[i] {
+		case "driver":
+			res.Driver = match
 		case "username":
 			res.User = match
 		case "passwd":

--- a/trace/sql/sql.go
+++ b/trace/sql/sql.go
@@ -127,7 +127,12 @@ func Open(driverName, dataSourceName string) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &DB{db: db}, nil
+	info, err := ParseDSN(dataSourceName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DB{connInfo: connInfo{info.DBName, info.User}, db: db}, nil
 }
 
 // OpenDB opens a database.

--- a/trace/sql/sql.go
+++ b/trace/sql/sql.go
@@ -24,6 +24,16 @@ type Conn struct {
 	conn *sql.Conn
 }
 
+// DSNData contains information extracted from a valid
+// connection string. Additional parameters provided are discarded
+type DSNData struct {
+	DBName   string
+	Address  string
+	User     string
+	Protocol string
+	Passwd   string
+}
+
 // BeginTx starts a transaction.
 func (c *Conn) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
 	sp, _ := c.startSpan(ctx, "conn.BeginTx", "")
@@ -372,4 +382,11 @@ func (tx *Tx) Stmt(ctx context.Context, stmt *Stmt) *Stmt {
 	sp, _ := tx.startSpan(ctx, "tx.Stmt", "")
 	defer trace.SpanSuccess(sp)
 	return &Stmt{stmt: tx.tx.StmtContext(ctx, stmt.stmt)}
+}
+
+// ParseDSN unpacks the connections string to the relevant struct
+func ParseDSN(dsn string) (DSNData, error) {
+	res := DSNData{}
+
+	return res, nil
 }

--- a/trace/sql/sql.go
+++ b/trace/sql/sql.go
@@ -33,7 +33,6 @@ type DSNInfo struct {
 	Address  string
 	User     string
 	Protocol string
-	Passwd   string
 }
 
 // BeginTx starts a transaction.
@@ -393,7 +392,7 @@ func ParseDSN(dsn string) DSNInfo {
 	res := DSNInfo{}
 
 	dsnPattern := regexp.MustCompile(
-		`^(?P<driver>.*:\/\/)?(?:(?P<username>.*?)(?::(?P<passwd>.*))?@)?` + // [driver://][user[:password]@]
+		`^(?P<driver>.*:\/\/)?(?:(?P<username>.*?)(?::(.*))?@)?` + // [driver://][user[:password]@]
 			`(?:(?P<protocol>[^\(]*)(?:\((?P<address>[^\)]*)\))?)?` + // [net[(addr)]]
 			`\/(?P<dbname>.*?)` + // /dbname
 			`(?:\?(?P<params>[^\?]*))?$`) // [?param1=value1&paramN=valueN]
@@ -407,8 +406,6 @@ func ParseDSN(dsn string) DSNInfo {
 			res.Driver = match
 		case "username":
 			res.User = match
-		case "passwd":
-			res.Passwd = match
 		case "protocol":
 			res.Protocol = match
 		case "address":

--- a/trace/sql/sql.go
+++ b/trace/sql/sql.go
@@ -127,7 +127,7 @@ func Open(driverName, dataSourceName string) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	info := ParseDSN(dataSourceName)
+	info := parseDSN(dataSourceName)
 
 	return &DB{connInfo: connInfo{info.DBName, info.User}, db: db}, nil
 }
@@ -387,8 +387,7 @@ func (tx *Tx) Stmt(ctx context.Context, stmt *Stmt) *Stmt {
 	return &Stmt{stmt: tx.tx.StmtContext(ctx, stmt.stmt)}
 }
 
-// ParseDSN unpacks the connections string to the relevant struct
-func ParseDSN(dsn string) DSNInfo {
+func parseDSN(dsn string) DSNInfo {
 	res := DSNInfo{}
 
 	dsnPattern := regexp.MustCompile(

--- a/trace/sql/sql_test.go
+++ b/trace/sql/sql_test.go
@@ -13,17 +13,21 @@ func TestParseDSN(t *testing.T) {
 
 	//TODO: restructure table-driven tests to the proposed way
 	var testcases = []testcase{
-		{"username:password@protocol(address)/dbname?param=value", DSNInfo{"dbname", "address", "username", "protocol", "password"}},
-		{"/", DSNInfo{"", "", "", "", ""}},
-		{"/dbname", DSNInfo{"dbname", "", "", "", ""}},
-		{"user:p@/ssword@/", DSNInfo{"", "", "user", "", "p@/ssword"}},
-		{"user@unix(/path/to/socket)/dbname?charset=utf8", DSNInfo{"dbname", "/path/to/socket", "user", "unix", ""}},
-		{"user:password@/dbname?param1=val1&param2=val2&param3=val3", DSNInfo{"dbname", "", "user", "", "password"}},
-		{"bruce:hunter2@tcp(127.0.0.1)/arkhamdb?param=value", DSNInfo{"arkhamdb", "127.0.0.1", "bruce", "tcp", "hunter2"}},
-		{"user@unix(/path/to/mydir@/socket)/dbname?charset=utf8", DSNInfo{"dbname", "/path/to/mydir@/socket", "user", "unix", ""}},
-		{"user:password@tcp(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"dbname", "localhost:5555", "user", "tcp", "password"}},
-		{"us:er:name:password@memory(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"dbname", "localhost:5555", "us", "memory", "er:name:password"}},
-		{"user:p@ss(word)@tcp([c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80)/dbname?loc=Local", DSNInfo{"dbname", "[c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80", "user", "tcp", "p@ss(word)"}},
+		{"username:password@protocol(address)/dbname?param=value", DSNInfo{"", "dbname", "address", "username", "protocol", "password"}},
+		{"/", DSNInfo{"", "", "", "", "", ""}},
+		{"/dbname", DSNInfo{"", "dbname", "", "", "", ""}},
+		{"user:p@/ssword@/", DSNInfo{"", "", "", "user", "", "p@/ssword"}},
+		{"mysql://user:p@/ssword@/", DSNInfo{"mysql://", "", "", "user", "", "p@/ssword"}},
+		{"postgresql://user:p@/ssword@/", DSNInfo{"postgresql://", "", "", "user", "", "p@/ssword"}},
+		{"user@unix(/path/to/socket)/dbname?charset=utf8", DSNInfo{"", "dbname", "/path/to/socket", "user", "unix", ""}},
+		{"user:password@/dbname?param1=val1&param2=val2&param3=val3", DSNInfo{"", "dbname", "", "user", "", "password"}},
+		{"bruce:hunter2@tcp(127.0.0.1)/arkhamdb?param=value", DSNInfo{"", "arkhamdb", "127.0.0.1", "bruce", "tcp", "hunter2"}},
+		{"user@unix(/path/to/mydir@/socket)/dbname?charset=utf8", DSNInfo{"", "dbname", "/path/to/mydir@/socket", "user", "unix", ""}},
+		{"user:password@tcp(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"", "dbname", "localhost:5555", "user", "tcp", "password"}},
+		{"us:er:name:password@memory(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"", "dbname", "localhost:5555", "us", "memory", "er:name:password"}},
+		{"user:p@ss(word)@tcp([c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80)/dbname?loc=Local", DSNInfo{"", "dbname", "[c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80", "user", "tcp", "p@ss(word)"}},
+		{"", DSNInfo{"", "", "", "", "", ""}},
+		{"rosebud", DSNInfo{"", "", "", "", "", ""}},
 	}
 
 	for _, tc := range testcases {

--- a/trace/sql/sql_test.go
+++ b/trace/sql/sql_test.go
@@ -7,17 +7,27 @@ import (
 
 func TestParseDSN(t *testing.T) {
 	type testcase struct {
-		dsn     string
-		want    DSNData
-		wantErr error
+		dsn  string
+		want DSNInfo
 	}
+
+	//TODO: restructure table-driven tests to the proposed way
 	var testcases = []testcase{
-		{"username:password@protocol(address)/dbname?param=value", DSNData{"dbname", "address", "username", "protocol", "password"}, nil},
-		{"bruce:hunter2@tcp(127.0.0.1)/arkhamdb?param=value", DSNData{"arkhamdb", "127.0.0.1", "bruce", "tcp", "hunter2"}, nil},
+		{"username:password@protocol(address)/dbname?param=value", DSNInfo{"dbname", "address", "username", "protocol", "password"}},
+		{"/", DSNInfo{"", "", "", "", ""}},
+		{"/dbname", DSNInfo{"dbname", "", "", "", ""}},
+		{"user:p@/ssword@/", DSNInfo{"", "", "user", "", "p@/ssword"}},
+		{"user@unix(/path/to/socket)/dbname?charset=utf8", DSNInfo{"dbname", "/path/to/socket", "user", "unix", ""}},
+		{"user:password@/dbname?param1=val1&param2=val2&param3=val3", DSNInfo{"dbname", "", "user", "", "password"}},
+		{"bruce:hunter2@tcp(127.0.0.1)/arkhamdb?param=value", DSNInfo{"arkhamdb", "127.0.0.1", "bruce", "tcp", "hunter2"}},
+		{"user@unix(/path/to/mydir@/socket)/dbname?charset=utf8", DSNInfo{"dbname", "/path/to/mydir@/socket", "user", "unix", ""}},
+		{"user:password@tcp(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"dbname", "localhost:5555", "user", "tcp", "password"}},
+		{"us:er:name:password@memory(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"dbname", "localhost:5555", "us", "memory", "er:name:password"}},
+		{"user:p@ss(word)@tcp([c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80)/dbname?loc=Local", DSNInfo{"dbname", "[c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80", "user", "tcp", "p@ss(word)"}},
 	}
 
 	for _, tc := range testcases {
-		got, _ := ParseDSN(tc.dsn)
+		got := ParseDSN(tc.dsn)
 		assert.Equal(t, got, tc.want)
 	}
 }

--- a/trace/sql/sql_test.go
+++ b/trace/sql/sql_test.go
@@ -13,10 +13,17 @@ func TestParseDSN(t *testing.T) {
 	}
 	var testcases = []testcase{
 		{"username:password@protocol(address)/dbname?param=value", DSNData{"dbname", "address", "username", "protocol", "password"}, nil},
+		{"bruce:hunter2@tcp(127.0.0.1)/arkhamdb?param=value", DSNData{"arkhamdb", "127.0.0.1", "bruce", "tcp", "hunter2"}, nil},
 	}
 
 	for _, tc := range testcases {
 		got, _ := ParseDSN(tc.dsn)
 		assert.Equal(t, got, tc.want)
+	}
+}
+
+func BenchmarkParseDSN(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		ParseDSN("bruce:hunter2@tcp(127.0.0.1)/arkhamdb?param=value")
 	}
 }

--- a/trace/sql/sql_test.go
+++ b/trace/sql/sql_test.go
@@ -28,14 +28,8 @@ func TestParseDSN(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := ParseDSN(tc.dsn)
+			got := parseDSN(tc.dsn)
 			assert.Equal(t, got, tc.want)
 		})
-	}
-}
-
-func BenchmarkParseDSN(b *testing.B) {
-	for n := 0; n < b.N; n++ {
-		ParseDSN("bruce:hunter2@tcp(127.0.0.1)/arkhamdb?param=value")
 	}
 }

--- a/trace/sql/sql_test.go
+++ b/trace/sql/sql_test.go
@@ -10,20 +10,20 @@ func TestParseDSN(t *testing.T) {
 		dsn  string
 		want DSNInfo
 	}{
-		"generic case":          {"username:password@protocol(address)/dbname?param=value", DSNInfo{"", "dbname", "address", "username", "protocol", "password"}},
-		"empty DSN":             {"/", DSNInfo{"", "", "", "", "", ""}},
-		"dbname only":           {"/dbname", DSNInfo{"", "dbname", "", "", "", ""}},
-		"multiple @":            {"user:p@/ssword@/", DSNInfo{"", "", "", "user", "", "p@/ssword"}},
-		"driver and multiple @": {"postgresql://user:p@/ssword@/", DSNInfo{"postgresql://", "", "", "user", "", "p@/ssword"}},
-		"unix socket":           {"user@unix(/path/to/socket)/dbname?charset=utf8", DSNInfo{"", "dbname", "/path/to/socket", "user", "unix", ""}},
-		"params added":          {"user:password@/dbname?param1=val1&param2=val2&param3=val3", DSNInfo{"", "dbname", "", "user", "", "password"}},
-		"IP as address":         {"bruce:hunter2@tcp(127.0.0.1)/arkhamdb?param=value", DSNInfo{"", "arkhamdb", "127.0.0.1", "bruce", "tcp", "hunter2"}},
-		"@ in path to socker":   {"user@unix(/path/to/mydir@/socket)/dbname?charset=utf8", DSNInfo{"", "dbname", "/path/to/mydir@/socket", "user", "unix", ""}},
-		"port in address":       {"user:password@tcp(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"", "dbname", "localhost:5555", "user", "tcp", "password"}},
-		"multiple ':'":          {"us:er:name:password@memory(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"", "dbname", "localhost:5555", "us", "memory", "er:name:password"}},
-		"IPv6 provided":         {"user:p@ss(word)@tcp([c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80)/dbname?loc=Local", DSNInfo{"", "dbname", "[c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80", "user", "tcp", "p@ss(word)"}},
-		"empty string":          {"", DSNInfo{"", "", "", "", "", ""}},
-		"non-matching string":   {"rosebud", DSNInfo{"", "", "", "", "", ""}},
+		"generic case":          {"username:password@protocol(address)/dbname?param=value", DSNInfo{"", "dbname", "address", "username", "protocol"}},
+		"empty DSN":             {"/", DSNInfo{"", "", "", "", ""}},
+		"dbname only":           {"/dbname", DSNInfo{"", "dbname", "", "", ""}},
+		"multiple @":            {"user:p@/ssword@/", DSNInfo{"", "", "", "user", ""}},
+		"driver and multiple @": {"postgresql://user:p@/ssword@/", DSNInfo{"postgresql://", "", "", "user", ""}},
+		"unix socket":           {"user@unix(/path/to/socket)/dbname?charset=utf8", DSNInfo{"", "dbname", "/path/to/socket", "user", "unix"}},
+		"params added":          {"user:password@/dbname?param1=val1&param2=val2&param3=val3", DSNInfo{"", "dbname", "", "user", ""}},
+		"IP as address":         {"bruce:hunter2@tcp(127.0.0.1)/arkhamdb?param=value", DSNInfo{"", "arkhamdb", "127.0.0.1", "bruce", "tcp"}},
+		"@ in path to socker":   {"user@unix(/path/to/mydir@/socket)/dbname?charset=utf8", DSNInfo{"", "dbname", "/path/to/mydir@/socket", "user", "unix"}},
+		"port in address":       {"user:password@tcp(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"", "dbname", "localhost:5555", "user", "tcp"}},
+		"multiple ':'":          {"us:er:name:password@memory(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"", "dbname", "localhost:5555", "us", "memory"}},
+		"IPv6 provided":         {"user:p@ss(word)@tcp([c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80)/dbname?loc=Local", DSNInfo{"", "dbname", "[c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80", "user", "tcp"}},
+		"empty string":          {"", DSNInfo{"", "", "", "", ""}},
+		"non-matching string":   {"rosebud", DSNInfo{"", "", "", "", ""}},
 	}
 
 	for name, tc := range tests {

--- a/trace/sql/sql_test.go
+++ b/trace/sql/sql_test.go
@@ -6,33 +6,31 @@ import (
 )
 
 func TestParseDSN(t *testing.T) {
-	type testcase struct {
+	tests := map[string]struct {
 		dsn  string
 		want DSNInfo
+	}{
+		"generic case":          {"username:password@protocol(address)/dbname?param=value", DSNInfo{"", "dbname", "address", "username", "protocol", "password"}},
+		"empty DSN":             {"/", DSNInfo{"", "", "", "", "", ""}},
+		"dbname only":           {"/dbname", DSNInfo{"", "dbname", "", "", "", ""}},
+		"multiple @":            {"user:p@/ssword@/", DSNInfo{"", "", "", "user", "", "p@/ssword"}},
+		"driver and multiple @": {"postgresql://user:p@/ssword@/", DSNInfo{"postgresql://", "", "", "user", "", "p@/ssword"}},
+		"unix socket":           {"user@unix(/path/to/socket)/dbname?charset=utf8", DSNInfo{"", "dbname", "/path/to/socket", "user", "unix", ""}},
+		"params added":          {"user:password@/dbname?param1=val1&param2=val2&param3=val3", DSNInfo{"", "dbname", "", "user", "", "password"}},
+		"IP as address":         {"bruce:hunter2@tcp(127.0.0.1)/arkhamdb?param=value", DSNInfo{"", "arkhamdb", "127.0.0.1", "bruce", "tcp", "hunter2"}},
+		"@ in path to socker":   {"user@unix(/path/to/mydir@/socket)/dbname?charset=utf8", DSNInfo{"", "dbname", "/path/to/mydir@/socket", "user", "unix", ""}},
+		"port in address":       {"user:password@tcp(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"", "dbname", "localhost:5555", "user", "tcp", "password"}},
+		"multiple ':'":          {"us:er:name:password@memory(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"", "dbname", "localhost:5555", "us", "memory", "er:name:password"}},
+		"IPv6 provided":         {"user:p@ss(word)@tcp([c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80)/dbname?loc=Local", DSNInfo{"", "dbname", "[c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80", "user", "tcp", "p@ss(word)"}},
+		"empty string":          {"", DSNInfo{"", "", "", "", "", ""}},
+		"non-matching string":   {"rosebud", DSNInfo{"", "", "", "", "", ""}},
 	}
 
-	//TODO: restructure table-driven tests to the proposed way
-	var testcases = []testcase{
-		{"username:password@protocol(address)/dbname?param=value", DSNInfo{"", "dbname", "address", "username", "protocol", "password"}},
-		{"/", DSNInfo{"", "", "", "", "", ""}},
-		{"/dbname", DSNInfo{"", "dbname", "", "", "", ""}},
-		{"user:p@/ssword@/", DSNInfo{"", "", "", "user", "", "p@/ssword"}},
-		{"mysql://user:p@/ssword@/", DSNInfo{"mysql://", "", "", "user", "", "p@/ssword"}},
-		{"postgresql://user:p@/ssword@/", DSNInfo{"postgresql://", "", "", "user", "", "p@/ssword"}},
-		{"user@unix(/path/to/socket)/dbname?charset=utf8", DSNInfo{"", "dbname", "/path/to/socket", "user", "unix", ""}},
-		{"user:password@/dbname?param1=val1&param2=val2&param3=val3", DSNInfo{"", "dbname", "", "user", "", "password"}},
-		{"bruce:hunter2@tcp(127.0.0.1)/arkhamdb?param=value", DSNInfo{"", "arkhamdb", "127.0.0.1", "bruce", "tcp", "hunter2"}},
-		{"user@unix(/path/to/mydir@/socket)/dbname?charset=utf8", DSNInfo{"", "dbname", "/path/to/mydir@/socket", "user", "unix", ""}},
-		{"user:password@tcp(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"", "dbname", "localhost:5555", "user", "tcp", "password"}},
-		{"us:er:name:password@memory(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"", "dbname", "localhost:5555", "us", "memory", "er:name:password"}},
-		{"user:p@ss(word)@tcp([c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80)/dbname?loc=Local", DSNInfo{"", "dbname", "[c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80", "user", "tcp", "p@ss(word)"}},
-		{"", DSNInfo{"", "", "", "", "", ""}},
-		{"rosebud", DSNInfo{"", "", "", "", "", ""}},
-	}
-
-	for _, tc := range testcases {
-		got := ParseDSN(tc.dsn)
-		assert.Equal(t, got, tc.want)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := ParseDSN(tc.dsn)
+			assert.Equal(t, got, tc.want)
+		})
 	}
 }
 

--- a/trace/sql/sql_test.go
+++ b/trace/sql/sql_test.go
@@ -1,0 +1,22 @@
+package sql
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParseDSN(t *testing.T) {
+	type testcase struct {
+		dsn     string
+		want    DSNData
+		wantErr error
+	}
+	var testcases = []testcase{
+		{"username:password@protocol(address)/dbname?param=value", DSNData{"dbname", "address", "username", "protocol", "password"}, nil},
+	}
+
+	for _, tc := range testcases {
+		got, _ := ParseDSN(tc.dsn)
+		assert.Equal(t, got, tc.want)
+	}
+}


### PR DESCRIPTION
## Which problem is this PR solving?

This PR addresses #112  [Sql Client tracing does not populate the db name and the user ](https://github.com/beatlabs/patron/issues/112)

It introduces regex-based parsing for the Data Source Name connection string, so that we can populate the `ConnInfo` struct fields in `sql.go`

## Short description of the changes

* Introduce a regex-based parsing, based on an older [go-sql-driver](https://github.com/go-sql-driver/mysql/blob/f4bf8e8e0aa93d4ead0c6473503ca2f5d5eb65a8/utils.go#L34) commit.
* 100% test coverage on new code
* Introduce benchmarks and table-driven tests for new functionality

### TODO 
* Talk about if we should add support for ODBC-style DSNs (`param1=val1;param2=val2`)
* Talk about if we should return an error (personally I think not, since it's something optional)
* ~Talk about if we should *not* parse and store the password for safety reasons (it shouldn't just be laying around in memory after we connect to the database)~ Removed password field matching from the regex.
* Talk about setting defaults if the address or the protocol have not been set
* Talk about if we actually need the whole DSNInfo struct or if we should quickly return just the database and the username.

### Notes
The `sql.OpenDB` method's purpose is to [*"allow(ing) drivers to bypass a string based data source name"*](https://golang.org/pkg/database/sql/#OpenDB). I'm not sure how we could populate the `ConnInfo` struct in this case, (querying the DB itself?). The `driver.Connector`does present any useful methods.