### PR TITLE
Implement Transport OptionFunc for HTTP TracedClient

### DIFF
--- a/client/http/http_test.go
+++ b/client/http/http_test.go
@@ -29,6 +29,8 @@ func TestTracedClient_Do(t *testing.T) {
 	assert.NoError(t, err)
 	cb, err := New(CircuitBreaker("test", circuitbreaker.Setting{}))
 	assert.NoError(t, err)
+	ct, err := New(Transport(&http.Transport{}))
+	assert.NoError(t, err)
 	req, err := http.NewRequest("GET", ts.URL, nil)
 	assert.NoError(t, err)
 	reqErr, err := http.NewRequest("GET", "", nil)
@@ -48,6 +50,7 @@ func TestTracedClient_Do(t *testing.T) {
 	}{
 		{name: "respose", args: args{c: c, req: req}, wantErr: false, wantOpName: opName},
 		{name: "response with circuit breaker", args: args{c: cb, req: req}, wantErr: false, wantOpName: opName},
+		{name: "respose with custom transport", args: args{c: ct, req: req}, wantErr: false, wantOpName: opName},
 		{name: "error", args: args{c: cb, req: reqErr}, wantErr: true, wantOpName: opNameError},
 		{name: "error with circuit breaker", args: args{c: cb, req: reqErr}, wantErr: true, wantOpName: opNameError},
 	}
@@ -78,9 +81,10 @@ func TestNew(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{name: "success", args: args{oo: []OptionFunc{Timeout(time.Second), CircuitBreaker("test", circuitbreaker.Setting{})}}, wantErr: false},
+		{name: "success", args: args{oo: []OptionFunc{Timeout(time.Second), CircuitBreaker("test", circuitbreaker.Setting{}), Transport(&http.Transport{})}}, wantErr: false},
 		{name: "failure, invalid timeout", args: args{oo: []OptionFunc{Timeout(0 * time.Second)}}, wantErr: true},
 		{name: "failure, invalid circuit breaker", args: args{[]OptionFunc{CircuitBreaker("", circuitbreaker.Setting{})}}, wantErr: true},
+		{name: "failure, invalid transport", args: args{[]OptionFunc{Transport(nil)}}, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/client/http/option.go
+++ b/client/http/option.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/beatlabs/patron/reliability/circuitbreaker"
+	"github.com/opentracing-contrib/go-stdlib/nethttp"
 )
 
 // OptionFunc definition for configuring the client in a functional way.
@@ -41,7 +42,7 @@ func Transport(rt http.RoundTripper) OptionFunc {
 		if rt == nil {
 			return errors.New("transport must be supplied")
 		}
-		tc.cl.Transport = rt
+		tc.cl.Transport = &nethttp.Transport{RoundTripper: rt}
 		return nil
 	}
 }

--- a/client/http/option.go
+++ b/client/http/option.go
@@ -3,6 +3,7 @@ package http
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/beatlabs/patron/reliability/circuitbreaker"
@@ -30,6 +31,17 @@ func CircuitBreaker(name string, set circuitbreaker.Setting) OptionFunc {
 			return fmt.Errorf("failed to set circuit breaker: %w", err)
 		}
 		tc.cb = cb
+		return nil
+	}
+}
+
+// Transport option for setting the Transport for the client.
+func Transport(rt http.RoundTripper) OptionFunc {
+	return func(tc *TracedClient) error {
+		if rt == nil {
+			return errors.New("transport must be supplied")
+		}
+		tc.cl.Transport = rt
 		return nil
 	}
 }

--- a/client/http/option_test.go
+++ b/client/http/option_test.go
@@ -1,0 +1,17 @@
+package http
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransport(t *testing.T) {
+	transport := &http.Transport{}
+	client, err := New(Transport(transport))
+
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, transport, client.cl.Transport)
+}

--- a/client/http/option_test.go
+++ b/client/http/option_test.go
@@ -15,3 +15,10 @@ func TestTransport(t *testing.T) {
 	assert.NotNil(t, client)
 	assert.Equal(t, transport, client.cl.Transport)
 }
+
+func TestTransport_Nil(t *testing.T) {
+	client, err := New(Transport(nil))
+
+	assert.Nil(t, client)
+	assert.Error(t, err, "transport must be supplied")
+}

--- a/client/http/option_test.go
+++ b/client/http/option_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,7 +14,7 @@ func TestTransport(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, client)
-	assert.Equal(t, transport, client.cl.Transport)
+	assert.Equal(t, &nethttp.Transport{RoundTripper: transport}, client.cl.Transport)
 }
 
 func TestTransport_Nil(t *testing.T) {


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #264

## Short description of the changes

Adds a new `OptionFunc` under `client/http` which takes  a `RoundTripper` argument to set as the transport for the client.

The supplied `RoundTripper` is then wrapped in an opentracing-contrib's [nethttp.Transport](https://godoc.org/github.com/opentracing-contrib/go-stdlib/nethttp#Transport) due to dependencies in `TracedClient`.

### Side Note

The contribution [guidelines](https://github.com/beatlabs/patron/#how-to-contribute) say that the contributor should assign the issue to themselves, but this option isn't available to me with the current repo settings.

