### PR TITLE
Retrieve error closing consumer group

### DIFF
--- a/component/async/kafka/group/group.go
+++ b/component/async/kafka/group/group.go
@@ -125,8 +125,8 @@ func (c *consumer) Consume(ctx context.Context) (<-chan async.Message, <-chan er
 				closeConsumer(c.cg)
 				return
 			case consumerError := <-c.cg.Errors():
-				closeConsumer(c.cg)
 				chErr <- consumerError
+				closeConsumer(c.cg)
 				return
 			}
 		}

--- a/test/docker/kafka/consumer_group_integration_test.go
+++ b/test/docker/kafka/consumer_group_integration_test.go
@@ -106,8 +106,8 @@ func TestGroupConsume_ClaimMessageError(t *testing.T) {
 	case <-chMessages:
 		require.Fail(t, "no messages were expected")
 	case err = <-chErr:
-		require.EqualError(t, err, "kafka: error while consuming groupTopic2/0: " +
-			"could not determine decoder  failed to determine content type from message headers [] : " +
+		require.EqualError(t, err, "kafka: error while consuming groupTopic2/0: "+
+			"could not determine decoder  failed to determine content type from message headers [] : "+
 			"content type header is missing")
 	}
 }

--- a/test/docker/kafka/consumer_group_integration_test.go
+++ b/test/docker/kafka/consumer_group_integration_test.go
@@ -71,6 +71,7 @@ func TestGroupConsume_ClaimMessageError(t *testing.T) {
 	chErr := make(chan error)
 	go func() {
 
+		// Consumer will error out in ClaimMessage as no DecoderFunc has been set
 		factory, err := group.New("test1", uuid.New().String(), []string{groupTopic2}, Brokers(),
 			kafka.Version(sarama.V2_1_0_0.String()), kafka.StartFromNewest())
 		if err != nil {
@@ -103,8 +104,10 @@ func TestGroupConsume_ClaimMessageError(t *testing.T) {
 
 	select {
 	case <-chMessages:
-		require.Fail(t, "no messages where expected")
+		require.Fail(t, "no messages were expected")
 	case err = <-chErr:
-		require.EqualError(t, err, "kafka: tried to use a consumer group that was closed")
+		require.EqualError(t, err, "kafka: error while consuming groupTopic2/0: " +
+			"could not determine decoder  failed to determine content type from message headers [] : " +
+			"content type header is missing")
 	}
 }


### PR DESCRIPTION

## Which problem is this PR solving?
This PR fixes #175 [Consumer Groups close from errors silently](https://github.com/beatlabs/patron/issues/175).

Currently, when an error is encountered in Kafka's group consumer, the error that caused the consumer to shutdown is lost; we instead log an error like `kafka: tried to use a consumer group that was closed`.

The investigation in #176 revealed the cause of the issue; we close the consumer *before* propagating the error, so the 'consumer was closed' error is fetched instead.

The thing is, we never wrote a test to assert the behavior and fix the bug. Checking now, I see that we've incidentally added a test that can assert just that in `test/docker/kafka/consumer_group_integration_test.go`

## Short description of the changes

- Propagate the error that caused the consumer shutdown
- Fix assertion on error message
- Add comment on why we expect ClaimMessage to fail

## Notes
This is not a breaking change, at least I hope people aren't depending on the erroneous 'kafka: tried to use a consumer group that was closed' message.  