### PR TITLE
Remove a couple of goroutine leaks in case of processing/context failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ The following implementations are provided as sub-package and are by default wir
 
 ### Context Logging
 
-Logs can be associated with some contextual data e.g. a request id. Every line logged should contain this id thus grouping the logs together. This is achieved with the usage of the context package like demonstrated bellow:
+Logs can be associated with some contextual data e.g. a request id. Every line logged should contain this id thus grouping the logs together. This is achieved with the usage of the context package as demonstrated below:
 
 ```go
 ctx := log.WithContext(r.Context(), log.Sub(map[string]interface{}{"requestID": uuid.New().String()}))


### PR DESCRIPTION
Linearize some error handling logic to avoid goroutine leaks.

Issue: #206

## What problem is this PR solving?

There are goroutine leaks at:
* https://github.com/beatlabs/patron/blob/3e49af8/component/async/component.go#L178
* https://github.com/beatlabs/patron/blob/3e49af8/component/async/component.go#L181

They also cause the Sarama errors channel and `failCh` to leak as a side-effect.