### PR TITLE
Issue #204 - Redis Get response in case of missing value

### DIFF
--- a/cache/redis/redis.go
+++ b/cache/redis/redis.go
@@ -27,10 +27,13 @@ func New(ctx context.Context, opt Options) (*Cache, error) {
 // Get executes a lookup and returns whether a key exists in the cache along with its value.
 func (c *Cache) Get(key string) (interface{}, bool, error) {
 	res, err := c.rdb.Do(c.ctx, "get", key).Result()
-	if err == redis.Nil || err != nil {
-		return nil, false, err
+	if err == nil {
+		return res, true, nil
 	}
-	return res, true, nil
+	if err == redis.Nil { // cache miss
+		return nil, false, nil
+	}
+	return nil, false, err
 }
 
 // Set registers a key-value pair to the cache.

--- a/cache/redis/redis.go
+++ b/cache/redis/redis.go
@@ -27,13 +27,13 @@ func New(ctx context.Context, opt Options) (*Cache, error) {
 // Get executes a lookup and returns whether a key exists in the cache along with its value.
 func (c *Cache) Get(key string) (interface{}, bool, error) {
 	res, err := c.rdb.Do(c.ctx, "get", key).Result()
-	if err == nil {
-		return res, true, nil
+	if err != nil {
+		if err == redis.Nil { // cache miss
+			return nil, false, nil
+		}
+		return nil, false, err
 	}
-	if err == redis.Nil { // cache miss
-		return nil, false, nil
-	}
-	return nil, false, err
+	return res, true, nil
 }
 
 // Set registers a key-value pair to the cache.


### PR DESCRIPTION
Signed-off-by: George Christou <christgf@gmail.com>
## Which problem is this PR solving?

Resolves #204 - Redis Get response in case of missing value

## Short description of the changes

When returning results from Redis, an empty cache key is handled as an error, which is inconsistent with the caching API interface. The change ensures cache misses don't result in errors, as proposed.
Please note there's currently no test fixture for the Redis cache implementation.
