### PR TITLE
Log 'connection reset' errors on info level

### DIFF
--- a/component/http/middleware_test.go
+++ b/component/http/middleware_test.go
@@ -551,3 +551,41 @@ func TestAddWithWeight(t *testing.T) {
 		})
 	}
 }
+
+func TestIsConnectionReset(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "Broken pipe",
+			err:      errors.New("blah blah broken pipe blah blah"),
+			expected: true,
+		},
+		{
+			name:     "connection reset",
+			err:      errors.New("blah blah connection reset blah blah"),
+			expected: true,
+		},
+		{
+			name:     "read: connection reset",
+			err:      errors.New("blah blah read: connection reset blah blah"),
+			expected: false,
+		}, {
+			name:     "b00m random error",
+			err:      errors.New("blah blah b00m random error blah blah"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// when
+			result := isErrConnectionReset(tc.err)
+
+			// then
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/component/http/middleware_test.go
+++ b/component/http/middleware_test.go
@@ -553,34 +553,30 @@ func TestAddWithWeight(t *testing.T) {
 }
 
 func TestIsConnectionReset(t *testing.T) {
-	tests := []struct {
-		name     string
+	tests := map[string]struct {
 		err      error
 		expected bool
 	}{
-		{
-			name:     "Broken pipe",
+		"Broken pipe": {
 			err:      errors.New("blah blah broken pipe blah blah"),
 			expected: true,
 		},
-		{
-			name:     "connection reset",
+		"connection reset": {
 			err:      errors.New("blah blah connection reset blah blah"),
 			expected: true,
 		},
-		{
-			name:     "read: connection reset",
+		"read: connection reset": {
 			err:      errors.New("blah blah read: connection reset blah blah"),
 			expected: false,
-		}, {
-			name:     "b00m random error",
+		},
+		"b00m random error": {
 			err:      errors.New("blah blah b00m random error blah blah"),
 			expected: false,
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
 			// when
 			result := isErrConnectionReset(tc.err)
 


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Solves https://github.com/beatlabs/patron/issues/332
_(I know the issue hasn't been discussed, but the code was ready anyway)_

## Short description of the changes

When an error happens in compression middleware which is not really an error but rather an expected (although rare) thing, don't spoil the logs with an error message.
The implementation is based on what AWS considers to belong to that kind of errors.
