### PR TITLE
Add support for HTTP read/write timeouts as enviroment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ The `Service` has the role of glueing all of the above together, which are:
 The service has some default settings which can be changed via environment variables:
 
 - Service HTTP port, for setting the default HTTP components port to `50000` with `PATRON_HTTP_DEFAULT_PORT`
-- Service HTTP read timeout, for changing the default HTTP read timeout from `5s` to any value, use `PATRON_HTTP_READ_TIMEOUT_SECONDS`
-- Service HTTP write timeout, for changing the default HTTP write timeout from `10s` to any value, use `PATRON_HTTP_WRITE_TIMEOUT_SECONDS`
+- Service HTTP read and write timeout, for changing the default HTTP read and write timeout to any value, use `PATRON_HTTP_READ_TIMEOUT`, `PATRON_HTTP_WRITE_TIMEOUT` respectively. For acceptable values check [here](https://golang.org/pkg/time/#ParseDuration).
 - Log level, for setting zerolog with `INFO` log level with `PATRON_LOG_LEVEL`
 - Tracing, for setting up jaeger tracing with
   - agent host `0.0.0.0` with `PATRON_JAEGER_AGENT_HOST`

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ The `Service` has the role of glueing all of the above together, which are:
 The service has some default settings which can be changed via environment variables:
 
 - Service HTTP port, for setting the default HTTP components port to `50000` with `PATRON_HTTP_DEFAULT_PORT`
+- Service HTTP read timeout, for changing the default HTTP read timeout from `5s` to any value, use `PATRON_HTTP_READ_TIMEOUT_SECONDS`
+- Service HTTP write timeout, for changing the default HTTP write timeout from `10s` to any value, use `PATRON_HTTP_WRITE_TIMEOUT_SECONDS`
 - Log level, for setting zerolog with `INFO` log level with `PATRON_LOG_LEVEL`
 - Tracing, for setting up jaeger tracing with
   - agent host `0.0.0.0` with `PATRON_JAEGER_AGENT_HOST`

--- a/service.go
+++ b/service.go
@@ -142,24 +142,24 @@ func (s *service) createHTTPComponent() (Component, error) {
 
 	b := http.NewBuilder().WithPort(int(portVal))
 
-	httpReadTimeout, ok := os.LookupEnv("PATRON_HTTP_READ_TIMEOUT_SECONDS")
+	httpReadTimeout, ok := os.LookupEnv("PATRON_HTTP_READ_TIMEOUT")
 	if ok {
-		readTimeout, err := strconv.ParseInt(httpReadTimeout, 10, 64)
+		readTimeout, err := time.ParseDuration(httpReadTimeout)
 		if err != nil {
 			return nil, fmt.Errorf("env var for HTTP read timeout is not valid: %w", err)
 		}
-		b.WithReadTimeout(time.Duration(readTimeout) * time.Second)
-		log.Infof("setting up default HTTP read timeout %ss", httpReadTimeout)
+		b.WithReadTimeout(readTimeout)
+		log.Infof("setting up default HTTP read timeout %s", httpReadTimeout)
 	}
 
-	httpWriteTimeout, ok := os.LookupEnv("PATRON_HTTP_WRITE_TIMEOUT_SECONDS")
+	httpWriteTimeout, ok := os.LookupEnv("PATRON_HTTP_WRITE_TIMEOUT")
 	if ok {
-		writeTimeout, err := strconv.ParseInt(httpWriteTimeout, 10, 64)
+		writeTimeout, err := time.ParseDuration(httpWriteTimeout)
 		if err != nil {
 			return nil, fmt.Errorf("env var for HTTP write timeout is not valid: %w", err)
 		}
-		b.WithWriteTimeout(time.Duration(writeTimeout) * time.Second)
-		log.Infof("setting up default HTTP write timeout %ss", httpWriteTimeout)
+		b.WithWriteTimeout(writeTimeout)
+		log.Infof("setting up default HTTP write timeout %s", httpWriteTimeout)
 	}
 
 	if s.acf != nil {

--- a/service.go
+++ b/service.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/beatlabs/patron/component/http"
 	patronErrors "github.com/beatlabs/patron/errors"
@@ -140,6 +141,26 @@ func (s *service) createHTTPComponent() (Component, error) {
 	log.Infof("creating default HTTP component at port %s", port)
 
 	b := http.NewBuilder().WithPort(int(portVal))
+
+	httpReadTimeout, ok := os.LookupEnv("PATRON_HTTP_READ_TIMEOUT_SECONDS")
+	if ok {
+		readTimeout, err := strconv.ParseInt(httpReadTimeout, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("env var for HTTP read timeout is not valid: %w", err)
+		}
+		b.WithReadTimeout(time.Duration(readTimeout) * time.Second)
+		log.Infof("setting up default HTTP read timeout %ss", httpReadTimeout)
+	}
+
+	httpWriteTimeout, ok := os.LookupEnv("PATRON_HTTP_WRITE_TIMEOUT_SECONDS")
+	if ok {
+		writeTimeout, err := strconv.ParseInt(httpWriteTimeout, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("env var for HTTP write timeout is not valid: %w", err)
+		}
+		b.WithWriteTimeout(time.Duration(writeTimeout) * time.Second)
+		log.Infof("setting up default HTTP write timeout %ss", httpWriteTimeout)
+	}
 
 	if s.acf != nil {
 		b.WithAliveCheckFunc(s.acf)

--- a/service_test.go
+++ b/service_test.go
@@ -213,6 +213,41 @@ func TestBuild_FailingConditions(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestServer_SetupReadWriteTimeouts(t *testing.T) {
+	tests := []struct {
+		name    string
+		cp      Component
+		ctx     context.Context
+		rt      string
+		wt      string
+		wantErr bool
+	}{
+		{name: "success wo/ setup read and write timeouts", cp: &testComponent{}, ctx: context.Background(), wantErr: false},
+		{name: "success w/ setup read and write timeouts", cp: &testComponent{}, ctx: context.Background(), rt: "60", wt: "20", wantErr: false},
+		{name: "failed w/ invalid write timeout", cp: &testComponent{}, ctx: context.Background(), wt: "invalid", wantErr: true},
+		{name: "failed w/ invalid read timeout", cp: &testComponent{}, ctx: context.Background(), rt: "invalid", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.rt != "" {
+				err := os.Setenv("PATRON_HTTP_READ_TIMEOUT_SECONDS", tt.rt)
+				assert.NoError(t, err)
+			}
+			if tt.wt != "" {
+				err := os.Setenv("PATRON_HTTP_WRITE_TIMEOUT_SECONDS", tt.wt)
+				assert.NoError(t, err)
+			}
+
+			_, err := New("test", "").WithComponents(tt.cp, tt.cp, tt.cp).build()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func getRandomPort() string {
 	rnd := 50000 + rand.Int63n(10000)
 	return strconv.FormatInt(rnd, 10)

--- a/service_test.go
+++ b/service_test.go
@@ -223,18 +223,20 @@ func TestServer_SetupReadWriteTimeouts(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "success wo/ setup read and write timeouts", cp: &testComponent{}, ctx: context.Background(), wantErr: false},
-		{name: "success w/ setup read and write timeouts", cp: &testComponent{}, ctx: context.Background(), rt: "60", wt: "20", wantErr: false},
+		{name: "success w/ setup read and write timeouts", cp: &testComponent{}, ctx: context.Background(), rt: "60s", wt: "20s", wantErr: false},
 		{name: "failed w/ invalid write timeout", cp: &testComponent{}, ctx: context.Background(), wt: "invalid", wantErr: true},
 		{name: "failed w/ invalid read timeout", cp: &testComponent{}, ctx: context.Background(), rt: "invalid", wantErr: true},
+		{name: "failed w/ negative write timeout", cp: &testComponent{}, ctx: context.Background(), wt: "-100s", wantErr: true},
+		{name: "failed w/ zero read timeout", cp: &testComponent{}, ctx: context.Background(), rt: "0s", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.rt != "" {
-				err := os.Setenv("PATRON_HTTP_READ_TIMEOUT_SECONDS", tt.rt)
+				err := os.Setenv("PATRON_HTTP_READ_TIMEOUT", tt.rt)
 				assert.NoError(t, err)
 			}
 			if tt.wt != "" {
-				err := os.Setenv("PATRON_HTTP_WRITE_TIMEOUT_SECONDS", tt.wt)
+				err := os.Setenv("PATRON_HTTP_WRITE_TIMEOUT", tt.wt)
 				assert.NoError(t, err)
 			}
 


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/CONTRIBUTING.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Closes #254. To be able to change the default HTTP read and write timeouts via env vars

## Short description of the changes

Use environment variables `PATRON_HTTP_READ_TIMEOUT_SECONDS` and `PATRON_HTTP_WRITE_TIMEOUT_SECONDS`,  to change the default timeouts for read and write respectively, on the HTTP component build.

