### PR TITLE
Add ActiveBrokers() method to Kafka AsyncProducer

### DIFF
--- a/client/kafka/builder.go
+++ b/client/kafka/builder.go
@@ -130,13 +130,18 @@ func (ab *AsyncBuilder) Create() (*AsyncProducer, error) {
 		return nil, patronErrors.Aggregate(ab.errors...)
 	}
 
-	prod, err := sarama.NewAsyncProducer(ab.brokers, ab.cfg)
+	prodClient, err := sarama.NewClient(ab.brokers, ab.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create async producer client: %w", err)
+	}
+	prod, err := sarama.NewAsyncProducerFromClient(prodClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create async producer: %w", err)
 	}
 
 	ap := AsyncProducer{
 		cfg:         ab.cfg,
+		prodClient:  prodClient,
 		prod:        prod,
 		chErr:       ab.chErr,
 		enc:         ab.enc,

--- a/client/kafka/kafka_test.go
+++ b/client/kafka/kafka_test.go
@@ -224,3 +224,14 @@ func assertMetric(t *testing.T, testMetrics ...testMetric) {
 		counter.Reset()
 	}
 }
+
+func TestAsyncProducerActiveBrokers(t *testing.T) {
+	seed := createKafkaBroker(t, true)
+	ap, err := NewBuilder([]string{seed.Addr()}).WithVersion(sarama.V0_8_2_0.String()).Create()
+	assert.NoError(t, err)
+	assert.NotNil(t, ap)
+
+	assert.NotEmpty(t, ap.ActiveBrokers())
+
+	assert.NoError(t, ap.Close())
+}


### PR DESCRIPTION
This PR adds an `ActiveBrokers()` method to Kafka `AsyncProducer`. It also expands the GoDoc comment for Close() method and fixes a typo in an error message.

Had to recreate PR #187 because I deleted the fork in-between.

## Which problem is this PR solving?

Closes #169