### PR TITLE
Sync goroutine assertion in component/http with caller test

### DIFF
--- a/component/http/route_cache_test.go
+++ b/component/http/route_cache_test.go
@@ -31,8 +31,6 @@ type arg struct {
 	err bool
 }
 
-var ce chan error
-
 func TestCachingMiddleware(t *testing.T) {
 
 	getRequest, err := http.NewRequest("GET", "/test", nil)
@@ -157,7 +155,7 @@ func assertRouteBuilder(t *testing.T, arg arg, routeBuilder *RouteBuilder, cache
 }
 
 func TestRouteCacheImplementation_WithSingleRequest(t *testing.T) {
-	ce = make(chan error, 1)
+	ce := make(chan error, 1)
 
 	cc := newTestingCache()
 	cc.instant = httpcache.NowSeconds
@@ -185,7 +183,7 @@ func TestRouteCacheImplementation_WithSingleRequest(t *testing.T) {
 	ctx, cln := context.WithTimeout(context.Background(), 5*time.Second)
 
 	port := 50023
-	runRoute(ctx, t, routeBuilder, port)
+	runRoute(ctx, t, routeBuilder, ce, port)
 
 	assertResponse(ctx, t, []http.Response{
 		{
@@ -227,7 +225,7 @@ func TestRouteCacheImplementation_WithSingleRequest(t *testing.T) {
 }
 
 func TestRouteCacheAsMiddleware_WithSingleRequest(t *testing.T) {
-	ce = make(chan error, 1)
+	ce := make(chan error, 1)
 
 	cc := newTestingCache()
 	cc.instant = httpcache.NowSeconds
@@ -259,7 +257,7 @@ func TestRouteCacheAsMiddleware_WithSingleRequest(t *testing.T) {
 	ctx, cln := context.WithTimeout(context.Background(), 5*time.Second)
 
 	port := 50023
-	runRoute(ctx, t, routeBuilder, port)
+	runRoute(ctx, t, routeBuilder, ce, port)
 
 	assertResponse(ctx, t, []http.Response{
 		{
@@ -320,7 +318,7 @@ func newMiddlewareWrapper(middlewareFunc func(w http.ResponseWriter, r *http.Req
 }
 
 func TestRawRouteCacheImplementation_WithSingleRequest(t *testing.T) {
-	ce = make(chan error, 1)
+	ce := make(chan error, 1)
 
 	cc := newTestingCache()
 	cc.instant = httpcache.NowSeconds
@@ -349,7 +347,7 @@ func TestRawRouteCacheImplementation_WithSingleRequest(t *testing.T) {
 	ctx, cln := context.WithTimeout(context.Background(), 5*time.Second)
 
 	port := 50024
-	runRoute(ctx, t, routeBuilder, port)
+	runRoute(ctx, t, routeBuilder, ce, port)
 
 	assertResponse(ctx, t, []http.Response{
 		{
@@ -407,7 +405,7 @@ func (br *bodyReader) Close() error {
 	return nil
 }
 
-func runRoute(ctx context.Context, t *testing.T, routeBuilder *RouteBuilder, port int) {
+func runRoute(ctx context.Context, t *testing.T, routeBuilder *RouteBuilder, ce chan error, port int) {
 	cmp, err := NewBuilder().WithRoutesBuilder(NewRoutesBuilder().Append(routeBuilder)).WithPort(port).Create()
 
 	assert.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <p.tsilias@thebeat.co>

## Which problem is this PR solving?

This PR fixes #243 [CI reports an error on test suite](https://github.com/beatlabs/patron/issues/243).

We noticed a panicking test in the `component/http` package caused by an assertion from a goroutine inside `runRoute`, which was triggered *after* the parent test had exited.


## Short description of the changes

- ~Define a package-level error channel.~
- Initiaize a channel in each test, and use it to fetch the error concurrently
- When an error is returned from `cmp.Run(ctx)` send it along the channel and close it.


## Notes
- We still don't know if there's actually an error triggering the assertion. I did 500 runs all tests on the component/http package locally, but no failures were noted.
- I initially used a shared, package-level error channel, but it produced data races, so I switched to individual ones.
- Do you think we should trigger the CI eg. 100-200 times and note the results?
- The tests are slightly slower (+~1.6 sec), since in these three tests, we have to wait for the http component to shut down which takes about ~500ms