### PR TITLE
Retry strategy in async component

### DIFF
--- a/component/async/component.go
+++ b/component/async/component.go
@@ -162,7 +162,7 @@ func (c *Component) Run(ctx context.Context) error {
 				log.Errorf("process error, retry %d/%d with %v wait: %v", retry, c.retries, c.retryWait, err)
 				if retry < c.retries {
 					time.Sleep(c.retryWait)
-					retry += 1
+					retry++
 				} else {
 					return err
 				}
@@ -172,7 +172,7 @@ func (c *Component) Run(ctx context.Context) error {
 			log.Errorf("consume error, retry %d/%d with %v wait: %v", retry, c.retries, c.retryWait, err)
 			if retry < c.retries {
 				time.Sleep(c.retryWait)
-				retry += 1
+				retry++
 			} else {
 				return err
 			}

--- a/component/async/component_test.go
+++ b/component/async/component_test.go
@@ -307,9 +307,7 @@ func TestRun_ConsumeError(t *testing.T) {
 // before exiting the execution
 func TestRun_ConsumeError_WithRetry(t *testing.T) {
 	retries := 3
-	// cf := &mockConsumerFactory{errRet: true}
 	builder := proxyBuilder{
-		// cf:        cf,
 		cnr: mockConsumer{
 			chMsg: make(chan Message),
 			chErr: make(chan error),


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #266 by following the first approach described in that issue: the retry strategy is essentially a tolerance for N **consecutive** errors in the async Run loop message handling.

Other changes:
- The retries now only apply to message related errors (process errors and consumer errors)
- Any errors that happen while setting up the consumer are returned immediately

Questions:
- Are more tests needed?