### PR TITLE
Kafka Duration Client: Time Extractor Failure

### DIFF
--- a/component/async/kafka/simple/duration_client.go
+++ b/component/async/kafka/simple/duration_client.go
@@ -112,7 +112,10 @@ func (d durationClient) offsetBinarySearch(ctx context.Context, topic string, si
 
 		t, err := timeExtractor(msg)
 		if err != nil {
-			return 0, fmt.Errorf("error while executing comparator: %w", err)
+			log.FromContext(ctx).Warnf("error while executing comparator: %v", err)
+			// In case of a failure, we compress the range so that the next calculated mid is different
+			left++
+			continue
 		}
 
 		if t.Equal(since) {


### PR DESCRIPTION
Signed-off-by: teivah <t.harsanyi@thebeat.co>

## Which problem is this PR solving?

Closes https://github.com/beatlabs/patron/issues/345

## Short description of the changes

* Log a warning if the time extractor fails
* Update the range of the binary search so that we don't keep consuming the same message
