### PR TITLE
Improve URL parameter handling for RawRoutes

### DIFF
--- a/component/http/handler.go
+++ b/component/http/handler.go
@@ -174,3 +174,8 @@ func extractParams(r *http.Request) map[string]string {
 	}
 	return p
 }
+
+// ExtractParams extracts dynamic URL parameters using httprouter's functionality
+func ExtractParams(r *http.Request) map[string]string {
+	return extractParams(r)
+}

--- a/component/http/handler.go
+++ b/component/http/handler.go
@@ -25,7 +25,7 @@ func handler(hnd ProcessorFunc) http.HandlerFunc {
 		prepareResponse(w, ct)
 
 		f := extractFields(r)
-		for k, v := range extractParams(r) {
+		for k, v := range ExtractParams(r) {
 			f[k] = v
 		}
 
@@ -163,7 +163,8 @@ func prepareResponse(w http.ResponseWriter, ct string) {
 	w.Header().Set(encoding.ContentTypeHeader, ct)
 }
 
-func extractParams(r *http.Request) map[string]string {
+// ExtractParams extracts dynamic URL parameters using httprouter's functionality
+func ExtractParams(r *http.Request) map[string]string {
 	par := httprouter.ParamsFromContext(r.Context())
 	if len(par) == 0 {
 		return make(map[string]string)
@@ -173,9 +174,4 @@ func extractParams(r *http.Request) map[string]string {
 		p[v.Key] = v.Value
 	}
 	return p
-}
-
-// ExtractParams extracts dynamic URL parameters using httprouter's functionality
-func ExtractParams(r *http.Request) map[string]string {
-	return extractParams(r)
 }

--- a/component/http/handler_test.go
+++ b/component/http/handler_test.go
@@ -284,3 +284,26 @@ func Test_extractParams(t *testing.T) {
 	router.ServeHTTP(httptest.NewRecorder(), req)
 	assert.Equal(t, "1", fields["id"])
 }
+
+func Test_extractParamsRawRoute(t *testing.T) {
+	r, err := http.NewRequest(http.MethodGet, "/users/42/status/online", nil)
+	assert.NoError(t, err)
+	r.Header.Set(encoding.ContentTypeHeader, json.Type)
+	r.Header.Set(encoding.AcceptHeader, json.Type)
+	var fields map[string]string
+
+	proc := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fields = extractParams(r)
+		return
+	})
+
+	router := httprouter.New()
+	route, err := NewRawRouteBuilder("/users/:id/status/:status", proc).MethodGet().Build()
+	assert.NoError(t, err)
+	router.HandlerFunc(route.method, route.path, route.handler)
+	router.ServeHTTP(httptest.NewRecorder(), r)
+
+	assert.Equal(t, "42", fields["id"])
+	assert.Equal(t, "online", fields["status"])
+
+}

--- a/component/http/handler_test.go
+++ b/component/http/handler_test.go
@@ -293,7 +293,7 @@ func Test_extractParamsRawRoute(t *testing.T) {
 	var fields map[string]string
 
 	proc := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fields = extractParams(r)
+		fields = ExtractParams(r)
 		return
 	})
 

--- a/component/http/handler_test.go
+++ b/component/http/handler_test.go
@@ -294,7 +294,6 @@ func Test_extractParamsRawRoute(t *testing.T) {
 
 	proc := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fields = ExtractParams(r)
-		return
 	})
 
 	router := httprouter.New()


### PR DESCRIPTION
Fixes #224 [Improve URL parameter handling for RawRoutes](https://github.com/beatlabs/patron/issues/224)

## Which problem is this PR solving?

This PR provides an easy and transparent way for users to retrieve dynamic URL parameters when using RawRoutes.

## Short description of the changes

This might seem the laziest/easiest/quickest solution, but I feel it *might* be the correct one.

- Provides a standard way for users to retrieve dynamic URL parameters.
- In case we might use another router in the future (eg. gorilla/mux, or go-chi/chi), we would only have to change the un-exported implementation and use the framework-specific way to retrieve these parameters (eg. `mux.Vars(r)` or `chi.URLParam(r, "*")`).   
I expect that all routers will store their URL parameters in the *matched request* object.
- It leaves us room to perform extra checks in the future if we wish so (eg. disable exposing parameters of requests beginning with `/internal`, or fields like `/user/:password`.
