### PR TITLE
GZIP Compression middleware

### DIFF
--- a/component/http/middleware.go
+++ b/component/http/middleware.go
@@ -1,7 +1,9 @@
 package http
 
 import (
+	"compress/gzip"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
 
@@ -119,6 +121,60 @@ func NewLoggingTracingMiddleware(path string) MiddlewareFunc {
 			next.ServeHTTP(lw, r)
 			finishSpan(sp, lw.Status())
 			logRequestResponse(corID, lw, r)
+		})
+	}
+}
+
+type gzipResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+}
+
+// GZIPConfiguration defines configuration for GZIP Middleware.
+type GZIPConfiguration struct {
+	IgnoreRoutes []string
+}
+
+// Ignore checks if the given url ignored from compression or not.
+func (gc GZIPConfiguration) Ignore(url string) bool {
+	for _, iURL := range gc.IgnoreRoutes {
+		if strings.HasPrefix(url, iURL) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Write provides write func to the writer.
+func (w gzipResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+// NewGzipMiddleware creates a Gzip compression middleware.
+func NewGzipMiddleware(config GZIPConfiguration) MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") || config.Ignore(r.URL.String()) {
+				next.ServeHTTP(w, r)
+				log.Debugf("url %s skipped from gzip encoding", r.URL.String())
+				return
+			}
+			// explicitly specify encoding in header
+			w.Header().Set("Content-Encoding", "gzip")
+
+			// keep content type intact
+			respHeader := r.Header.Get("Content-Type")
+			if respHeader != "" {
+				w.Header().Set("Content-Type", respHeader)
+			}
+
+			gz := gzip.NewWriter(w)
+			defer func() {
+				_ = gz.Close()
+			}()
+			gzr := gzipResponseWriter{Writer: gz, ResponseWriter: w}
+			next.ServeHTTP(gzr, r)
 		})
 	}
 }

--- a/component/http/middleware_test.go
+++ b/component/http/middleware_test.go
@@ -14,7 +14,7 @@ func tagMiddleware(tag string) MiddlewareFunc {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte(tag))
-			//next
+			// next
 			h.ServeHTTP(w, r)
 		})
 	}
@@ -117,4 +117,105 @@ func TestResponseWriter(t *testing.T) {
 	assert.Len(t, rw.Header(), 1, "header count expected to be 1")
 	assert.True(t, rw.statusHeaderWritten, "expected to be true")
 	assert.Equal(t, "test", rc.Body.String(), "body expected to be test but was %s", rc.Body.String())
+}
+
+func TestNewGzipMiddleware(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(202) })
+	req, err := http.NewRequest("GET", "/test", nil)
+	assert.NoError(t, err)
+
+	req.Header.Set("Accept-Encoding", "gzip")
+	gzipMiddleware := NewGzipMiddleware(GZIPConfiguration{})
+	assert.NoError(t, err)
+	assert.NotNil(t, gzipMiddleware)
+
+	rc := httptest.NewRecorder()
+	gzipMiddleware(handler).ServeHTTP(rc, req)
+	actual := rc.Header().Get("Content-Encoding")
+	assert.NotNil(t, actual)
+	assert.Equal(t, "gzip", actual)
+}
+
+func TestNewGzipMiddleware_Ignore(t *testing.T) {
+	var ceh, cth string // accept-encoding, content type
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(202) })
+	gzipMiddleware := NewGzipMiddleware(GZIPConfiguration{IgnoreRoutes: []string{"/metrics"}})
+	assert.NotNil(t, gzipMiddleware)
+
+	// check if the route actually ignored
+	req1, err := http.NewRequest("GET", "/metrics", nil)
+	assert.NoError(t, err)
+	req1.Header.Set("Accept-Encoding", "gzip")
+	assert.NoError(t, err)
+
+	rc1 := httptest.NewRecorder()
+	gzipMiddleware(handler).ServeHTTP(rc1, req1)
+
+	ceh = rc1.Header().Get("Content-Encoding")
+	assert.NotNil(t, ceh)
+	assert.Equal(t, ceh, "")
+
+	cth = rc1.Header().Get("Content-Type")
+	assert.NotNil(t, cth)
+	assert.Equal(t, cth, "")
+
+	// check if other routes remains untouched
+	req2, err := http.NewRequest("GET", "/alive", nil)
+	assert.NoError(t, err)
+	req2.Header.Set("Accept-Encoding", "gzip")
+	req2.Header.Set("Content-Type", "application/json")
+
+	rc2 := httptest.NewRecorder()
+	gzipMiddleware(handler).ServeHTTP(rc2, req2)
+
+	ceh = rc2.Header().Get("Content-Encoding")
+	assert.NotNil(t, ceh)
+	assert.Equal(t, "gzip", ceh)
+
+	cth = rc2.Header().Get("Content-Type")
+	assert.NotNil(t, cth)
+	assert.Equal(t, "application/json", cth)
+}
+
+func TestNewGzipMiddleware_Headers(t *testing.T) {
+	var ceh, cth string // accept-encoding, content type
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(202) })
+	gzipMiddleware := NewGzipMiddleware(GZIPConfiguration{IgnoreRoutes: []string{"/metrics"}})
+	assert.NotNil(t, gzipMiddleware)
+
+	// check if the route actually ignored
+	req1, err := http.NewRequest("GET", "/alive", nil)
+	assert.NoError(t, err)
+	req1.Header.Set("Accept-Encoding", "gzip")
+	req1.Header.Set("Content-Type", "text/plain")
+
+	rc1 := httptest.NewRecorder()
+	gzipMiddleware(handler).ServeHTTP(rc1, req1)
+
+	ceh = rc1.Header().Get("Content-Encoding")
+	assert.NotNil(t, ceh)
+	assert.Equal(t, "gzip", ceh)
+
+	cth = rc1.Header().Get("Content-Type")
+	assert.NotNil(t, cth)
+	assert.Equal(t, "text/plain", cth)
+
+	// check if other routes remains untouched
+	req2, err := http.NewRequest("GET", "/alive", nil)
+	assert.NoError(t, err)
+	req2.Header.Set("Accept-Encoding", "gzip")
+	req2.Header.Set("Content-Type", "application/json")
+
+	rc2 := httptest.NewRecorder()
+	gzipMiddleware(handler).ServeHTTP(rc2, req2)
+
+	ceh = rc2.Header().Get("Content-Encoding")
+	assert.NotNil(t, ceh)
+	assert.Equal(t, "gzip", ceh)
+
+	cth = rc2.Header().Get("Content-Type")
+	assert.NotNil(t, cth)
+	assert.Equal(t, "application/json", cth)
 }


### PR DESCRIPTION
Signed-off-by: Kanan Rahimov <mail@kenanbek.me>

## Which problem is this PR solving?

This PR closes #223 

It introduces optional GZIP compression middleware. It's tested in production by some Beat's internal services.

Usage examples:

```
	gzipMiddleware := middleware.NewGzipMiddleware(middleware.GZIPConfiguration{
		IgnoreRoutes: []string{"/metrics"},
	})

	routesBuilder := http.NewRoutesBuilder()
	for _, builder := range initCtx.RouteBuilders() {
		routesBuilder.Append(builder)
	}

	err = patron.New(config.Name, version).
		WithRoutesBuilder(routesBuilder).
		WithMiddlewares(corsMiddleware, gzipMiddleware).
		Run(ctx)
	if err != nil {
		log.Fatalf("failed to run service %v", err)
	}
```

## Short description of the changes

- Added `NewGzipMiddleware` optional middleware
- Added configurable ignore options (if some of routes needed to be ignored)
- Added unit tests

## Notes

As a next step I see point in splitting GZIP encoding part into `encoding` package. Let me know what do you think about this.