### PR TITLE
Add a tracing log field if an HTTP service returns an error

### DIFF
--- a/component/http/middleware_test.go
+++ b/component/http/middleware_test.go
@@ -6,7 +6,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // A middleware generator that tags resp for assertions
@@ -105,6 +108,55 @@ func TestMiddlewares(t *testing.T) {
 	}
 }
 
+// TestSpanLogError tests whether an HTTP handler with a tracing middleware adds a log event in case of we return an error.
+func TestSpanLogError(t *testing.T) {
+	mtr := mocktracer.New()
+	opentracing.SetGlobalTracer(mtr)
+
+	successHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	errorHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("foo"))
+	})
+
+	r, err := http.NewRequest("POST", "/test", nil)
+	assert.NoError(t, err)
+
+	type args struct {
+		next http.Handler
+		mws  []MiddlewareFunc
+	}
+	tests := []struct {
+		name                 string
+		args                 args
+		expectedCode         int
+		expectedBody         string
+		expectedSpanLogError string
+	}{
+		{"tracing middleware - error", args{next: errorHandler, mws: []MiddlewareFunc{NewLoggingTracingMiddleware("/index")}}, http.StatusInternalServerError, "foo", "foo"},
+		{"tracing middleware - success", args{next: successHandler, mws: []MiddlewareFunc{NewLoggingTracingMiddleware("/index")}}, http.StatusOK, "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mtr.Reset()
+			rc := httptest.NewRecorder()
+			rw := newResponseWriter(rc)
+			tt.args.next = MiddlewareChain(tt.args.next, tt.args.mws...)
+			tt.args.next.ServeHTTP(rw, r)
+			assert.Equal(t, tt.expectedCode, rw.Status())
+			assert.Equal(t, tt.expectedBody, rc.Body.String())
+
+			if tt.expectedSpanLogError != "" {
+				require.Equal(t, 1, len(mtr.FinishedSpans()))
+				spanLogError := getSpanLogError(t, mtr.FinishedSpans()[0])
+				assert.Equal(t, tt.expectedSpanLogError, spanLogError)
+			}
+		})
+	}
+}
+
 func TestResponseWriter(t *testing.T) {
 	rc := httptest.NewRecorder()
 	rw := newResponseWriter(rc)
@@ -117,4 +169,23 @@ func TestResponseWriter(t *testing.T) {
 	assert.Len(t, rw.Header(), 1, "Header count expected to be 1")
 	assert.True(t, rw.statusHeaderWritten, "expected to be true")
 	assert.Equal(t, "test", rc.Body.String(), "body expected to be test but was %s", rc.Body.String())
+}
+
+func getSpanLogError(t *testing.T, span *mocktracer.MockSpan) string {
+	logs := span.Logs()
+	if len(logs) == 0 {
+		assert.FailNow(t, "empty logs")
+		return ""
+	}
+
+	for _, log := range logs {
+		for _, field := range log.Fields {
+			if field.Key == fieldNameError {
+				return field.ValueString
+			}
+		}
+	}
+
+	assert.FailNowf(t, "missing logs", "missing field %s", fieldNameError)
+	return ""
 }

--- a/component/http/middleware_test.go
+++ b/component/http/middleware_test.go
@@ -118,7 +118,8 @@ func TestSpanLogError(t *testing.T) {
 	})
 	errorHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("foo"))
+		_, err := w.Write([]byte("foo"))
+		require.NoError(t, err)
 	})
 
 	r, err := http.NewRequest("POST", "/test", nil)


### PR DESCRIPTION
## Which problem is this PR solving?

https://github.com/beatlabs/patron/issues/241

## Short description of the changes

* Modify `responseWriter` to add a payload byte slice
* Change `responseWriter.Write()` to store the payload written
* Retrieve this payload in the tracing middleware modify `finishSpan` to add a log field (only if there is an error)
