### PR TITLE
trace/sql: Wrap and return standard library sql.DB

### DIFF
--- a/trace/sql/sql.go
+++ b/trace/sql/sql.go
@@ -140,6 +140,18 @@ func OpenDB(c driver.Connector) *DB {
 	return &DB{db: db}
 }
 
+// FromDB wraps an opened db. This allows to support libraries that provide
+// *sql.DB like sqlmock.
+func FromDB(db *sql.DB) *DB {
+	return &DB{db: db}
+}
+
+// DB returns the underlying db. This is useful for SQL code that does not
+// require tracing.
+func (db *DB) DB() *sql.DB {
+	return db.db
+}
+
 // BeginTx starts a transaction.
 func (db *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
 	sp, _ := db.startSpan(ctx, "db.BeginTx", "")

--- a/trace/sql/sql_test.go
+++ b/trace/sql/sql_test.go
@@ -2,6 +2,7 @@ package sql
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/beatlabs/patron/trace"
@@ -62,4 +63,11 @@ func TestSQLStartFinishSpan(t *testing.T) {
 		"error":        false,
 		"key":          "value",
 	}, rawSpan.Tags())
+}
+
+func TestFromDB(t *testing.T) {
+	want := &sql.DB{}
+	db := FromDB(want)
+	got := db.DB()
+	assert.Equal(t, want, got)
 }


### PR DESCRIPTION
This change adds two functions to package trace/sql. One that wraps the
standard library sql.DB, which provides support for libraries like
sqlmock and another that provides access to the wrapped sql.DB which is
useful for SQL code that does not require tracing.

Closes #179.

Signed-off-by: Stratos Neiros <s.neiros@thebeat.co>