### PR TITLE
Add support for Kafka synchronous producer through builder

### DIFF
--- a/client/kafka/async_producer.go
+++ b/client/kafka/async_producer.go
@@ -1,0 +1,64 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Shopify/sarama"
+	"github.com/beatlabs/patron/trace"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+)
+
+// AsyncProducer is an asynchronous Kafka producer.
+type AsyncProducer struct {
+	baseProducer
+	asyncProd sarama.AsyncProducer
+	chErr     chan error
+}
+
+// Send a message to a topic, asynchronously. Producer errors are queued on the
+// channel obtained during the AsyncProducer creation.
+func (ap *AsyncProducer) Send(ctx context.Context, msg *Message) error {
+	sp, _ := trace.ChildSpan(ctx, trace.ComponentOpName(producerComponent, msg.topic),
+		producerComponent, ext.SpanKindProducer, ap.tag,
+		opentracing.Tag{Key: "topic", Value: msg.topic})
+	pm, err := ap.createProducerMessage(ctx, msg, sp)
+	if err != nil {
+		messageStatusCountInc(messageCreationErrors, msg.topic)
+		trace.SpanError(sp)
+		return err
+	}
+
+	messageStatusCountInc(messageSent, msg.topic)
+	ap.asyncProd.Input() <- pm
+	trace.SpanSuccess(sp)
+
+	return nil
+}
+
+func (ap *AsyncProducer) propagateError() {
+	for pe := range ap.asyncProd.Errors() {
+		messageStatusCountInc(messageSendErrors, pe.Msg.Topic)
+		ap.chErr <- fmt.Errorf("failed to send message: %w", pe)
+	}
+}
+
+// Close shuts down the producer and waits for any buffered messages to be
+// flushed. You must call this function before a producer object passes out of
+// scope, as it may otherwise leak memory.
+func (ap *AsyncProducer) Close() error {
+	err := ap.asyncProd.Close()
+	if err != nil {
+		// always close client
+		_ = ap.prodClient.Close()
+
+		return fmt.Errorf("failed to close async producer client: %w", err)
+	}
+
+	err = ap.prodClient.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close async producer: %w", err)
+	}
+	return nil
+}

--- a/client/kafka/builder.go
+++ b/client/kafka/builder.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Shopify/sarama"
 	"github.com/beatlabs/patron/encoding"
 	"github.com/beatlabs/patron/encoding/json"
 	patronErrors "github.com/beatlabs/patron/errors"
 	"github.com/beatlabs/patron/internal/validation"
 	"github.com/beatlabs/patron/log"
+
+	"github.com/Shopify/sarama"
 	"github.com/opentracing/opentracing-go"
 )
 
@@ -128,10 +129,12 @@ func (ab *Builder) CreateAsync() (*AsyncProducer, <-chan error, error) {
 
 	ap := AsyncProducer{
 		baseProducer: baseProducer{
-			cfg:         ab.cfg,
-			enc:         ab.enc,
-			contentType: ab.contentType,
-			tag:         opentracing.Tag{Key: "type", Value: "async"},
+			messageStatus: messageStatus,
+			deliveryType:  "async",
+			cfg:           ab.cfg,
+			enc:           ab.enc,
+			contentType:   ab.contentType,
+			tag:           opentracing.Tag{Key: "type", Value: "async"},
 		},
 	}
 
@@ -154,7 +157,6 @@ func (ab *Builder) CreateAsync() (*AsyncProducer, <-chan error, error) {
 
 // CreateSync constructs the SyncProducer component by applying the gathered properties.
 func (ab *Builder) CreateSync() (*SyncProducer, error) {
-
 	if len(ab.errors) > 0 {
 		return nil, patronErrors.Aggregate(ab.errors...)
 	}
@@ -164,10 +166,12 @@ func (ab *Builder) CreateSync() (*SyncProducer, error) {
 
 	p := SyncProducer{
 		baseProducer: baseProducer{
-			cfg:         ab.cfg,
-			enc:         ab.enc,
-			contentType: ab.contentType,
-			tag:         opentracing.Tag{Key: "type", Value: "sync"},
+			messageStatus: messageStatus,
+			deliveryType:  "sync",
+			cfg:           ab.cfg,
+			enc:           ab.enc,
+			contentType:   ab.contentType,
+			tag:           opentracing.Tag{Key: "type", Value: "sync"},
 		},
 	}
 

--- a/client/kafka/builder.go
+++ b/client/kafka/builder.go
@@ -29,22 +29,22 @@ const (
 
 const fieldSetMsg = "Setting property '%v' for '%v'"
 
-// AsyncBuilder gathers all required and optional properties, in order
-// to construct a Kafka AsyncProducer.
-type AsyncBuilder struct {
+// Builder gathers all required and optional properties, in order
+// to construct a Kafka Producer/AsyncProducer.
+type Builder struct {
 	brokers     []string
 	cfg         *sarama.Config
 	chErr       chan error
-	tag         opentracing.Tag
 	enc         encoding.EncodeFunc
 	contentType string
 	errors      []error
+	sync        bool
 }
 
-// NewBuilder initiates the AsyncProducer builder chain.
+// NewBuilder initiates the Producer/AsyncProducer builder chain.
 // The builder instantiates the component using default values for
 // EncodeFunc and Content-Type header.
-func NewBuilder(brokers []string) *AsyncBuilder {
+func NewBuilder(brokers []string) *Builder {
 	cfg := sarama.NewConfig()
 	cfg.Version = sarama.V0_11_0_0
 
@@ -53,19 +53,19 @@ func NewBuilder(brokers []string) *AsyncBuilder {
 		errs = append(errs, errors.New("brokers are empty or have an empty value"))
 	}
 
-	return &AsyncBuilder{
+	return &Builder{
 		brokers:     brokers,
 		cfg:         cfg,
 		chErr:       make(chan error),
-		tag:         opentracing.Tag{Key: "type", Value: "async"},
 		enc:         json.Encode,
 		contentType: json.Type,
 		errors:      errs,
+		sync:        false,
 	}
 }
 
-// WithTimeout sets the dial timeout for the AsyncProducer.
-func (ab *AsyncBuilder) WithTimeout(dial time.Duration) *AsyncBuilder {
+// WithTimeout sets the dial timeout for the Producer/AsyncProducer.
+func (ab *Builder) WithTimeout(dial time.Duration) *Builder {
 	if dial <= 0 {
 		ab.errors = append(ab.errors, errors.New("dial timeout has to be positive"))
 		return ab
@@ -75,8 +75,8 @@ func (ab *AsyncBuilder) WithTimeout(dial time.Duration) *AsyncBuilder {
 	return ab
 }
 
-// WithVersion sets the kafka versionfor the AsyncProducer.
-func (ab *AsyncBuilder) WithVersion(version string) *AsyncBuilder {
+// WithVersion sets the kafka versionfor the Producer/AsyncProducer.
+func (ab *Builder) WithVersion(version string) *Builder {
 	if version == "" {
 		ab.errors = append(ab.errors, errors.New("version is required"))
 		return ab
@@ -94,7 +94,7 @@ func (ab *AsyncBuilder) WithVersion(version string) *AsyncBuilder {
 
 // WithRequiredAcksPolicy adjusts how many replica acknowledgements
 // broker must see before responding.
-func (ab *AsyncBuilder) WithRequiredAcksPolicy(ack RequiredAcks) *AsyncBuilder {
+func (ab *Builder) WithRequiredAcksPolicy(ack RequiredAcks) *Builder {
 	if !isValidRequiredAcks(ack) {
 		ab.errors = append(ab.errors, errors.New("invalid value for required acks policy provided"))
 		return ab
@@ -106,7 +106,7 @@ func (ab *AsyncBuilder) WithRequiredAcksPolicy(ack RequiredAcks) *AsyncBuilder {
 
 // WithEncoder sets a specific encoder implementation and Content-Type string header;
 // if no option is provided it defaults to json.
-func (ab *AsyncBuilder) WithEncoder(enc encoding.EncodeFunc, contentType string) *AsyncBuilder {
+func (ab *Builder) WithEncoder(enc encoding.EncodeFunc, contentType string) *Builder {
 	if enc == nil {
 		ab.errors = append(ab.errors, errors.New("encoder is nil"))
 	} else {
@@ -123,33 +123,57 @@ func (ab *AsyncBuilder) WithEncoder(enc encoding.EncodeFunc, contentType string)
 	return ab
 }
 
-// Create constructs the AsyncProducer component by applying the gathered properties.
-func (ab *AsyncBuilder) Create() (*AsyncProducer, error) {
+// WithSync determines whether the producer is synchronous or asynchronous; default is asynchronous.
+func (ab *Builder) WithSync(sync bool) *Builder {
+	ab.sync = sync
+
+	log.Info(fieldSetMsg, "required sync", sync)
+
+	return ab
+}
+
+// Create constructs the Producer/AsyncProducer component by applying the gathered properties.
+func (ab *Builder) Create() (*KafkaProducer, error) {
 
 	if len(ab.errors) > 0 {
 		return nil, patronErrors.Aggregate(ab.errors...)
 	}
 
-	prodClient, err := sarama.NewClient(ab.brokers, ab.cfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create async producer client: %w", err)
-	}
-	prod, err := sarama.NewAsyncProducerFromClient(prodClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create async producer: %w", err)
+	var typeTag string
+	if ab.sync {
+		typeTag = "sync"
+	} else {
+		typeTag = "async"
 	}
 
-	ap := AsyncProducer{
+	ap := KafkaProducer{
 		cfg:         ab.cfg,
-		prodClient:  prodClient,
-		prod:        prod,
 		chErr:       ab.chErr,
 		enc:         ab.enc,
 		contentType: ab.contentType,
-		tag:         ab.tag,
+		tag:         opentracing.Tag{Key: "type", Value: typeTag},
+		sync:        ab.sync,
 	}
 
-	go ap.propagateError()
+	var err error
+	ap.prodClient, err = sarama.NewClient(ab.brokers, ab.cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create producer client: %w", err)
+	}
+
+	if !ab.sync {
+		ap.asyncProd, err = sarama.NewAsyncProducerFromClient(ap.prodClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create async producer: %w", err)
+		}
+
+		go ap.propagateError()
+	} else {
+		ap.syncProd, err = sarama.NewSyncProducerFromClient(ap.prodClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create sync producer: %w", err)
+		}
+	}
 	return &ap, nil
 }
 

--- a/client/kafka/builder_test.go
+++ b/client/kafka/builder_test.go
@@ -176,6 +176,7 @@ func Test_createAsyncProducerUsingBuilder(t *testing.T) {
 		enc         encoding.EncodeFunc
 		contentType string
 		wantErrs    []error
+		sync        bool
 	}{
 		"success": {
 			brokers:     []string{seed.Addr()},
@@ -212,10 +213,11 @@ func Test_createAsyncProducerUsingBuilder(t *testing.T) {
 				assert.Nil(t, gotAsyncProducer)
 			} else {
 				assert.NotNil(t, gotAsyncProducer)
-				assert.IsType(t, &AsyncProducer{}, gotAsyncProducer)
+				assert.IsType(t, &KafkaProducer{}, gotAsyncProducer)
 				assert.EqualValues(t, v, gotAsyncProducer.cfg.Version)
 				assert.EqualValues(t, tt.ack, gotAsyncProducer.cfg.Producer.RequiredAcks)
 				assert.Equal(t, tt.timeout, gotAsyncProducer.cfg.Net.DialTimeout)
+				assert.Equal(t, tt.sync, gotAsyncProducer.sync)
 			}
 		})
 	}

--- a/client/kafka/builder_test.go
+++ b/client/kafka/builder_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Shopify/sarama"
 	"github.com/beatlabs/patron/encoding"
 	"github.com/beatlabs/patron/encoding/json"
 	"github.com/beatlabs/patron/encoding/protobuf"
+
+	"github.com/Shopify/sarama"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client/kafka/sync_producer.go
+++ b/client/kafka/sync_producer.go
@@ -1,0 +1,62 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Shopify/sarama"
+	"github.com/beatlabs/patron/trace"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+)
+
+// SyncProducer is a synchronous Kafka producer.
+type SyncProducer struct {
+	baseProducer
+
+	syncProd sarama.SyncProducer
+}
+
+// Send a message to a topic.
+func (p *SyncProducer) Send(ctx context.Context, msg *Message) error {
+	sp, _ := trace.ChildSpan(ctx, trace.ComponentOpName(producerComponent, msg.topic),
+		producerComponent, ext.SpanKindProducer, p.tag,
+		opentracing.Tag{Key: "topic", Value: msg.topic})
+	pm, err := p.createProducerMessage(ctx, msg, sp)
+	if err != nil {
+		messageStatusCountInc(messageCreationErrors, msg.topic)
+		trace.SpanError(sp)
+		return err
+	}
+
+	_, _, err = p.syncProd.SendMessage(pm)
+	if err != nil {
+		messageStatusCountInc(messageCreationErrors, msg.topic)
+		trace.SpanError(sp)
+		return err
+	}
+
+	messageStatusCountInc(messageSent, msg.topic)
+	trace.SpanSuccess(sp)
+
+	return nil
+}
+
+// Close shuts down the producer and waits for any buffered messages to be
+// flushed. You must call this function before a producer object passes out of
+// scope, as it may otherwise leak memory.
+func (p *SyncProducer) Close() error {
+	err := p.syncProd.Close()
+	if err != nil {
+		// always close client
+		_ = p.prodClient.Close()
+
+		return fmt.Errorf("failed to close sync producer client: %w", err)
+	}
+
+	err = p.prodClient.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close sync producer: %w", err)
+	}
+	return nil
+}

--- a/examples/second/main.go
+++ b/examples/second/main.go
@@ -76,10 +76,16 @@ type httpComponent struct {
 }
 
 func newHTTPComponent(kafkaBroker, topic, url string) (*httpComponent, error) {
-	prd, err := kafka.NewBuilder([]string{kafkaBroker}).Create()
+	prd, chErr, err := kafka.NewBuilder([]string{kafkaBroker}).CreateAsync()
 	if err != nil {
 		return nil, err
 	}
+	go func() {
+		for {
+			err := <-chErr
+			log.Errorf("error producing Kafka message: %v", err)
+		}
+	}()
 	return &httpComponent{prd: prd, topic: topic}, nil
 }
 


### PR DESCRIPTION
This PR is a proposed solution for #36.

## Short description of the changes

* allow creating a synchronous Kafka producer through a specific builder option

I have separated the `SyncProducer` and `AsyncProducer`, while keeping a minimal `Producer` interface.

The unit test `TestSendWithCustomEncoder` now uses the synchronous producer to simplify the error handling.

Fixes as well the description of the metrics which was copied from the consumer.

This PR supersedes #170. 