### PR TITLE
Multi error

### DIFF
--- a/errors/multi.go
+++ b/errors/multi.go
@@ -1,0 +1,89 @@
+package errors
+
+import (
+	"errors"
+	"strings"
+)
+
+// Multi is an error implementation that allows to handle multiple errors.
+type Multi struct {
+	Errors []error
+	Format func([]error) string
+}
+
+// Error stringify the error.
+// If a format was specified, we use it instead of the default implementation.
+func (m *Multi) Error() string {
+	if m.Format != nil {
+		return m.Format(m.Errors)
+	}
+
+	sb := strings.Builder{}
+	for i := 0; i < len(m.Errors); i++ {
+		sb.WriteString(m.Errors[i].Error())
+		if i != len(m.Errors)-1 {
+			sb.WriteRune('\n')
+		}
+	}
+	return sb.String()
+}
+
+// ErrorOrNil returns an error only if the internal slice is not empty.
+// Otherwise, it returns nil.
+// This utility method is used to avoid the insidious bug while returning a nil structure converted into an interface.
+func (m *Multi) ErrorOrNil() error {
+	if m == nil || len(m.Errors) == 0 {
+		return nil
+	}
+	return m
+}
+
+// Unwrap unwraps a Multi structure by returning a subset of the internal errors.
+func (m *Multi) Unwrap() error {
+	if len(m.Errors) <= 1 {
+		return nil
+	}
+	return &Multi{
+		Errors: m.Errors[1:],
+		Format: m.Format,
+	}
+}
+
+// As implements the standard As function from the errors library.
+func (m *Multi) As(target interface{}) bool {
+	return errors.As(m.Errors[0], target)
+}
+
+// Is implements the standard Is function from the errors library.
+func (m *Multi) Is(target error) bool {
+	return errors.Is(m.Errors[0], target)
+}
+
+// Append returns a Multi error that appends a list of errors to a current error.
+// The current error can be nil.
+func Append(current error, err error) *Multi {
+	if current == nil {
+		current = &Multi{}
+	}
+
+	if err == nil {
+		switch t := current.(type) {
+		default:
+			return &Multi{
+				Errors: []error{current},
+			}
+		case *Multi:
+			return t
+		}
+	}
+
+	switch result := current.(type) {
+	default:
+		m := &Multi{}
+		m.Errors = append([]error{result}, err)
+		return m
+	case *Multi:
+		result.Errors = append(result.Errors, err)
+		return result
+	}
+}

--- a/errors/multi_test.go
+++ b/errors/multi_test.go
@@ -1,0 +1,97 @@
+package errors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testError struct{}
+
+func (t *testError) Error() string {
+	return "test"
+}
+
+func TestAppend(t *testing.T) {
+	var result error
+	result = Append(result, errors.New("foo"))
+	result = Append(result, errors.New("bar"))
+	result = Append(result, errors.New("baz"))
+	assert.Equal(t, `foo
+bar
+baz`, result.Error())
+}
+
+func TestAppend_NilErrorsFromMulti(t *testing.T) {
+	var result error
+	result = Append(result, errors.New("foo"))
+	result = Append(result, nil)
+	assert.Equal(t, "foo", result.Error())
+}
+
+func TestAppend_NilErrorsFromOtherError(t *testing.T) {
+	result := Append(&testError{}, nil)
+	assert.Equal(t, "test", result.Error())
+}
+
+func TestAppend_FromOtherType(t *testing.T) {
+	result := errors.New("foo")
+	result = Append(result, errors.New("bar"))
+	result = Append(result, errors.New("baz"))
+	assert.Equal(t, `foo
+bar
+baz`, result.Error())
+}
+
+func Test_Format(t *testing.T) {
+	result := &Multi{}
+	result.Format = func(errs []error) string {
+		s := ""
+		for _, err := range errs {
+			s += err.Error() + "_"
+		}
+		return s
+	}
+	result = Append(result, errors.New("foo"))
+	assert.Equal(t, "foo_", result.Error())
+}
+
+func Test_As(t *testing.T) {
+	result := errors.New("foo")
+	result = Append(result, &testError{})
+	result = Append(result, errors.New("baz"))
+	var e *testError
+	assert.True(t, errors.As(result, &e))
+}
+
+func Test_Is(t *testing.T) {
+	result := errors.New("foo")
+	expected := &testError{}
+	result = Append(result, expected)
+	result = Append(result, errors.New("baz"))
+	assert.True(t, errors.Is(result, expected))
+}
+
+func TestUnwrap_Empty(t *testing.T) {
+	m := &Multi{
+		Errors: []error{errors.New("foo")},
+	}
+	assert.Nil(t, m.Unwrap())
+}
+
+func TestErrorOrNil_NotNil(t *testing.T) {
+	m := &Multi{
+		Errors: []error{errors.New("foo")},
+	}
+	assert.NotNil(t, m.ErrorOrNil())
+}
+
+func TestErrorOrNil_Nil(t *testing.T) {
+	assert.Nil(t, getError())
+}
+
+func getError() error {
+	var m = &Multi{}
+	return m.ErrorOrNil()
+}


### PR DESCRIPTION
A small lib to handle multiple errors.

The problem in my humble opinion with `Aggregate` is that we need to keep track of all the errors in a different variable name. Something like this:
```go
if err1 := foo(); err1 != nil {
  // Do something
}

if err2 := bar(); err2 != nil {
  // Do something
}

if err3 := baz(); err3 != nil {
  // Do something
}

result := Aggregate(err1, err2, err3)
```

Instead, with this proposition we could do it on the fly this way:

```go
var result error

if err := foo(); err != nil {
  // Do something
  result = Append(result, err)
}

if err := bar(); err != nil {
  // Do something
  result = Append(result, err)
}

if err := baz(); err != nil {
  // Do something
  result = Append(result, err)
}
```

In the meantime, two small features:
* Allows passing a formatter function that will be invoked while calling `Error()`
* Support for Go 1.13 `As` & `Is` functions (thru `Unwrap`)