### PR TITLE
Add new constructors to get http.Method specific RouteBuilders  & Update examples to use the same

### DIFF
--- a/component/http/route.go
+++ b/component/http/route.go
@@ -206,6 +206,60 @@ func NewRouteBuilder(path string, processor ProcessorFunc) *RouteBuilder {
 	return &RouteBuilder{path: path, errors: ee, handler: handler(processor)}
 }
 
+// NewGetRouteBuilder constructor
+func NewGetRouteBuilder(path string, processor ProcessorFunc) *RouteBuilder {
+
+	return NewRouteBuilder(path, processor).MethodGet()
+}
+
+// NewHeadRouteBuilder constructor.
+func NewHeadRouteBuilder(path string, processor ProcessorFunc) *RouteBuilder {
+
+	return NewRouteBuilder(path, processor).MethodHead()
+}
+
+// NewPostRouteBuilder constructor.
+func NewPostRouteBuilder(path string, processor ProcessorFunc) *RouteBuilder {
+
+	return NewRouteBuilder(path, processor).MethodPost()
+}
+
+// NewPutRouteBuilder constructor.
+func NewPutRouteBuilder(path string, processor ProcessorFunc) *RouteBuilder {
+
+	return NewRouteBuilder(path, processor).MethodPut()
+}
+
+// NewPatchRouteBuilder constructor.
+func NewPatchRouteBuilder(path string, processor ProcessorFunc) *RouteBuilder {
+
+	return NewRouteBuilder(path, processor).MethodPatch()
+}
+
+// NewDeleteRouteBuilder constructor.
+func NewDeleteRouteBuilder(path string, processor ProcessorFunc) *RouteBuilder {
+
+	return NewRouteBuilder(path, processor).MethodDelete()
+}
+
+// NewConnectRouteBuilder constructor.
+func NewConnectRouteBuilder(path string, processor ProcessorFunc) *RouteBuilder {
+
+	return NewRouteBuilder(path, processor).MethodConnect()
+}
+
+// NewOptionsRouteBuilder constructor.
+func NewOptionsRouteBuilder(path string, processor ProcessorFunc) *RouteBuilder {
+
+	return NewRouteBuilder(path, processor).MethodOptions()
+}
+
+// NewTraceRouteBuilder constructor.
+func NewTraceRouteBuilder(path string, processor ProcessorFunc) *RouteBuilder {
+
+	return NewRouteBuilder(path, processor).MethodTrace()
+}
+
 // RoutesBuilder creates a list of routes.
 type RoutesBuilder struct {
 	routes []Route

--- a/component/http/route_test.go
+++ b/component/http/route_test.go
@@ -263,6 +263,44 @@ func TestNewRouteBuilder(t *testing.T) {
 	}
 }
 
+func TestNewGetRouteBuilder(t *testing.T) {
+	mockProcessor := func(context.Context, *Request) (*Response, error) { return nil, nil }
+	assert.Equal(t, http.MethodGet, NewGetRouteBuilder("/", mockProcessor).method)
+}
+
+func TestNewHeadRouteBuilder(t *testing.T) {
+	mockProcessor := func(context.Context, *Request) (*Response, error) { return nil, nil }
+	assert.Equal(t, http.MethodHead, NewHeadRouteBuilder("/", mockProcessor).method)
+}
+func TestNewPostRouteBuilder(t *testing.T) {
+	mockProcessor := func(context.Context, *Request) (*Response, error) { return nil, nil }
+	assert.Equal(t, http.MethodPost, NewPostRouteBuilder("/", mockProcessor).method)
+}
+func TestNewPutGetRouteBuilder(t *testing.T) {
+	mockProcessor := func(context.Context, *Request) (*Response, error) { return nil, nil }
+	assert.Equal(t, http.MethodPut, NewPutRouteBuilder("/", mockProcessor).method)
+}
+func TestNewPatchRouteBuilder(t *testing.T) {
+	mockProcessor := func(context.Context, *Request) (*Response, error) { return nil, nil }
+	assert.Equal(t, http.MethodPatch, NewPatchRouteBuilder("/", mockProcessor).method)
+}
+func TestNewDeleteRouteBuilder(t *testing.T) {
+	mockProcessor := func(context.Context, *Request) (*Response, error) { return nil, nil }
+	assert.Equal(t, http.MethodDelete, NewDeleteRouteBuilder("/", mockProcessor).method)
+}
+func TestNewConnectRouteBuilder(t *testing.T) {
+	mockProcessor := func(context.Context, *Request) (*Response, error) { return nil, nil }
+	assert.Equal(t, http.MethodConnect, NewConnectRouteBuilder("/", mockProcessor).method)
+}
+func TestNewOptionsRouteBuilder(t *testing.T) {
+	mockProcessor := func(context.Context, *Request) (*Response, error) { return nil, nil }
+	assert.Equal(t, http.MethodOptions, NewOptionsRouteBuilder("/", mockProcessor).method)
+}
+func TestNewTraceRouteBuilder(t *testing.T) {
+	mockProcessor := func(context.Context, *Request) (*Response, error) { return nil, nil }
+	assert.Equal(t, http.MethodTrace, NewTraceRouteBuilder("/", mockProcessor).method)
+}
+
 func TestRoutesBuilder_Build(t *testing.T) {
 	mockHandler := func(http.ResponseWriter, *http.Request) {}
 	validRb := NewRawRouteBuilder("/", mockHandler).MethodGet()

--- a/examples/first/main.go
+++ b/examples/first/main.go
@@ -39,7 +39,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	routesBuilder := patronhttp.NewRoutesBuilder().Append(patronhttp.NewRouteBuilder("/", first).MethodPost())
+	routesBuilder := patronhttp.NewRoutesBuilder().Append(patronhttp.NewPostRouteBuilder("/", first))
 
 	// Setup a simple CORS middleware
 	middlewareCors := func(h http.Handler) http.Handler {

--- a/examples/second/main.go
+++ b/examples/second/main.go
@@ -61,7 +61,7 @@ func main() {
 	}
 
 	routesBuilder := patronhttp.NewRoutesBuilder().
-		Append(patronhttp.NewRouteBuilder("/", httpCmp.second).MethodGet().WithTrace().WithAuth(auth))
+		Append(patronhttp.NewGetRouteBuilder("/", httpCmp.second).WithTrace().WithAuth(auth))
 
 	ctx := context.Background()
 	err = service.WithRoutesBuilder(routesBuilder).Run(ctx)

--- a/examples/seventh/main.go
+++ b/examples/seventh/main.go
@@ -50,14 +50,13 @@ func main() {
 	}
 
 	routesBuilder := http.NewRoutesBuilder().
-		Append(http.NewRouteBuilder("/", seventh).
+		Append(http.NewGetRouteBuilder("/", seventh).
 			WithRouteCache(cache, httpcache.Age{
 				// we wont allow to override the cache more than once per 15 seconds
 				Min: 15 * time.Second,
 				// by default we might send stale response for up to 1 minute
 				Max: 60 * time.Second,
-			}).
-			MethodGet())
+			}))
 
 	sig := func() {
 		fmt.Println("exit gracefully...")


### PR DESCRIPTION
Signed-off-by: santosh <bsantosh@thoughtworks.com>

<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Resolves #201 

## Short description of the changes
Adds http.Method specific Routebuilder constructor functions. Updates examples to use the same.

Note: Examples are failing now due to existing known issues (#277 and #285 ). Tested examples by applying fixes of these issues, faced no issues.
