### PR TITLE
Ordering is Not Guaranteed with a Simple Kafka Consumer

### DIFF
--- a/component/async/kafka/simple/simple.go
+++ b/component/async/kafka/simple/simple.go
@@ -122,7 +122,7 @@ func (c *consumer) Consume(ctx context.Context) (<-chan async.Message, <-chan er
 					if err != nil {
 						kafka.MessageStatusCountInc(kafka.MessageClaimErrors, "", m.Topic)
 						chErr <- err
-						return
+						continue
 					}
 					kafka.MessageStatusCountInc(kafka.MessageDecoded, "", m.Topic)
 					chMsg <- msg

--- a/component/async/kafka/simple/simple.go
+++ b/component/async/kafka/simple/simple.go
@@ -118,16 +118,14 @@ func (c *consumer) Consume(ctx context.Context) (<-chan async.Message, <-chan er
 					kafka.TopicPartitionOffsetDiffGaugeSet("", m.Topic, m.Partition, consumer.HighWaterMarkOffset(), m.Offset)
 					kafka.MessageStatusCountInc(kafka.MessageReceived, "", m.Topic)
 
-					go func(message *sarama.ConsumerMessage) {
-						msg, err := kafka.ClaimMessage(ctx, message, c.config.DecoderFunc, nil)
-						if err != nil {
-							kafka.MessageStatusCountInc(kafka.MessageClaimErrors, "", message.Topic)
-							chErr <- err
-							return
-						}
-						kafka.MessageStatusCountInc(kafka.MessageDecoded, "", message.Topic)
-						chMsg <- msg
-					}(m)
+					msg, err := kafka.ClaimMessage(ctx, m, c.config.DecoderFunc, nil)
+					if err != nil {
+						kafka.MessageStatusCountInc(kafka.MessageClaimErrors, "", m.Topic)
+						chErr <- err
+						return
+					}
+					kafka.MessageStatusCountInc(kafka.MessageDecoded, "", m.Topic)
+					chMsg <- msg
 				}
 			}
 		}(pc)


### PR DESCRIPTION
## Which problem is this PR solving?

Guaranteed ordering with a simple Kafka consumer: Closes #228.

## Short description of the changes

Removing the extra goroutine created while iterating over the partition consumer messages.