### PR TITLE
Change logging output to os.Stderr

### DIFF
--- a/log/zerolog/factory.go
+++ b/log/zerolog/factory.go
@@ -17,7 +17,7 @@ func Create(lvl log.Level) log.FactoryFunc {
 	zerolog.LevelFieldName = "lvl"
 	zerolog.MessageFieldName = "msg"
 	zerolog.TimeFieldFormat = time.RFC3339Nano
-	zl := zerolog.New(os.Stdout).With().Timestamp().Logger().Hook(sourceHook{skip: 7})
+	zl := zerolog.New(os.Stderr).With().Timestamp().Logger().Hook(sourceHook{skip: 7})
 	return func(f map[string]interface{}) log.Logger {
 		return NewLogger(&zl, lvl, f)
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

~It is not safe to write directly to `os.Stdout`/`os.Stderr` in concurrent scenarios; writes can intermingle and cause corrupt log lines output. See also: https://stackoverflow.com/a/14694666~

It turns out it is safe instead, see:
* https://github.com/golang/go/blob/go1.14.3/src/internal/poll/fd_unix.go#L255
* https://github.com/golang/go/blob/go1.14.3/src/internal/poll/fd_windows.go#L684

(No issue created yet)

## Short description of the changes

Switch logging output to `os.Stderr`; this is the usual file descriptor for log output, also used by Go's `log` package: https://golang.org/src/log/log.go?s=9636:9664#L76