### PR TITLE
Distributed tracing: strip query parameters from the operation name

### DIFF
--- a/component/http/middleware.go
+++ b/component/http/middleware.go
@@ -3,6 +3,7 @@ package http
 import (
 	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/beatlabs/patron/component/http/auth"
@@ -201,13 +202,34 @@ func span(path, corID string, r *http.Request) (opentracing.Span, *http.Request)
 	if err != nil && err != opentracing.ErrSpanContextNotFound {
 		log.Errorf("failed to extract HTTP span: %v", err)
 	}
-	sp := opentracing.StartSpan(opName(r.Method, path), ext.RPCServerOption(ctx))
+
+	strippedPath, err := stripQueryString(path)
+	if err != nil {
+		log.Warnf("unable to strip query string %q: %v", path, err)
+		strippedPath = path
+	}
+
+	sp := opentracing.StartSpan(opName(r.Method, strippedPath), ext.RPCServerOption(ctx))
 	ext.HTTPMethod.Set(sp, r.Method)
 	ext.HTTPUrl.Set(sp, r.URL.String())
 	ext.Component.Set(sp, serverComponent)
 	sp.SetTag(trace.VersionTag, trace.Version)
 	sp.SetTag(correlation.ID, corID)
 	return sp, r.WithContext(opentracing.ContextWithSpan(r.Context(), sp))
+}
+
+// stripQueryString returns a path without the query string
+func stripQueryString(path string) (string, error) {
+	u, err := url.Parse(path)
+	if err != nil {
+		return "", err
+	}
+
+	if len(u.RawQuery) == 0 {
+		return path, nil
+	}
+
+	return path[:len(path)-len(u.RawQuery)-1], nil
 }
 
 func finishSpan(sp opentracing.Span, code int) {

--- a/component/http/middleware_test.go
+++ b/component/http/middleware_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // A middleware generator that tags resp for assertions
@@ -117,4 +118,57 @@ func TestResponseWriter(t *testing.T) {
 	assert.Len(t, rw.Header(), 1, "Header count expected to be 1")
 	assert.True(t, rw.statusHeaderWritten, "expected to be true")
 	assert.Equal(t, "test", rc.Body.String(), "body expected to be test but was %s", rc.Body.String())
+}
+
+func TestStripQueryString(t *testing.T) {
+	type args struct {
+		path string
+	}
+	tests := map[string]struct {
+		args         args
+		expectedPath string
+		expectedErr  error
+	}{
+		"query string 1": {
+			args: args{
+				path: "foo?bar=value1&baz=value2",
+			},
+			expectedPath: "foo",
+		},
+		"query string 2": {
+			args: args{
+				path: "/foo?bar=value1&baz=value2",
+			},
+			expectedPath: "/foo",
+		},
+		"query string 3": {
+			args: args{
+				path: "http://foo/bar?baz=value1",
+			},
+			expectedPath: "http://foo/bar",
+		},
+		"no query string": {
+			args: args{
+				path: "http://foo/bar",
+			},
+			expectedPath: "http://foo/bar",
+		},
+		"empty": {
+			args: args{
+				path: "",
+			},
+			expectedPath: "",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			s, err := stripQueryString(tt.args.path)
+			if tt.expectedErr != nil {
+				assert.EqualError(t, err, tt.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedPath, s)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Closes #239.

## Short description of the changes

Strip the query string when creating a new span
