### PR TITLE
Fix incorrect use of AsyncProducer by allowing to close and spool the producer

### DIFF
--- a/trace/kafka/builder.go
+++ b/trace/kafka/builder.go
@@ -33,7 +33,6 @@ const fieldSetMsg = "Setting property '%v' for '%v'"
 type AsyncBuilder struct {
 	brokers     []string
 	cfg         *sarama.Config
-	chErr       chan error
 	tag         opentracing.Tag
 	enc         encoding.EncodeFunc
 	contentType string
@@ -55,7 +54,6 @@ func NewBuilder(brokers []string) *AsyncBuilder {
 	return &AsyncBuilder{
 		brokers:     brokers,
 		cfg:         cfg,
-		chErr:       make(chan error),
 		tag:         opentracing.Tag{Key: "type", Value: "async"},
 		enc:         json.Encode,
 		contentType: json.Type,
@@ -135,15 +133,13 @@ func (ab *AsyncBuilder) Create() (*AsyncProducer, error) {
 	}
 
 	ap := AsyncProducer{
-		cfg:         ab.cfg,
-		prod:        prod,
-		chErr:       ab.chErr,
-		enc:         ab.enc,
-		contentType: ab.contentType,
-		tag:         ab.tag,
+		cfg:           ab.cfg,
+		AsyncProducer: prod,
+		enc:           ab.enc,
+		contentType:   ab.contentType,
+		tag:           ab.tag,
 	}
 
-	go ap.propagateError()
 	return &ap, nil
 }
 

--- a/trace/kafka/kafka_test.go
+++ b/trace/kafka/kafka_test.go
@@ -74,7 +74,7 @@ func TestAsyncProducer_SendMessage_Close(t *testing.T) {
 	_, ctx := trace.ChildSpan(context.Background(), "123", "cmp")
 	err = ap.Send(ctx, msg)
 	assert.NoError(t, err)
-	assert.Error(t, <-ap.Error())
+	assert.Error(t, <-ap.Errors())
 	assert.NoError(t, ap.Close())
 }
 
@@ -92,7 +92,7 @@ func TestAsyncProducer_SendMessage_WithKey(t *testing.T) {
 	_, ctx := trace.ChildSpan(context.Background(), "123", "cmp")
 	err = ap.Send(ctx, msg)
 	assert.NoError(t, err)
-	assert.Error(t, <-ap.Error())
+	assert.Error(t, <-ap.Errors())
 	assert.NoError(t, ap.Close())
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

https://github.com/beatlabs/patron/issues/148

## Short description of the changes

* Extend sarama.AsyncProducer instead of making it private, so that it can be used correctly and developer is responsible for its correct usage
* Remove redundant errors channel
* Update second example to show how to use sarama.AsyncProducer properly

In general I believe it would be more idiomatic to extend the AsyncProducer rather than making it private and proxying all the fields/methods (as it was partially done for the `Errors()` channel).