### PR TITLE
Parse Accept-Encoding header, and set Content-Encoding correctly

### DIFF
--- a/component/http/middleware.go
+++ b/component/http/middleware.go
@@ -322,7 +322,7 @@ func MiddlewareChain(f http.Handler, mm ...MiddlewareFunc) http.Handler {
 }
 
 func isCompressionHeader(h string) bool {
-	return strings.Contains(h, "gzip") || strings.Contains(h, "deflate")
+	return strings.Contains(h, gzipHeader) || strings.Contains(h, deflateHeader)
 }
 
 func logRequestResponse(corID string, w *responseWriter, r *http.Request) {

--- a/component/http/middleware.go
+++ b/component/http/middleware.go
@@ -166,10 +166,6 @@ func parseAcceptEncoding(header string) (string, error) {
 
 	weighted := make(map[float64]string)
 
-	addWithWeight := func(weight float64, algorithm string) {
-		addWithWeight(weighted, weight, algorithm)
-	}
-
 	algorithms := strings.Split(header, ",")
 	for _, a := range algorithms {
 		algAndWeight := strings.Split(a, ";")
@@ -180,18 +176,18 @@ func parseAcceptEncoding(header string) (string, error) {
 		}
 
 		if len(algAndWeight) != 2 {
-			addWithWeight(0.0, algorithm)
+			addWithWeight(weighted, 0.0, algorithm)
 			continue
 		}
 
 		qWeight := algAndWeight[1]
 		weight, err := parseWeight(qWeight)
 		if err != nil {
-			addWithWeight(0.0, algorithm)
+			addWithWeight(weighted, 0.0, algorithm)
 			continue
 		}
 
-		addWithWeight(weight, algorithm)
+		addWithWeight(weighted, weight, algorithm)
 	}
 
 	return selectByWeight(weighted)

--- a/component/http/middleware_test.go
+++ b/component/http/middleware_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -370,128 +371,191 @@ func TestNewCompressionMiddleware_Headers(t *testing.T) {
 }
 
 func TestSelectEncoding(t *testing.T) {
-	testFn := func(hdr string, expected string, isErr bool) func(t *testing.T) {
-		return func(t *testing.T) {
-			result, err := parseAcceptEncoding(hdr)
-			assert.Equal(t, isErr, err != nil)
-			assert.Equal(t, expected, result)
-		}
+	tests := []struct {
+		optionalName string
+		given        string
+		expected     string
+		isErr        bool
+	}{
+		{given: "*", expected: "*"},
+		{given: "gzip", expected: "gzip"},
+		{given: "deflate", expected: "deflate"},
+
+		{given: "whatever", expected: "", isErr: true, optionalName: "whatever, not supported"},
+		{given: "whatever, *", expected: "*", optionalName: "whatever, but also a star"},
+
+		{given: "gzip, deflate", expected: "gzip"},
+		{given: "whatever, gzip, deflate", expected: "gzip"},
+		{given: "gzip, whatever, deflate", expected: "gzip"},
+		{given: "gzip, deflate, whatever", expected: "gzip"},
+
+		{given: "gzip,deflate", expected: "gzip"},
+		{given: "gzip,whatever,deflate", expected: "gzip"},
+		{given: "whatever,gzip,deflate", expected: "gzip"},
+		{given: "gzip,deflate,whatever", expected: "gzip"},
+
+		{given: "deflate, gzip", expected: "deflate"},
+		{given: "whatever, deflate, gzip", expected: "deflate"},
+		{given: "deflate, whatever, gzip", expected: "deflate"},
+		{given: "deflate, gzip, whatever", expected: "deflate"},
+
+		{given: "deflate, gzip", expected: "deflate"},
+		{given: "whatever,deflate,gzip", expected: "deflate"},
+		{given: "deflate,whatever,gzip", expected: "deflate"},
+		{given: "deflate,gzip,whatever", expected: "deflate"},
+
+		{given: "gzip;q=1.0, deflate;q=1.0", expected: "gzip", optionalName: "equal weights"},
+		{given: "deflate;q=1.0, gzip;q=1.0", expected: "deflate", optionalName: "equal weights 2"},
+
+		{given: "gzip;q=1.0, deflate;q=0.5", expected: "gzip"},
+		{given: "gzip;q=1.0, deflate;q=0.5, *;q=0.2", expected: "gzip"},
+		{given: "deflate;q=1.0, gzip;q=0.5", expected: "deflate"},
+		{given: "deflate;q=1.0, gzip;q=0.5, *;q=0.2", expected: "deflate"},
+
+		{given: "gzip;q=0.5, deflate;q=1.0", expected: "deflate"},
+		{given: "gzip;q=0.5, deflate;q=1.0, *;q=0.2", expected: "deflate"},
+		{given: "deflate;q=0.5, gzip;q=1.0", expected: "gzip"},
+		{given: "deflate;q=0.5, gzip;q=1.0, *;q=0.2", expected: "gzip"},
+
+		{given: "whatever;q=1.0, *;q=0.2", expected: "*"},
+
+		{given: "deflate, gzip;q=1.0", expected: "gzip"},
+		{given: "deflate;q=0.5, gzip", expected: "deflate"},
 	}
 
-	t.Run("*", testFn("*", "*", false))
-	t.Run("gzip", testFn("gzip", "gzip", false))
-	t.Run("deflate", testFn("deflate", "deflate", false))
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("encoding %q is parsed as %s ; error is expected: %t ; %s", tc.given, tc.expected, tc.isErr, tc.optionalName), func(t *testing.T) {
+			// when
+			result, err := parseAcceptEncoding(tc.given)
 
-	t.Run("whatever, not supported", testFn("whatever", "", true))
-	t.Run("whatever, but also a star", testFn("whatever, *", "*", false))
-
-	t.Run("gzip, deflate", testFn("gzip, deflate", "gzip", false))
-	t.Run("whatever, gzip, deflate", testFn("whatever, gzip, deflate", "gzip", false))
-	t.Run("gzip, whatever, deflate", testFn("gzip, whatever, deflate", "gzip", false))
-	t.Run("gzip, deflate, whatever", testFn("gzip, deflate, whatever", "gzip", false))
-
-	t.Run("gzip,deflate", testFn("gzip,deflate", "gzip", false))
-	t.Run("gzip,whatever,deflate", testFn("gzip,whatever,deflate", "gzip", false))
-	t.Run("whatever,gzip,deflate", testFn("whatever,gzip,deflate", "gzip", false))
-	t.Run("gzip,deflate,whatever", testFn("gzip,deflate,whatever", "gzip", false))
-
-	t.Run("deflate, gzip", testFn("deflate, gzip", "deflate", false))
-	t.Run("whatever, deflate, gzip", testFn("whatever, deflate, gzip", "deflate", false))
-	t.Run("deflate, whatever, gzip", testFn("deflate, whatever, gzip", "deflate", false))
-	t.Run("deflate, gzip, whatever", testFn("deflate, gzip, whatever", "deflate", false))
-
-	t.Run("deflate,gzip", testFn("deflate, gzip", "deflate", false))
-	t.Run("whatever,deflate,gzip", testFn("whatever,deflate,gzip", "deflate", false))
-	t.Run("deflate,whatever,gzip", testFn("deflate,whatever,gzip", "deflate", false))
-	t.Run("deflate,gzip,whatever", testFn("deflate,gzip,whatever", "deflate", false))
-
-	t.Run("equal weights", testFn("gzip;q=1.0, deflate;q=1.0", "gzip", false))
-	t.Run("equal weights 2", testFn("deflate;q=1.0, gzip;q=1.0", "deflate", false))
-
-	t.Run("gzip;q=1.0, deflate;q=0.5", testFn("gzip;q=1.0, deflate;q=0.5", "gzip", false))
-	t.Run("gzip;q=1.0, deflate;q=0.5, *;q=0.2", testFn("gzip;q=1.0, deflate;q=0.5, *;q=0.2", "gzip", false))
-	t.Run("deflate;q=1.0, gzip;q=0.5", testFn("deflate;q=1.0, gzip;q=0.5", "deflate", false))
-	t.Run("deflate;q=1.0, gzip;q=0.5, *;q=0.2", testFn("deflate;q=1.0, gzip;q=0.5, *;q=0.2", "deflate", false))
-
-	t.Run("gzip;q=0.5, deflate;q=1.0", testFn("gzip;q=0.5, deflate;q=1.0", "deflate", false))
-	t.Run("gzip;q=0.5, deflate;q=1.0, *;q=0.2", testFn("gzip;q=0.5, deflate;q=1.0, *;q=0.2", "deflate", false))
-	t.Run("deflate;q=0.5, gzip;q=1.0", testFn("deflate;q=0.5, gzip;q=1.0", "gzip", false))
-	t.Run("deflate;q=0.5, gzip;q=1.0, *;q=0.2", testFn("deflate;q=0.5, gzip;q=1.0, *;q=0.2", "gzip", false))
-
-	t.Run("whatever;q=1.0, *;q=0.2", testFn("whatever;q=1.0, *;q=0.2", "*", false))
-
-	t.Run("deflate, gzip;q=1.0", testFn("deflate, gzip;q=1.0", "gzip", false))
-	t.Run("deflate;q=0.5, gzip", testFn("deflate;q=0.5, gzip", "deflate", false))
+			// then
+			assert.Equal(t, tc.isErr, err != nil)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
 }
 
 func TestSupported(t *testing.T) {
-	testFn := func(algorithm string, expected bool) func(t *testing.T) {
-		return func(t *testing.T) {
-			// when
-			notSupported := notSupportedCompression(algorithm)
-
-			// then
-			assert.Equal(t, notSupported, !expected)
-		}
+	tests := []struct {
+		algorithm   string
+		isSupported bool
+	}{
+		{algorithm: "gzip", isSupported: true},
+		{algorithm: "deflate", isSupported: true},
+		{algorithm: "*", isSupported: true},
+		{algorithm: "something else", isSupported: false},
 	}
 
-	t.Run("gzip", testFn("gzip", true))
-	t.Run("deflate", testFn("deflate", true))
-	t.Run("star", testFn("*", true))
-	t.Run("something else", testFn("something else", false))
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%q check results in %t", tc.algorithm, tc.isSupported), func(t *testing.T) {
+			// when
+			result := !notSupportedCompression(tc.algorithm)
+
+			// then
+			assert.Equal(t, result, tc.isSupported)
+		})
+	}
 }
 
 func TestParseWeights(t *testing.T) {
-	testFn := func(qStr string, expected float64, isErr bool) func(t *testing.T) {
-		return func(t *testing.T) {
-			// when
-			result, err := parseWeight(qStr)
-
-			// then
-			assert.Equal(t, isErr, err != nil)
-			assert.Equal(t, expected, result)
-		}
+	tests := []struct {
+		priorityStr string
+		expected    float64
+		isErr       bool
+	}{
+		{priorityStr: "q=1.0", expected: 1.0},
+		{priorityStr: "q=0.5", expected: 0.5},
+		{priorityStr: "q=", expected: 0.0, isErr: true},
+		{priorityStr: "", expected: 0.0, isErr: true},
 	}
 
-	t.Run("q=1.0", testFn("q=1.0", 1.0, false))
-	t.Run("q=0.5", testFn("q=0.5", 0.5, false))
-	t.Run("q=", testFn("q=", 0.0, true))
-	t.Run("empty string", testFn("", 0.0, true))
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("for given priority: %q, expect %f, and error = %t", tc.priorityStr, tc.expected, tc.isErr), func(t *testing.T) {
+			// when
+			result, err := parseWeight(tc.priorityStr)
+
+			// then
+			assert.Equal(t, tc.isErr, err != nil)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
 }
 
 func TestSelectByWeight(t *testing.T) {
-	testFn := func(given map[float64]string, expected string, isErr bool) func(t *testing.T) {
-		return func(t *testing.T) {
-			// when
-			selected, err := selectByWeight(given)
-
-			// then
-			assert.Equal(t, isErr, err != nil)
-			assert.Equal(t, expected, selected)
-		}
+	tests := []struct {
+		name     string
+		given    map[float64]string
+		expected string
+		isErr    bool
+	}{
+		{
+			name:     "sorted map",
+			given:    map[float64]string{1.0: "gzip", 0.5: "deflate"},
+			expected: "gzip",
+		},
+		{
+			name:     "not sorted map",
+			given:    map[float64]string{0.5: "gzip", 1.0: "deflate"},
+			expected: "deflate",
+		},
+		{
+			name:     "empty weights map",
+			given:    map[float64]string{},
+			expected: "",
+			isErr:    true,
+		},
 	}
 
-	t.Run("sorted", testFn(map[float64]string{1.0: "gzip", 0.5: "deflate"}, "gzip", false))
-	t.Run("not sorted", testFn(map[float64]string{0.5: "gzip", 1.0: "deflate"}, "deflate", false))
-	t.Run("empty", testFn(map[float64]string{}, "", true))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// when
+			selected, err := selectByWeight(tc.given)
+
+			// then
+			assert.Equal(t, tc.isErr, err != nil)
+			assert.Equal(t, tc.expected, selected)
+		})
+	}
 }
 
 func TestAddWithWeight(t *testing.T) {
-	testFn := func(
-		weightedMap map[float64]string, weight float64, algorithm string,
-		expected map[float64]string) func(t *testing.T) {
-		return func(t *testing.T) {
-			// given
-
-			// when
-			addWithWeight(weightedMap, weight, algorithm)
-
-			// then
-			assert.Equal(t, expected, weightedMap)
-		}
+	tests := []struct {
+		name        string
+		weightedMap map[float64]string
+		weight      float64
+		algorithm   string
+		expected    map[float64]string
+	}{
+		{
+			name:        "empty",
+			weightedMap: map[float64]string{},
+			weight:      1.0,
+			algorithm:   "gzip",
+			expected:    map[float64]string{1.0: "gzip"},
+		},
+		{
+			name:        "new",
+			weightedMap: map[float64]string{1.0: "gzip"},
+			weight:      0.5,
+			algorithm:   "deflate",
+			expected:    map[float64]string{1.0: "gzip", 0.5: "deflate"},
+		},
+		{
+			name:        "already exists",
+			weightedMap: map[float64]string{1.0: "gzip"},
+			weight:      1.0,
+			algorithm:   "deflate",
+			expected:    map[float64]string{1.0: "gzip"},
+		},
 	}
 
-	t.Run("empty", testFn(map[float64]string{}, 1.0, "gzip", map[float64]string{1.0: "gzip"}))
-	t.Run("new", testFn(map[float64]string{1.0: "gzip"}, 0.5, "deflate", map[float64]string{1.0: "gzip", 0.5: "deflate"}))
-	t.Run("already exists", testFn(map[float64]string{1.0: "gzip"}, 1.0, "deflate", map[float64]string{1.0: "gzip"}))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// when
+			addWithWeight(tc.weightedMap, tc.weight, tc.algorithm)
+
+			// then
+			assert.Equal(t, tc.expected, tc.weightedMap)
+		})
+	}
 }

--- a/component/http/route_cache_test.go
+++ b/component/http/route_cache_test.go
@@ -445,7 +445,7 @@ func assertResponse(ctx context.Context, t *testing.T, expected []http.Response,
 	cl, err := httpclient.New()
 	assert.NoError(t, err)
 	req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d/path", port), nil)
-	req.Header.Set(encoding.AcceptEncodingHeader, "Non-GZIP") // bypass default HTTP client GZIP-ing our response
+	req.Header.Set(encoding.AcceptEncodingHeader, "*") // bypass default HTTP client GZIP-ing our response
 	assert.NoError(t, err)
 
 	for _, expectedResponse := range expected {


### PR DESCRIPTION
Issue #300, #301

<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Resolves issues https://github.com/beatlabs/patron/issues/300 and https://github.com/beatlabs/patron/issues/301

## Short description of the changes

`Accept-Encoding` header is now parsed and respected in compression middleware
`Content-Encoding` header is not correctly set
