### PR TITLE
Fix logger initialization in patron-cli

### DIFF
--- a/cmd/patron/main.go
+++ b/cmd/patron/main.go
@@ -246,7 +246,7 @@ var (
 func main() {
 	name := "{{ .Name}}"
 
-	err := patron.SetupLogger(name, version)
+	err := patron.SetupLogging(name, version)
 	if err != nil {
 		fmt.Printf("failed to set up logging: %v", err)
 		os.Exit(1)

--- a/cmd/patron/main_test.go
+++ b/cmd/patron/main_test.go
@@ -86,7 +86,7 @@ var (
 func main() {
 	name := "name"
 
-	err := patron.SetupLogger(name, version)
+	err := patron.SetupLogging(name, version)
 	if err != nil {
 		fmt.Printf("failed to set up logging: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <p.tsilias@thebeat.co>

## Which problem is this PR solving?

This PR fixes #257 by correcting the erroneous logger initialization introduced back in #159. 

I introduced the initial bug, so it's only fair that I fix this. I'd like to apologise for anyone getting bitten by this due to my error.

## Short description of the changes

Change the template used in patron-cli to reflect the correct name
