### PR TITLE
Add support for custom encoding/decoding schemes

### DIFF
--- a/component/http/handler.go
+++ b/component/http/handler.go
@@ -185,11 +185,11 @@ func ExtractParams(r *http.Request) map[string]string {
 	return p
 }
 
-func getCustomEncDec(pth string, ce ...encoding.CustomEncodingScheme) (string, encoding.DecodeFunc, encoding.EncodeFunc, error) {
+func getCustomEncDec(pth []string, ce ...encoding.CustomEncodingScheme) (string, encoding.DecodeFunc, encoding.EncodeFunc, error) {
 	// first match wins
 	for _, p := range pth {
 		for _, s := range ce {
-			if pth == s.Header {
+			if p == s.Header {
 				return s.Header, s.Dec, s.Enc, nil
 			}
 		}

--- a/component/http/route.go
+++ b/component/http/route.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/beatlabs/patron/component/http/auth"
+	"github.com/beatlabs/patron/encoding"
 	errs "github.com/beatlabs/patron/errors"
 )
 
@@ -171,7 +172,7 @@ func NewRawRouteBuilder(path string, handler http.HandlerFunc) *RouteBuilder {
 }
 
 // NewRouteBuilder constructor.
-func NewRouteBuilder(path string, processor ProcessorFunc) *RouteBuilder {
+func NewRouteBuilder(path string, processor ProcessorFunc, ce ...encoding.CustomEncodingScheme) *RouteBuilder {
 
 	var err error
 
@@ -179,7 +180,7 @@ func NewRouteBuilder(path string, processor ProcessorFunc) *RouteBuilder {
 		err = errors.New("processor is nil")
 	}
 
-	rb := NewRawRouteBuilder(path, handler(processor))
+	rb := NewRawRouteBuilder(path, handler(processor, ce...))
 	if err != nil {
 		rb.errors = append(rb.errors, err)
 	}

--- a/component/http/route_test.go
+++ b/component/http/route_test.go
@@ -330,10 +330,16 @@ func TestRoute_Getters(t *testing.T) {
 }
 
 func TestCustomEncodingSchemes(t *testing.T) {
-	type testResponse struct {
-		Value string
-	}
 
+	testingCustomEncHandlerMock := func(t *testing.T) ProcessorFunc {
+		return func(_ context.Context, r *Request) (*Response, error) {
+			var s string
+			err := r.decode(r.Raw, &s)
+			assert.Nil(t, err)
+			assert.Equal(t, s, "⬇️")
+			return NewResponse(s), nil
+		}
+	}
 	customEncFunc := func(v interface{}) ([]byte, error) {
 		return []byte("⬆️"), nil
 	}
@@ -383,14 +389,5 @@ func TestCustomEncodingSchemes(t *testing.T) {
 func testingHandlerMock(expected interface{}) ProcessorFunc {
 	return func(_ context.Context, _ *Request) (*Response, error) {
 		return NewResponse(expected), nil
-	}
-}
-
-func testingCustomEncHandlerMock(t *testing.T) ProcessorFunc {
-	return func(_ context.Context, r *Request) (*Response, error) {
-		var s string
-		r.decode(r.Raw, &s)
-		assert.Equal(t, s, "⬇️")
-		return NewResponse(s), nil
 	}
 }

--- a/component/http/route_test.go
+++ b/component/http/route_test.go
@@ -382,7 +382,7 @@ func TestCustomEncodingSchemes(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, string(br), "⬆️")
-	ctHeader := w.Header().Values(encoding.ContentTypeHeader)
+	ctHeader := w.Header().Get(encoding.ContentTypeHeader)
 	assert.Contains(t, ctHeader, customEncHeader)
 }
 

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -10,6 +10,8 @@ const (
 	AcceptHeader string = "Accept"
 	// ContentTypeHeader for defining content type headers.
 	ContentTypeHeader string = "Content-Type"
+	// CustomEncodingHeader for defining user-provided enc/dec schemes.
+	CustomEncodingHeader string = "Patron-Custom-Encoding"
 )
 
 // DecodeFunc function definition of a JSON decoding function.
@@ -20,3 +22,10 @@ type DecodeRawFunc func(data []byte, v interface{}) error
 
 // EncodeFunc function definition of a JSON encoding function.
 type EncodeFunc func(v interface{}) ([]byte, error)
+
+// CustomEncodingScheme for defining user-provided enc/dec schemes.
+type CustomEncodingScheme struct {
+	Header string
+	Enc    EncodeFunc
+	Dec    DecodeFunc
+}


### PR DESCRIPTION
## Which problem is this PR solving?

This PR closes #5 [HTTP custom encoding headers and encoders/decoders](https://github.com/beatlabs/patron/issues/5).

It introduces the ability for end-users to provide their own encoding/decoding schemes in a way that is compatible with Patron's HTTP handling, without having to regularly resort to RawRoutes.

There were a couple of ways we could have gotten around to doing this; from what I've seen in about half a dozen projects using Patron, I feel this is a reasonable way to go about it. 

Let me know how it looks to y'all, and if we should prefer a different approach!


## Short description of the changes
- Add a new `CustomEncodingScheme` and `CustomEncodingHeader` in our encoding package
- Add support for such custom enc/dec schemes in `NewRouteBuilder`
- Change `determineEncoding` to include these new custom schemes, if a relevant HTTP header is detected

I'm not the best at naming things, so also let me know if you agree with terms like *CustomEncodingHeader* or *CustomEncodingScheme*.

## Notes
- The custom encoding-decoding scheme *will overwrite* currently implemented encoding/decoding functions

- Any performance degradation will be due to a) the user-provided encoding/decoding functions implementation, b) the `determineEncoding` method.

We only have control over the second point, so here are the benchmarks comparing the previous and current implementation

Nothing magical happens here; if we don't provide the custom header, performance is the same. Having to dig around and match the header with one of three possible schemes adds a minimal amount of overhead.

```
#   "Before" benchmark -- headers are ignored
pkg: github.com/beatlabs/patron/component/http
BenchmarkDeterminEncoding-8   	100000000	        12.0 ns/op	       0 B/op	       0 allocs/op

#   "After" benchmark -- don't provide custom header value
pkg: github.com/beatlabs/patron/component/http
BenchmarkDeterminEncoding-8   	100000000	        11.6 ns/op	       0 B/op	       0 allocs/op

#   "After" benchmark -- provide custom header and three schemes with one match
pkg: github.com/beatlabs/patron/component/http
BenchmarkDeterminEncoding-8   	36952747	        32.6 ns/op	       0 B/op	       0 allocs/op

```
