### PR TITLE
WIP: Fixing a bug (fixes #133)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,10 @@ jobs:
   build:
     docker:
       - image: circleci/golang:1.13
+      - image: circleci/postgres:9.6.9-alpine
+        environment:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: test123
 
     environment:
       TEST_RESULTS: /tmp/test-results

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ cover: fmtcheck
 	rm coverage.txt
 
 coverci: fmtcheck
-	gotestsum --junitfile gotestsum-report.xml -- ./... -cover -race -count=1 -mod=vendor -coverprofile=coverage.txt -covermode=atomic
+	gotestsum --junitfile gotestsum-report.xml -- ./... -cover -race -count=1 -mod=vendor -tags=integration -coverprofile=coverage.txt -covermode=atomic
 
 fmt:
 	go fmt ./...

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/protobuf v1.2.0
 	github.com/google/uuid v1.1.0
 	github.com/julienschmidt/httprouter v1.2.0
+	github.com/lib/pq v1.3.0
 	github.com/opentracing-contrib/go-stdlib v0.0.0-20180313041242-367231351874
 	github.com/opentracing/opentracing-go v0.0.0-20180606204148-bd9c31933947
 	github.com/prometheus/client_golang v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/julienschmidt/httprouter v1.2.0 h1:TDTW5Yz1mjftljbcKqRcrYhd4XeOoI98t+
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
+github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/trace/sql/sql_integration_test.go
+++ b/trace/sql/sql_integration_test.go
@@ -1,0 +1,144 @@
+// +build integration
+
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// These values are taken from examples/docker-compose.yml
+	testPsqlInfo string = "host=localhost port=5432 user=postgres password=test123 sslmode=disable"
+)
+
+func TestSQL(t *testing.T) {
+	mockedCtx := context.Background()
+	db := newDB(mockedCtx, t)
+	conn := newConn(mockedCtx, t, db)
+
+	createTestTableWithDB(mockedCtx, t, db)
+	createTestTableWithConn(mockedCtx, t, conn)
+
+	insertTestDataWithDB(mockedCtx, t, db)
+	insertTestDataWithConn(mockedCtx, t, conn)
+
+	queryTestDataWithDB(mockedCtx, t, db)
+	queryTestDataWithConn(mockedCtx, t, conn)
+
+	stats := db.Stats(mockedCtx)
+	assert.NotNil(t, stats)
+
+	err := conn.Close(mockedCtx)
+	assert.NoError(t, err)
+	err = db.Close(mockedCtx)
+	assert.NoError(t, err)
+}
+
+func newDB(ctx context.Context, t *testing.T) *DB {
+	db, err := Open("postgres", testPsqlInfo)
+	require.NoError(t, err)
+
+	err = db.Ping(ctx)
+	assert.NoError(t, err)
+
+	return db
+}
+
+func newConn(ctx context.Context, t *testing.T, db *DB) *Conn {
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+
+	err = conn.Ping(ctx)
+	require.NoError(t, err)
+
+	return conn
+}
+
+func createTestTableWithDB(ctx context.Context, t *testing.T, db *DB) {
+	// test table is created
+	dstmt, err := db.Prepare(ctx, "DROP TABLE IF EXISTS test")
+	require.NoError(t, err)
+	_, err = dstmt.Exec(ctx)
+	require.NoError(t, err)
+	err = dstmt.Close(ctx)
+	require.NoError(t, err)
+	stmt, err := db.Prepare(ctx, "CREATE TABLE test(id int, column1 VARCHAR (50))")
+	require.NoError(t, err)
+	_, err = stmt.Exec(ctx)
+	require.NoError(t, err)
+	err = stmt.Close(ctx)
+	require.NoError(t, err)
+}
+
+func createTestTableWithConn(ctx context.Context, t *testing.T, conn *Conn) {
+	// test table is created
+	dstmt, err := conn.Prepare(ctx, "DROP TABLE IF EXISTS test")
+	require.NoError(t, err)
+	_, err = dstmt.Exec(ctx)
+	require.NoError(t, err)
+	err = dstmt.Close(ctx)
+	require.NoError(t, err)
+	stmt, err := conn.Prepare(ctx, "CREATE TABLE test(id int, column1 VARCHAR (50))")
+	require.NoError(t, err)
+	_, err = stmt.Exec(ctx)
+	require.NoError(t, err)
+	err = stmt.Close(ctx)
+	require.NoError(t, err)
+}
+
+func insertTestDataWithDB(ctx context.Context, t *testing.T, db *DB) {
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{})
+	require.NoError(t, err)
+
+	_, err = tx.Exec(ctx, "INSERT INTO test VALUES (1, 'value1')")
+	require.NoError(t, err)
+	err = tx.Commit(ctx)
+	require.NoError(t, err)
+}
+
+func insertTestDataWithConn(ctx context.Context, t *testing.T, conn *Conn) {
+	tx, err := conn.BeginTx(ctx, &sql.TxOptions{})
+	require.NoError(t, err)
+
+	_, err = tx.Exec(ctx, "INSERT INTO test VALUES (2, 'value2')")
+	require.NoError(t, err)
+	err = tx.Commit(ctx)
+	require.NoError(t, err)
+}
+
+func queryTestDataWithDB(ctx context.Context, t *testing.T, db *DB) {
+	stmt, err := db.Prepare(ctx, "SELECT column1 FROM test where id = 1")
+	require.NoError(t, err)
+
+	var column1 string
+	row := stmt.QueryRow(ctx)
+	err = row.Scan(&column1)
+	require.NoError(t, err)
+
+	require.Equal(t, column1, "value1")
+
+	err = stmt.Close(ctx)
+	require.NoError(t, err)
+}
+
+func queryTestDataWithConn(ctx context.Context, t *testing.T, conn *Conn) {
+	stmt, err := conn.Prepare(ctx, "SELECT column1 FROM test where id = 1")
+	require.NoError(t, err)
+
+	var column1 string
+	row := stmt.QueryRow(ctx)
+	err = row.Scan(&column1)
+	require.NoError(t, err)
+
+	require.Equal(t, column1, "value1")
+
+	err = stmt.Close(ctx)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
##  Which problem is this PR solving?

Fixes #133 

<!-- REQUIRED -->

## Short description of the changes

As stated in the trace/sql package, unit test coverage is low and it pulls down average test coverage below the threshold. Thus, integration test is added, and circleci configuration is edited to trigger integrations tests too. This is not completed work, because of 2 reasons;
* Already implemented publisher_integration_test returns failure, because of that circleci might start returning error.
* `make coverci` command returns error such that `go test: mod flag may be set only once`. (`-mod=vendor` can be removed.)

After discussing these 2 points, PR can be ready for being merged.

<!-- REQUIRED -->
