### PR TITLE
Clean Up trace pkg

### DIFF
--- a/async/amqp/amqp.go
+++ b/async/amqp/amqp.go
@@ -18,6 +18,11 @@ import (
 	"github.com/streadway/amqp"
 )
 
+const (
+	// AMQPConsumerComponent definition.
+	AMQPConsumerComponent = "amqp-consumer"
+)
+
 var (
 	defaultCfg = amqp.Config{
 		Dial: func(network, addr string) (net.Conn, error) {
@@ -171,8 +176,8 @@ func (c *consumer) Consume(ctx context.Context) (<-chan async.Message, <-chan er
 				log.Debugf("processing message %d", d.DeliveryTag)
 				corID := getCorrelationID(d.Headers)
 
-				sp, ctxCh := trace.ConsumerSpan(ctx, trace.ComponentOpName(trace.AMQPConsumerComponent, c.queue),
-					trace.AMQPConsumerComponent, corID, mapHeader(d.Headers), c.traceTag)
+				sp, ctxCh := trace.ConsumerSpan(ctx, trace.ComponentOpName(AMQPConsumerComponent, c.queue),
+					AMQPConsumerComponent, corID, mapHeader(d.Headers), c.traceTag)
 
 				dec, err := async.DetermineDecoder(d.ContentType)
 				if err != nil {

--- a/async/amqp/amqp.go
+++ b/async/amqp/amqp.go
@@ -19,8 +19,7 @@ import (
 )
 
 const (
-	// AMQPConsumerComponent definition.
-	AMQPConsumerComponent = "amqp-consumer"
+	consumerComponent = "amqp-consumer"
 )
 
 var (
@@ -176,8 +175,8 @@ func (c *consumer) Consume(ctx context.Context) (<-chan async.Message, <-chan er
 				log.Debugf("processing message %d", d.DeliveryTag)
 				corID := getCorrelationID(d.Headers)
 
-				sp, ctxCh := trace.ConsumerSpan(ctx, trace.ComponentOpName(AMQPConsumerComponent, c.queue),
-					AMQPConsumerComponent, corID, mapHeader(d.Headers), c.traceTag)
+				sp, ctxCh := trace.ConsumerSpan(ctx, trace.ComponentOpName(consumerComponent, c.queue),
+					consumerComponent, corID, mapHeader(d.Headers), c.traceTag)
 
 				dec, err := async.DetermineDecoder(d.ContentType)
 				if err != nil {

--- a/async/kafka/kafka.go
+++ b/async/kafka/kafka.go
@@ -19,8 +19,7 @@ import (
 )
 
 const (
-	// KafkaConsumerComponent definition.
-	KafkaConsumerComponent = "kafka-consumer"
+	consumerComponent = "kafka-consumer"
 )
 
 var topicPartitionOffsetDiff *prometheus.GaugeVec
@@ -111,8 +110,8 @@ func ClaimMessage(ctx context.Context, msg *sarama.ConsumerMessage, d encoding.D
 
 	corID := getCorrelationID(msg.Headers)
 
-	sp, ctxCh := trace.ConsumerSpan(ctx, trace.ComponentOpName(KafkaConsumerComponent, msg.Topic),
-		KafkaConsumerComponent, corID, mapHeader(msg.Headers))
+	sp, ctxCh := trace.ConsumerSpan(ctx, trace.ComponentOpName(consumerComponent, msg.Topic),
+		consumerComponent, corID, mapHeader(msg.Headers))
 	ctxCh = correlation.ContextWithID(ctxCh, corID)
 	ctxCh = log.WithContext(ctxCh, log.Sub(map[string]interface{}{"correlationID": corID}))
 

--- a/async/kafka/kafka.go
+++ b/async/kafka/kafka.go
@@ -18,6 +18,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	// KafkaConsumerComponent definition.
+	KafkaConsumerComponent = "kafka-consumer"
+)
+
 var topicPartitionOffsetDiff *prometheus.GaugeVec
 
 // TopicPartitionOffsetDiffGaugeSet creates a new Gauge that measures partition offsets.
@@ -106,8 +111,8 @@ func ClaimMessage(ctx context.Context, msg *sarama.ConsumerMessage, d encoding.D
 
 	corID := getCorrelationID(msg.Headers)
 
-	sp, ctxCh := trace.ConsumerSpan(ctx, trace.ComponentOpName(trace.KafkaConsumerComponent, msg.Topic),
-		trace.KafkaConsumerComponent, corID, mapHeader(msg.Headers))
+	sp, ctxCh := trace.ConsumerSpan(ctx, trace.ComponentOpName(KafkaConsumerComponent, msg.Topic),
+		KafkaConsumerComponent, corID, mapHeader(msg.Headers))
 	ctxCh = correlation.ContextWithID(ctxCh, corID)
 	ctxCh = log.WithContext(ctxCh, log.Sub(map[string]interface{}{"correlationID": corID}))
 

--- a/async/sqs/sqs.go
+++ b/async/sqs/sqs.go
@@ -34,6 +34,9 @@ const (
 	ackMessageState     messageState = "ACK"
 	nackMessageState    messageState = "NACK"
 	fetchedMessageState messageState = "FETCHED"
+
+	// SQSConsumerComponent definition.
+	SQSConsumerComponent = "sqs-consumer"
 )
 
 var messageAge *prometheus.GaugeVec
@@ -238,8 +241,8 @@ func (c *consumer) Consume(ctx context.Context) (<-chan async.Message, <-chan er
 
 				corID := getCorrelationID(msg.MessageAttributes)
 
-				sp, ctxCh := trace.ConsumerSpan(sqsCtx, trace.ComponentOpName(trace.SQSConsumerComponent, c.queueName),
-					trace.SQSConsumerComponent, corID, mapHeader(msg.MessageAttributes))
+				sp, ctxCh := trace.ConsumerSpan(sqsCtx, trace.ComponentOpName(SQSConsumerComponent, c.queueName),
+					SQSConsumerComponent, corID, mapHeader(msg.MessageAttributes))
 
 				ctxCh = correlation.ContextWithID(ctxCh, corID)
 				logger := log.Sub(map[string]interface{}{"correlationID": corID})

--- a/async/sqs/sqs.go
+++ b/async/sqs/sqs.go
@@ -35,8 +35,7 @@ const (
 	nackMessageState    messageState = "NACK"
 	fetchedMessageState messageState = "FETCHED"
 
-	// SQSConsumerComponent definition.
-	SQSConsumerComponent = "sqs-consumer"
+	consumerComponent = "sqs-consumer"
 )
 
 var messageAge *prometheus.GaugeVec
@@ -241,8 +240,8 @@ func (c *consumer) Consume(ctx context.Context) (<-chan async.Message, <-chan er
 
 				corID := getCorrelationID(msg.MessageAttributes)
 
-				sp, ctxCh := trace.ConsumerSpan(sqsCtx, trace.ComponentOpName(SQSConsumerComponent, c.queueName),
-					SQSConsumerComponent, corID, mapHeader(msg.MessageAttributes))
+				sp, ctxCh := trace.ConsumerSpan(sqsCtx, trace.ComponentOpName(consumerComponent, c.queueName),
+					consumerComponent, corID, mapHeader(msg.MessageAttributes))
 
 				ctxCh = correlation.ContextWithID(ctxCh, corID)
 				logger := log.Sub(map[string]interface{}{"correlationID": corID})

--- a/sync/http/middleware.go
+++ b/sync/http/middleware.go
@@ -8,7 +8,7 @@ import (
 	"github.com/beatlabs/patron/correlation"
 	"github.com/beatlabs/patron/log"
 	"github.com/beatlabs/patron/sync/http/auth"
-	"github.com/beatlabs/patron/trace"
+	trace_http "github.com/beatlabs/patron/trace/http"
 	"github.com/google/uuid"
 )
 
@@ -108,10 +108,10 @@ func NewLoggingTracingMiddleware(path string) MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			corID := getOrSetCorrelationID(r.Header)
-			sp, r := trace.HTTPSpan(path, corID, r)
+			sp, r := trace_http.Span(path, corID, r)
 			lw := newResponseWriter(w)
 			next.ServeHTTP(lw, r)
-			trace.FinishHTTPSpan(sp, lw.Status())
+			trace_http.FinishSpan(sp, lw.Status())
 			logRequestResponse(lw, r)
 		})
 	}

--- a/trace/amqp/amqp.go
+++ b/trace/amqp/amqp.go
@@ -18,8 +18,7 @@ import (
 )
 
 const (
-	// AMQPPublisherComponent definition.
-	AMQPPublisherComponent = "amqp-publisher"
+	publisherComponent = "amqp-publisher"
 )
 
 // Message abstraction for publishing.
@@ -122,8 +121,8 @@ func NewPublisher(url, exc string, oo ...OptionFunc) (*TracedPublisher, error) {
 
 // Publish a message to a exchange.
 func (tc *TracedPublisher) Publish(ctx context.Context, msg *Message) error {
-	sp, _ := trace.ChildSpan(ctx, trace.ComponentOpName(AMQPPublisherComponent, tc.exc),
-		AMQPPublisherComponent, ext.SpanKindProducer, tc.tag)
+	sp, _ := trace.ChildSpan(ctx, trace.ComponentOpName(publisherComponent, tc.exc),
+		publisherComponent, ext.SpanKindProducer, tc.tag)
 
 	p := amqp.Publishing{
 		Headers:     amqp.Table{},

--- a/trace/amqp/amqp.go
+++ b/trace/amqp/amqp.go
@@ -17,6 +17,11 @@ import (
 	"github.com/streadway/amqp"
 )
 
+const (
+	// AMQPPublisherComponent definition.
+	AMQPPublisherComponent = "amqp-publisher"
+)
+
 // Message abstraction for publishing.
 type Message struct {
 	contentType string
@@ -117,8 +122,8 @@ func NewPublisher(url, exc string, oo ...OptionFunc) (*TracedPublisher, error) {
 
 // Publish a message to a exchange.
 func (tc *TracedPublisher) Publish(ctx context.Context, msg *Message) error {
-	sp, _ := trace.ChildSpan(ctx, trace.ComponentOpName(trace.AMQPPublisherComponent, tc.exc),
-		trace.AMQPPublisherComponent, ext.SpanKindProducer, tc.tag)
+	sp, _ := trace.ChildSpan(ctx, trace.ComponentOpName(AMQPPublisherComponent, tc.exc),
+		AMQPPublisherComponent, ext.SpanKindProducer, tc.tag)
 
 	p := amqp.Publishing{
 		Headers:     amqp.Table{},

--- a/trace/es/elasticsearch.go
+++ b/trace/es/elasticsearch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/go-elasticsearch/v8/esapi"
 	"github.com/elastic/go-elasticsearch/v8/estransport"
 	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 )
 
 const (
@@ -52,7 +53,20 @@ func (t *tracingInfo) startSpan(req *http.Request) (opentracing.Span, error) {
 		}
 	}
 
-	return trace.EsSpan(req.Context(), opName, cmpName, t.user, uri, method, bodyFmt, t.hosts), nil
+	sp, _ := opentracing.StartSpanFromContext(req.Context(), opName)
+	ext.Component.Set(sp, cmpName)
+	ext.DBType.Set(sp, "elasticsearch")
+	ext.DBUser.Set(sp, t.user)
+
+	ext.HTTPUrl.Set(sp, uri)
+	ext.HTTPMethod.Set(sp, method)
+	ext.DBStatement.Set(sp, bodyFmt)
+
+	hostsFmt := "[" + strings.Join(t.hosts, ", ") + "]"
+	sp.SetTag(trace.HostsTag, hostsFmt)
+	sp.SetTag(trace.VersionTag, trace.Version)
+
+	return sp, nil
 }
 
 func endSpan(sp opentracing.Span, rsp *http.Response) {

--- a/trace/es/elasticsearch.go
+++ b/trace/es/elasticsearch.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/beatlabs/patron/trace"
+	trace_http "github.com/beatlabs/patron/trace/http"
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/esapi"
 	"github.com/elastic/go-elasticsearch/v8/estransport"
@@ -58,7 +59,7 @@ func endSpan(sp opentracing.Span, rsp *http.Response) {
 	// In cases where more than one host is given, the selected one is only known at this time
 	sp.SetTag(respondentTag, rsp.Request.URL.Host)
 
-	trace.FinishHTTPSpan(sp, rsp.StatusCode)
+	trace_http.FinishSpan(sp, rsp.StatusCode)
 }
 
 type transportClient struct {

--- a/trace/http/http.go
+++ b/trace/http/http.go
@@ -6,11 +6,19 @@ import (
 	"time"
 
 	"github.com/beatlabs/patron/correlation"
+	"github.com/beatlabs/patron/log"
 	"github.com/beatlabs/patron/reliability/circuitbreaker"
 	"github.com/beatlabs/patron/trace"
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+)
+
+const (
+	// HTTPComponent definition.
+	HTTPComponent = "http"
+	// HTTPClientComponent definition.
+	HTTPClientComponent = "http-client"
 )
 
 // Client interface of a HTTP client.
@@ -48,8 +56,8 @@ func New(oo ...OptionFunc) (*TracedClient, error) {
 func (tc *TracedClient) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
 	req = req.WithContext(ctx)
 	req, ht := nethttp.TraceRequest(opentracing.GlobalTracer(), req,
-		nethttp.OperationName(trace.HTTPOpName(req.Method, req.URL.String())),
-		nethttp.ComponentName(trace.HTTPClientComponent))
+		nethttp.OperationName(OpName(req.Method, req.URL.String())),
+		nethttp.ComponentName(HTTPClientComponent))
 	defer ht.Finish()
 
 	req.Header.Set(correlation.HeaderID, correlation.IDFromContext(ctx))
@@ -79,4 +87,31 @@ func (tc *TracedClient) do(req *http.Request) (*http.Response, error) {
 	}
 
 	return r.(*http.Response), nil
+}
+
+// Span starts a new HTTP span.
+func Span(path, corID string, r *http.Request) (opentracing.Span, *http.Request) {
+	ctx, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))
+	if err != nil && err != opentracing.ErrSpanContextNotFound {
+		log.Errorf("failed to extract HTTP span: %v", err)
+	}
+	sp := opentracing.StartSpan(OpName(r.Method, path), ext.RPCServerOption(ctx))
+	ext.HTTPMethod.Set(sp, r.Method)
+	ext.HTTPUrl.Set(sp, r.URL.String())
+	ext.Component.Set(sp, "http")
+	sp.SetTag(trace.VersionTag, trace.Version)
+	sp.SetTag(correlation.ID, corID)
+	return sp, r.WithContext(opentracing.ContextWithSpan(r.Context(), sp))
+}
+
+// FinishSpan finishes a HTTP span by providing a HTTP status code.
+func FinishSpan(sp opentracing.Span, code int) {
+	ext.HTTPStatusCode.Set(sp, uint16(code))
+	ext.Error.Set(sp, code >= http.StatusInternalServerError)
+	sp.Finish()
+}
+
+// OpName return a string representation of the HTTP request operation.
+func OpName(method, path string) string {
+	return method + " " + path
 }

--- a/trace/http/http.go
+++ b/trace/http/http.go
@@ -56,7 +56,7 @@ func New(oo ...OptionFunc) (*TracedClient, error) {
 func (tc *TracedClient) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
 	req = req.WithContext(ctx)
 	req, ht := nethttp.TraceRequest(opentracing.GlobalTracer(), req,
-		nethttp.OperationName(OpName(req.Method, req.URL.String())),
+		nethttp.OperationName(opName(req.Method, req.URL.String())),
 		nethttp.ComponentName(HTTPClientComponent))
 	defer ht.Finish()
 
@@ -95,7 +95,7 @@ func Span(path, corID string, r *http.Request) (opentracing.Span, *http.Request)
 	if err != nil && err != opentracing.ErrSpanContextNotFound {
 		log.Errorf("failed to extract HTTP span: %v", err)
 	}
-	sp := opentracing.StartSpan(OpName(r.Method, path), ext.RPCServerOption(ctx))
+	sp := opentracing.StartSpan(opName(r.Method, path), ext.RPCServerOption(ctx))
 	ext.HTTPMethod.Set(sp, r.Method)
 	ext.HTTPUrl.Set(sp, r.URL.String())
 	ext.Component.Set(sp, "http")
@@ -111,7 +111,6 @@ func FinishSpan(sp opentracing.Span, code int) {
 	sp.Finish()
 }
 
-// OpName return a string representation of the HTTP request operation.
-func OpName(method, path string) string {
+func opName(method, path string) string {
 	return method + " " + path
 }

--- a/trace/http/http.go
+++ b/trace/http/http.go
@@ -15,10 +15,7 @@ import (
 )
 
 const (
-	// HTTPComponent definition.
-	HTTPComponent = "http"
-	// HTTPClientComponent definition.
-	HTTPClientComponent = "http-client"
+	clientComponent = "http-client"
 )
 
 // Client interface of a HTTP client.
@@ -57,7 +54,7 @@ func (tc *TracedClient) Do(ctx context.Context, req *http.Request) (*http.Respon
 	req = req.WithContext(ctx)
 	req, ht := nethttp.TraceRequest(opentracing.GlobalTracer(), req,
 		nethttp.OperationName(opName(req.Method, req.URL.String())),
-		nethttp.ComponentName(HTTPClientComponent))
+		nethttp.ComponentName(clientComponent))
 	defer ht.Finish()
 
 	req.Header.Set(correlation.HeaderID, correlation.IDFromContext(ctx))

--- a/trace/http/http_test.go
+++ b/trace/http/http_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/beatlabs/patron/reliability/circuitbreaker"
-	"github.com/beatlabs/patron/trace"
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
 )
@@ -33,7 +33,7 @@ func TestTracedClient_Do(t *testing.T) {
 	assert.NoError(t, err)
 	reqErr, err := http.NewRequest("GET", "", nil)
 	assert.NoError(t, err)
-	opName := trace.HTTPOpName("GET", ts.URL)
+	opName := OpName("GET", ts.URL)
 	opNameError := "HTTP GET"
 
 	type args struct {
@@ -94,4 +94,31 @@ func TestNew(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHTTPStartFinishSpan(t *testing.T) {
+	mtr := mocktracer.New()
+	opentracing.SetGlobalTracer(mtr)
+	req, err := http.NewRequest("GET", "/", nil)
+	assert.NoError(t, err)
+	sp, req := Span("/", "corID", req)
+	assert.NotNil(t, sp)
+	assert.NotNil(t, req)
+	assert.IsType(t, &mocktracer.MockSpan{}, sp)
+	jsp := sp.(*mocktracer.MockSpan)
+	assert.NotNil(t, jsp)
+	assert.Equal(t, "GET /", jsp.OperationName)
+	FinishSpan(jsp, 200)
+	assert.NotNil(t, jsp)
+	rawSpan := mtr.FinishedSpans()[0]
+	assert.Equal(t, map[string]interface{}{
+		"span.kind":        ext.SpanKindRPCServerEnum,
+		"component":        "http",
+		"error":            false,
+		"http.method":      "GET",
+		"http.status_code": uint16(200),
+		"http.url":         "/",
+		"version":          "dev",
+		"correlationID":    "corID",
+	}, rawSpan.Tags())
 }

--- a/trace/http/http_test.go
+++ b/trace/http/http_test.go
@@ -33,7 +33,7 @@ func TestTracedClient_Do(t *testing.T) {
 	assert.NoError(t, err)
 	reqErr, err := http.NewRequest("GET", "", nil)
 	assert.NoError(t, err)
-	opName := OpName("GET", ts.URL)
+	opName := opName("GET", ts.URL)
 	opNameError := "HTTP GET"
 
 	type args struct {

--- a/trace/kafka/kafka.go
+++ b/trace/kafka/kafka.go
@@ -13,6 +13,11 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
+const (
+	// KafkaAsyncProducerComponent definition.
+	KafkaAsyncProducerComponent = "kafka-async-producer"
+)
+
 // Message abstraction of a Kafka message.
 type Message struct {
 	topic string
@@ -52,8 +57,8 @@ type AsyncProducer struct {
 
 // Send a message to a topic.
 func (ap *AsyncProducer) Send(ctx context.Context, msg *Message) error {
-	sp, _ := trace.ChildSpan(ctx, trace.ComponentOpName(trace.KafkaAsyncProducerComponent, msg.topic),
-		trace.KafkaAsyncProducerComponent, ext.SpanKindProducer, ap.tag,
+	sp, _ := trace.ChildSpan(ctx, trace.ComponentOpName(KafkaAsyncProducerComponent, msg.topic),
+		KafkaAsyncProducerComponent, ext.SpanKindProducer, ap.tag,
 		opentracing.Tag{Key: "topic", Value: msg.topic})
 	pm, err := ap.createProducerMessage(ctx, msg, sp)
 	if err != nil {

--- a/trace/kafka/kafka.go
+++ b/trace/kafka/kafka.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	// KafkaAsyncProducerComponent definition.
-	KafkaAsyncProducerComponent = "kafka-async-producer"
+	producerComponent = "kafka-async-producer"
 )
 
 // Message abstraction of a Kafka message.
@@ -57,8 +56,8 @@ type AsyncProducer struct {
 
 // Send a message to a topic.
 func (ap *AsyncProducer) Send(ctx context.Context, msg *Message) error {
-	sp, _ := trace.ChildSpan(ctx, trace.ComponentOpName(KafkaAsyncProducerComponent, msg.topic),
-		KafkaAsyncProducerComponent, ext.SpanKindProducer, ap.tag,
+	sp, _ := trace.ChildSpan(ctx, trace.ComponentOpName(producerComponent, msg.topic),
+		producerComponent, ext.SpanKindProducer, ap.tag,
 		opentracing.Tag{Key: "topic", Value: msg.topic})
 	pm, err := ap.createProducerMessage(ctx, msg, sp)
 	if err != nil {

--- a/trace/sns/publisher.go
+++ b/trace/sns/publisher.go
@@ -14,6 +14,11 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
+const (
+	// SNSPublisherComponent definition.
+	SNSPublisherComponent = "sns-publisher"
+)
+
 // Publisher is the interface defining an SNS publisher, used to publish messages to SNS.
 type Publisher interface {
 	Publish(ctx context.Context, msg Message) (messageID string, err error)
@@ -37,7 +42,7 @@ func NewPublisher(api snsiface.SNSAPI) (*TracedPublisher, error) {
 
 	return &TracedPublisher{
 		api:       api,
-		component: trace.SNSPublisherComponent,
+		component: SNSPublisherComponent,
 		tag:       ext.SpanKindProducer,
 	}, nil
 }

--- a/trace/sns/publisher.go
+++ b/trace/sns/publisher.go
@@ -15,8 +15,7 @@ import (
 )
 
 const (
-	// SNSPublisherComponent definition.
-	SNSPublisherComponent = "sns-publisher"
+	publisherComponent = "sns-publisher"
 )
 
 // Publisher is the interface defining an SNS publisher, used to publish messages to SNS.
@@ -42,7 +41,7 @@ func NewPublisher(api snsiface.SNSAPI) (*TracedPublisher, error) {
 
 	return &TracedPublisher{
 		api:       api,
-		component: SNSPublisherComponent,
+		component: publisherComponent,
 		tag:       ext.SpanKindProducer,
 	}, nil
 }

--- a/trace/sns/publisher_test.go
+++ b/trace/sns/publisher_test.go
@@ -43,7 +43,7 @@ func Test_NewPublisher(t *testing.T) {
 				assert.EqualError(t, err, tC.expectedErr.Error())
 			} else {
 				assert.Equal(t, tC.api, p.api)
-				assert.Equal(t, p.component, SNSPublisherComponent)
+				assert.Equal(t, p.component, publisherComponent)
 				assert.Equal(t, p.tag, ext.SpanKindProducer)
 			}
 		})

--- a/trace/sns/publisher_test.go
+++ b/trace/sns/publisher_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sns/snsiface"
-	"github.com/beatlabs/patron/trace"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,7 +43,7 @@ func Test_NewPublisher(t *testing.T) {
 				assert.EqualError(t, err, tC.expectedErr.Error())
 			} else {
 				assert.Equal(t, tC.api, p.api)
-				assert.Equal(t, p.component, trace.SNSPublisherComponent)
+				assert.Equal(t, p.component, SNSPublisherComponent)
 				assert.Equal(t, p.tag, ext.SpanKindProducer)
 			}
 		})

--- a/trace/sql/sql.go
+++ b/trace/sql/sql.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	cmp     = "sql"
-	sqlType = "RDBMS"
+	component = "sql"
+	dbtype    = "RDBMS"
 )
 
 type connInfo struct {
@@ -23,8 +23,8 @@ type connInfo struct {
 
 func (c *connInfo) startSpan(ctx context.Context, opName, stmt string, tags ...opentracing.Tag) (opentracing.Span, context.Context) {
 	sp, ctx := opentracing.StartSpanFromContext(ctx, opName)
-	ext.Component.Set(sp, cmp)
-	ext.DBType.Set(sp, sqlType)
+	ext.Component.Set(sp, component)
+	ext.DBType.Set(sp, dbtype)
 	ext.DBInstance.Set(sp, c.instance)
 	ext.DBUser.Set(sp, c.user)
 	ext.DBStatement.Set(sp, stmt)
@@ -42,7 +42,7 @@ type Conn struct {
 }
 
 // DSNInfo contains information extracted from a valid
-// connection string. Additional parameters provided are discarded
+// connection string. Additional parameters provided are discarded.
 type DSNInfo struct {
 	Driver   string
 	DBName   string

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -18,23 +18,11 @@ import (
 )
 
 const (
-	// KafkaConsumerComponent definition.
-	KafkaConsumerComponent = "kafka-consumer"
-	// KafkaAsyncProducerComponent definition.
-	KafkaAsyncProducerComponent = "kafka-async-producer"
-	// AMQPConsumerComponent definition.
-	AMQPConsumerComponent = "amqp-consumer"
-	// AMQPPublisherComponent definition.
-	AMQPPublisherComponent = "amqp-publisher"
 	// HTTPComponent definition.
 	HTTPComponent = "http"
 	// HTTPClientComponent definition.
 	HTTPClientComponent = "http-client"
-	// SQSConsumerComponent definition.
-	SQSConsumerComponent = "sqs-consumer"
-	// SNSPublisherComponent definition.
-	SNSPublisherComponent = "sns-publisher"
-	hostsTag              = "hosts"
+	hostsTag            = "hosts"
 )
 
 var (

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -34,19 +34,22 @@ const (
 	SQSConsumerComponent = "sqs-consumer"
 	// SNSPublisherComponent definition.
 	SNSPublisherComponent = "sns-publisher"
-	versionTag            = "version"
 	hostsTag              = "hosts"
 )
 
 var (
-	cls     io.Closer
-	version = "dev"
+	cls io.Closer
+	// VersionTag is used to tag the components's version.
+	VersionTag = "version"
+	// Version will be used to tag all traced components.
+	// It can be used to distinguish between dev, stage, and prod environments.
+	Version = "dev"
 )
 
 // Setup tracing by providing all necessary parameters.
 func Setup(name, ver, agent, typ string, prm float64) error {
 	if ver != "" {
-		version = ver
+		Version = ver
 	}
 	cfg := config.Configuration{
 		ServiceName: name,
@@ -71,7 +74,6 @@ func Setup(name, ver, agent, typ string, prm float64) error {
 	}
 	cls = clsTemp
 	opentracing.SetGlobalTracer(tr)
-	version = ver
 	return nil
 }
 
@@ -91,7 +93,7 @@ func HTTPSpan(path, corID string, r *http.Request) (opentracing.Span, *http.Requ
 	ext.HTTPMethod.Set(sp, r.Method)
 	ext.HTTPUrl.Set(sp, r.URL.String())
 	ext.Component.Set(sp, "http")
-	sp.SetTag(versionTag, version)
+	sp.SetTag(VersionTag, Version)
 	sp.SetTag(correlation.ID, corID)
 	return sp, r.WithContext(opentracing.ContextWithSpan(r.Context(), sp))
 }
@@ -113,7 +115,7 @@ func ConsumerSpan(ctx context.Context, opName, cmp, corID string, hdr map[string
 	sp := opentracing.StartSpan(opName, consumerOption{ctx: spCtx})
 	ext.Component.Set(sp, cmp)
 	sp.SetTag(correlation.ID, corID)
-	sp.SetTag(versionTag, version)
+	sp.SetTag(VersionTag, Version)
 	for _, t := range tags {
 		sp.SetTag(t.Key, t.Value)
 	}
@@ -145,24 +147,7 @@ func ChildSpan(ctx context.Context, opName, cmp string, tags ...opentracing.Tag)
 	for _, t := range tags {
 		sp.SetTag(t.Key, t.Value)
 	}
-	sp.SetTag(versionTag, version)
-	return sp, ctx
-}
-
-// SQLSpan starts a new SQL child span with specified tags.
-func SQLSpan(ctx context.Context, opName, cmp, sqlType, instance, user, stmt string,
-	tags ...opentracing.Tag) (opentracing.Span, context.Context) {
-
-	sp, ctx := opentracing.StartSpanFromContext(ctx, opName)
-	ext.Component.Set(sp, cmp)
-	ext.DBType.Set(sp, sqlType)
-	ext.DBInstance.Set(sp, instance)
-	ext.DBUser.Set(sp, user)
-	ext.DBStatement.Set(sp, stmt)
-	for _, t := range tags {
-		sp.SetTag(t.Key, t.Value)
-	}
-	sp.SetTag(versionTag, version)
+	sp.SetTag(VersionTag, Version)
 	return sp, ctx
 }
 
@@ -180,7 +165,7 @@ func EsSpan(ctx context.Context, opName, cmp, user, uri, method, body string, ho
 
 	hostsFmt := "[" + strings.Join(hostPool, ", ") + "]"
 	sp.SetTag(hostsTag, hostsFmt)
-	sp.SetTag(versionTag, version)
+	sp.SetTag(VersionTag, Version)
 
 	return sp
 }

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/beatlabs/patron/correlation"
@@ -17,7 +16,8 @@ import (
 )
 
 const (
-	hostsTag = "hosts"
+	// HostsTag is used to tag the components's hosts.
+	HostsTag = "hosts"
 	// VersionTag is used to tag the components's version.
 	VersionTag = "version"
 )
@@ -110,25 +110,6 @@ func ChildSpan(ctx context.Context, opName, cmp string, tags ...opentracing.Tag)
 	}
 	sp.SetTag(VersionTag, Version)
 	return sp, ctx
-}
-
-// EsSpan starts a new elasticsearch child span with specified tags.
-func EsSpan(ctx context.Context, opName, cmp, user, uri, method, body string, hostPool []string) opentracing.Span {
-
-	sp, _ := opentracing.StartSpanFromContext(ctx, opName)
-	ext.Component.Set(sp, cmp)
-	ext.DBType.Set(sp, "elasticsearch")
-	ext.DBUser.Set(sp, user)
-
-	ext.HTTPUrl.Set(sp, uri)
-	ext.HTTPMethod.Set(sp, method)
-	ext.DBStatement.Set(sp, body)
-
-	hostsFmt := "[" + strings.Join(hostPool, ", ") + "]"
-	sp.SetTag(hostsTag, hostsFmt)
-	sp.SetTag(VersionTag, Version)
-
-	return sp
 }
 
 type jaegerLoggerAdapter struct {

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -2,7 +2,6 @@ package trace
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -75,33 +74,6 @@ func TestStartFinishChildSpan(t *testing.T) {
 		"key":           "value",
 		"span.kind":     ext.SpanKindConsumerEnum,
 		"correlationID": "corID",
-	}, rawSpan.Tags())
-}
-
-func TestHTTPStartFinishSpan(t *testing.T) {
-	mtr := mocktracer.New()
-	opentracing.SetGlobalTracer(mtr)
-	req, err := http.NewRequest("GET", "/", nil)
-	assert.NoError(t, err)
-	sp, req := HTTPSpan("/", "corID", req)
-	assert.NotNil(t, sp)
-	assert.NotNil(t, req)
-	assert.IsType(t, &mocktracer.MockSpan{}, sp)
-	jsp := sp.(*mocktracer.MockSpan)
-	assert.NotNil(t, jsp)
-	assert.Equal(t, "GET /", jsp.OperationName)
-	FinishHTTPSpan(jsp, 200)
-	assert.NotNil(t, jsp)
-	rawSpan := mtr.FinishedSpans()[0]
-	assert.Equal(t, map[string]interface{}{
-		"span.kind":        ext.SpanKindRPCServerEnum,
-		"component":        "http",
-		"error":            false,
-		"http.method":      "GET",
-		"http.status_code": uint16(200),
-		"http.url":         "/",
-		"version":          "dev",
-		"correlationID":    "corID",
 	}, rawSpan.Tags())
 }
 

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -77,30 +77,6 @@ func TestStartFinishChildSpan(t *testing.T) {
 	}, rawSpan.Tags())
 }
 
-func TestEsSpan(t *testing.T) {
-	mtr := mocktracer.New()
-	opentracing.SetGlobalTracer(mtr)
-	hostPool := []string{"http://localhost:9200", "http:10.1.1.1:9201", "https://www.domain.com:9203"}
-	sp := EsSpan(context.Background(), "opName", "es-component", "es-user", "es-uri", "query-method", "query-body", hostPool)
-	assert.NotNil(t, sp)
-	assert.IsType(t, &mocktracer.MockSpan{}, sp)
-	jsp := sp.(*mocktracer.MockSpan)
-	assert.NotNil(t, jsp)
-	SpanSuccess(sp)
-	rawspan := mtr.FinishedSpans()[0]
-	assert.Equal(t, map[string]interface{}{
-		"component":    "es-component",
-		"version":      "dev",
-		"db.statement": "query-body",
-		"db.type":      "elasticsearch",
-		"db.user":      "es-user",
-		"http.url":     "es-uri",
-		"http.method":  "query-method",
-		hostsTag:       "[http://localhost:9200, http:10.1.1.1:9201, https://www.domain.com:9203]",
-		"error":        false,
-	}, rawspan.Tags())
-}
-
 func TestComponentOpName(t *testing.T) {
 	assert.Equal(t, "cmp target", ComponentOpName("cmp", "target"))
 }

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -16,7 +16,7 @@ func TestSetup_Tracer_Close(t *testing.T) {
 	assert.NoError(t, err)
 	err = Close()
 	assert.NoError(t, err)
-	version = "dev"
+	Version = "dev"
 }
 
 func TestStartFinishConsumerSpan(t *testing.T) {
@@ -102,30 +102,6 @@ func TestHTTPStartFinishSpan(t *testing.T) {
 		"http.url":         "/",
 		"version":          "dev",
 		"correlationID":    "corID",
-	}, rawSpan.Tags())
-}
-
-func TestSQLStartFinishSpan(t *testing.T) {
-	mtr := mocktracer.New()
-	opentracing.SetGlobalTracer(mtr)
-	tag := opentracing.Tag{Key: "key", Value: "value"}
-	sp, req := SQLSpan(context.Background(), "name", "sql", "rdbms", "instance", "sa", "ssf", tag)
-	assert.NotNil(t, sp)
-	assert.NotNil(t, req)
-	assert.IsType(t, &mocktracer.MockSpan{}, sp)
-	jsp := sp.(*mocktracer.MockSpan)
-	assert.NotNil(t, jsp)
-	SpanSuccess(sp)
-	rawSpan := mtr.FinishedSpans()[0]
-	assert.Equal(t, map[string]interface{}{
-		"component":    "sql",
-		"version":      "dev",
-		"db.instance":  "instance",
-		"db.statement": "ssf",
-		"db.type":      "rdbms",
-		"db.user":      "sa",
-		"error":        false,
-		"key":          "value",
 	}, rawSpan.Tags())
 }
 

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -23,7 +23,7 @@ func TestStartFinishConsumerSpan(t *testing.T) {
 	mtr := mocktracer.New()
 	opentracing.SetGlobalTracer(mtr)
 	hdr := map[string]string{"key": "val"}
-	sp, ctx := ConsumerSpan(context.Background(), "123", AMQPConsumerComponent, "corID", hdr)
+	sp, ctx := ConsumerSpan(context.Background(), "123", "custom-consumer", "corID", hdr)
 	assert.NotNil(t, sp)
 	assert.NotNil(t, ctx)
 	assert.IsType(t, &mocktracer.MockSpan{}, sp)
@@ -35,7 +35,7 @@ func TestStartFinishConsumerSpan(t *testing.T) {
 	rawSpan := mtr.FinishedSpans()[0]
 	assert.Equal(t, map[string]interface{}{
 		"span.kind":     ext.SpanKindConsumerEnum,
-		"component":     "amqp-consumer",
+		"component":     "custom-consumer",
 		"error":         true,
 		"version":       "dev",
 		"correlationID": "corID",
@@ -46,7 +46,7 @@ func TestStartFinishChildSpan(t *testing.T) {
 	mtr := mocktracer.New()
 	opentracing.SetGlobalTracer(mtr)
 	tag := opentracing.Tag{Key: "key", Value: "value"}
-	sp, ctx := ConsumerSpan(context.Background(), "123", AMQPConsumerComponent, "corID", nil, tag)
+	sp, ctx := ConsumerSpan(context.Background(), "123", "custom-consumer", "corID", nil, tag)
 	assert.NotNil(t, sp)
 	assert.NotNil(t, ctx)
 	childSp, childCtx := ChildSpan(ctx, "123", "cmp", tag)
@@ -69,7 +69,7 @@ func TestStartFinishChildSpan(t *testing.T) {
 	SpanSuccess(sp)
 	rawSpan = mtr.FinishedSpans()[1]
 	assert.Equal(t, map[string]interface{}{
-		"component":     "amqp-consumer",
+		"component":     "custom-consumer",
 		"error":         false,
 		"version":       "dev",
 		"key":           "value",


### PR DESCRIPTION
## Which problem is this PR solving?

This PR closes #145 [Clean up trace package](https://github.com/beatlabs/patron/issues/145). 

The end-goal is to refactor code which should live in another packages, and keep the base `trace/` package as lean and implementation-agnostic as possible.


## Short description of the changes

* Break up AMQP/Kafka/SQS Consumer component constant names in the `async/` sub-package.
* Break up AMQP/Kafka/SNS Publisher component names to the respective `trace/` sub-package.
* Break up the HTTP and SQL component names to the destination sub-package.
* For SQL, HTTP, and ElasticSearc, SQLMove the `XYZSpan()` function into their respective sub-package. Rename them to avoid stuttering. If a `startSpan()` function exists, integrate the functionality there, so there's exactly one entrypoint.
* Make `hostsTag` and `versionTag` public so they're re-used between current and future implementations.
* Fix and distribute unittests in their respective packages.
* TODO Check one more time on whether we can unexport some of the functions.

## Notes
The HTTP span functions have been left unexported, as they're used elsewhere (eg. in the middleware layer, and in the elasticsearch package). They're generic enough to be used in future places too, so I think they should remain exported, rather than copied.