### PR TITLE
Fix port conflict for http-cache and grpc examples

### DIFF
--- a/examples/http-cache/main.go
+++ b/examples/http-cache/main.go
@@ -24,7 +24,7 @@ func init() {
 		fmt.Printf("failed to set sampler env vars: %v", err)
 		os.Exit(1)
 	}
-	err = os.Setenv("PATRON_HTTP_DEFAULT_PORT", "50006")
+	err = os.Setenv("PATRON_HTTP_DEFAULT_PORT", "50007")
 	if err != nil {
 		fmt.Printf("failed to set default patron port env vars: %v", err)
 		os.Exit(1)

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -108,7 +108,7 @@ func httpHandler(ctx context.Context, req *patronhttp.Request) (*patronhttp.Resp
 
 // DoIntervalRequest is a helper method to make a request to the http-cache example service from other examples
 func DoIntervalRequest(ctx context.Context) (string, error) {
-	request, err := http.NewRequest("GET", "http://localhost:50006/", nil)
+	request, err := http.NewRequest("GET", "http://localhost:50007/", nil)
 	if err != nil {
 		return "", fmt.Errorf("failed create route request: %w", err)
 	}


### PR DESCRIPTION
Signed-off-by: santosh <bsantosh@thoughtworks.com>

<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Resolves #277

## Short description of the changes

Change port for seventh example to 50007 to avoid conflict with sixth example. Also change the port in DoTimingRequest function of 1st example which uses service exposed by 7th example.
