### PR TITLE
gRPC client Prometheus metrics

### DIFF
--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -4,18 +4,17 @@ package grpc
 
 import (
 	"context"
-	"fmt"
 	"time"
 
+	"github.com/beatlabs/patron/correlation"
+	"github.com/beatlabs/patron/log"
+	"github.com/beatlabs/patron/trace"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-
-	"github.com/beatlabs/patron/correlation"
-	"github.com/beatlabs/patron/trace"
 )
 
 const (
@@ -77,7 +76,7 @@ func unaryInterceptor(target string) grpc.UnaryClientInterceptor {
 		carrier := headersCarrier{Ctx: ctx}
 		err := span.Tracer().Inject(span.Context(), opentracing.TextMap, &carrier)
 		if err != nil {
-			return fmt.Errorf("failed to inject tracing headers: %w", err)
+			log.Errorf("failed to inject tracing headers: %v", err)
 		}
 
 		corID := correlation.IDFromContext(carrier.Ctx)

--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -76,7 +76,7 @@ func unaryInterceptor(target string) grpc.UnaryClientInterceptor {
 		carrier := headersCarrier{Ctx: ctx}
 		err := span.Tracer().Inject(span.Context(), opentracing.TextMap, &carrier)
 		if err != nil {
-			log.Errorf("failed to inject tracing headers: %v", err)
+			log.FromContext(ctx).Errorf("failed to inject tracing headers: %v", err)
 		}
 
 		corID := correlation.IDFromContext(carrier.Ctx)

--- a/client/grpc/grpc.go
+++ b/client/grpc/grpc.go
@@ -1,34 +1,59 @@
-// Package grpc provides a client implementation for gRPC with tracing included.
+// Package grpc provides a client implementation for gRPC with tracing and
+// metrics included.
 package grpc
 
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	"github.com/beatlabs/patron/correlation"
 	"github.com/beatlabs/patron/trace"
-	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 )
 
 const (
 	componentName = "grpc-client"
+	unary         = "unary"
 )
 
-// Dial creates a client connection to the given target with a tracing/logging interceptor.
+var (
+	rpcDurationMetrics *prometheus.HistogramVec
+)
+
+func init() {
+	rpcDurationMetrics = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "client",
+			Subsystem: "grpc",
+			Name:      "rpc_duration_seconds",
+			Help:      "RPC requests completed by the client.",
+		},
+		[]string{"grpc_type", "grpc_target", "grpc_method", "grpc_code"})
+
+	prometheus.MustRegister(rpcDurationMetrics)
+}
+
+// Dial creates a client connection to the given target with a tracing and
+// metrics unary interceptor.
 func Dial(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	return DialContext(context.Background(), target, opts...)
 }
 
-// DialContext creates a client connection to the given target with a context and a tracing/logging interceptor.
+// DialContext creates a client connection to the given target with a context and
+// a tracing and metrics unary interceptor.
 func DialContext(ctx context.Context, target string, opts ...grpc.DialOption) (conn *grpc.ClientConn, err error) {
 	if len(opts) == 0 {
 		opts = make([]grpc.DialOption, 0)
 	}
 
-	opts = append(opts, grpc.WithUnaryInterceptor(unaryInterceptor))
+	opts = append(opts, grpc.WithUnaryInterceptor(unaryInterceptor(target)))
 
 	return grpc.DialContext(ctx, target, opts...)
 }
@@ -42,26 +67,36 @@ func (c *headersCarrier) Set(key, val string) {
 	c.Ctx = metadata.AppendToOutgoingContext(c.Ctx, key, val)
 }
 
-func unaryInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn,
-	invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-	span, ctx := trace.ChildSpan(ctx, trace.ComponentOpName(componentName, method), componentName, ext.SpanKindProducer,
-		ext.SpanKindProducer)
+func unaryInterceptor(target string) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		span, ctx := trace.ChildSpan(ctx,
+			trace.ComponentOpName(componentName, method),
+			componentName,
+			ext.SpanKindProducer,
+		)
+		carrier := headersCarrier{Ctx: ctx}
+		err := span.Tracer().Inject(span.Context(), opentracing.TextMap, &carrier)
+		if err != nil {
+			return fmt.Errorf("failed to inject tracing headers: %w", err)
+		}
 
-	carrier := headersCarrier{Ctx: ctx}
-	err := span.Tracer().Inject(span.Context(), opentracing.TextMap, &carrier)
-	if err != nil {
-		return fmt.Errorf("failed to inject tracing headers: %w", err)
+		corID := correlation.IDFromContext(carrier.Ctx)
+		ctx = metadata.AppendToOutgoingContext(carrier.Ctx, correlation.HeaderID, corID)
+		invokeTime := time.Now()
+		err = invoker(ctx, method, req, reply, cc, opts...)
+		invokeDuration := time.Since(invokeTime)
+
+		rpcStatus, _ := status.FromError(err) // codes.OK if err == nil, codes.Unknown if !ok
+		rpcDurationMetrics.
+			WithLabelValues(unary, target, method, rpcStatus.Code().String()).
+			Observe(invokeDuration.Seconds())
+
+		if err != nil {
+			trace.SpanError(span)
+			return err
+		}
+
+		trace.SpanSuccess(span)
+		return nil
 	}
-
-	corID := correlation.IDFromContext(carrier.Ctx)
-
-	ctx = metadata.AppendToOutgoingContext(carrier.Ctx, correlation.HeaderID, corID)
-
-	err = invoker(ctx, method, req, reply, cc, opts...)
-	if err != nil {
-		trace.SpanError(span)
-		return err
-	}
-	trace.SpanSuccess(span)
-	return nil
 }

--- a/client/grpc/grpc_test.go
+++ b/client/grpc/grpc_test.go
@@ -8,14 +8,18 @@ import (
 	"os"
 	"testing"
 
-	"github.com/beatlabs/patron/examples"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/mocktracer"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/beatlabs/patron/examples"
 )
 
 const (
@@ -27,12 +31,15 @@ var lis *bufconn.Listener
 
 type server struct{}
 
-func (s *server) SayHelloStream(_ *examples.HelloRequest, streamServer examples.Greeter_SayHelloStreamServer) error {
-	return nil
+func (s *server) SayHelloStream(_ *examples.HelloRequest, _ examples.Greeter_SayHelloStreamServer) error {
+	return status.Error(codes.Unavailable, "streaming not supported")
 }
 
-func (s *server) SayHello(_ context.Context, in *examples.HelloRequest) (*examples.HelloReply, error) {
-	return &examples.HelloReply{Message: fmt.Sprintf("Hello %s %s", in.Firstname, in.Lastname)}, nil
+func (s *server) SayHello(_ context.Context, req *examples.HelloRequest) (*examples.HelloReply, error) {
+	if req.Firstname == "" {
+		return nil, status.Error(codes.InvalidArgument, "first name cannot be empty")
+	}
+	return &examples.HelloReply{Message: fmt.Sprintf("Hello %s!", req.Firstname)}, nil
 }
 
 func TestMain(m *testing.M) {
@@ -97,24 +104,81 @@ func TestDialContext(t *testing.T) {
 
 func TestSayHello(t *testing.T) {
 	mtr := mocktracer.New()
-	defer mtr.Reset()
 	opentracing.SetGlobalTracer(mtr)
+
 	ctx := context.Background()
-	conn, err := DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithInsecure())
+	conn, err := DialContext(ctx, target, grpc.WithContextDialer(bufDialer), grpc.WithInsecure())
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, conn.Close())
 	}()
 
 	client := examples.NewGreeterClient(conn)
-	resp, err := client.SayHello(ctx, &examples.HelloRequest{Firstname: "John", Lastname: "Doe"})
-	require.NoError(t, err)
-	assert.Equal(t, "Hello John Doe", resp.GetMessage())
-	expected := map[string]interface{}{
-		"component": "grpc-client",
-		"error":     false,
-		"span.kind": ext.SpanKindEnum("producer"),
-		"version":   "dev",
+
+	tt := []struct {
+		name        string
+		req         *examples.HelloRequest
+		wantErr     bool
+		wantCode    codes.Code
+		wantMsg     string
+		wantCounter int
+	}{
+		{
+			name:        "ok",
+			req:         &examples.HelloRequest{Firstname: "John"},
+			wantErr:     false,
+			wantCode:    codes.OK,
+			wantMsg:     "Hello John!",
+			wantCounter: 1,
+		},
+		{
+			name:        "invalid",
+			req:         &examples.HelloRequest{},
+			wantErr:     true,
+			wantCode:    codes.InvalidArgument,
+			wantMsg:     "first name cannot be empty",
+			wantCounter: 1,
+		},
+		{
+			name:        "internal",
+			req:         nil, /* oops */
+			wantErr:     true,
+			wantCode:    codes.Internal,
+			wantMsg:     "grpc: error while marshaling: proto: Marshal called with nil",
+			wantCounter: 1,
+		},
 	}
-	assert.Equal(t, expected, mtr.FinishedSpans()[0].Tags())
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := client.SayHello(ctx, tc.req)
+			if tc.wantErr {
+				require.Nil(t, res)
+				require.Error(t, err)
+
+				rpcStatus, ok := status.FromError(err)
+				require.True(t, ok)
+				require.Equal(t, tc.wantCode, rpcStatus.Code())
+				require.Equal(t, tc.wantMsg, rpcStatus.Message())
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, res)
+				require.Equal(t, tc.wantMsg, res.GetMessage())
+			}
+
+			// Tracing
+			wantSpanTags := map[string]interface{}{
+				"component": "grpc-client",
+				"version":   "dev",
+				"span.kind": ext.SpanKindEnum("producer"),
+				"error":     tc.wantErr,
+			}
+			assert.Equal(t, wantSpanTags, mtr.FinishedSpans()[0].Tags())
+			mtr.Reset()
+
+			// Metrics
+			assert.Equal(t, tc.wantCounter, testutil.CollectAndCount(rpcDurationMetrics))
+			rpcDurationMetrics.Reset()
+		})
+	}
 }

--- a/client/grpc/grpc_test.go
+++ b/client/grpc/grpc_test.go
@@ -115,32 +115,28 @@ func TestSayHello(t *testing.T) {
 
 	client := examples.NewGreeterClient(conn)
 
-	tt := []struct {
-		name        string
+	tt := map[string]struct {
 		req         *examples.HelloRequest
 		wantErr     bool
 		wantCode    codes.Code
 		wantMsg     string
 		wantCounter int
 	}{
-		{
-			name:        "ok",
+		"ok": {
 			req:         &examples.HelloRequest{Firstname: "John"},
 			wantErr:     false,
 			wantCode:    codes.OK,
 			wantMsg:     "Hello John!",
 			wantCounter: 1,
 		},
-		{
-			name:        "invalid",
+		"invalid": {
 			req:         &examples.HelloRequest{},
 			wantErr:     true,
 			wantCode:    codes.InvalidArgument,
 			wantMsg:     "first name cannot be empty",
 			wantCounter: 1,
 		},
-		{
-			name:        "internal",
+		"internal": {
 			req:         nil, /* oops */
 			wantErr:     true,
 			wantCode:    codes.Internal,
@@ -149,8 +145,8 @@ func TestSayHello(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
+	for n, tc := range tt {
+		t.Run(n, func(t *testing.T) {
 			res, err := client.SayHello(ctx, tc.req)
 			if tc.wantErr {
 				require.Nil(t, res)


### PR DESCRIPTION
## Which problem is this PR solving?

This PR closes #358 [gRPC client Prometheus metrics](https://github.com/beatlabs/patron/issues/358)

The Patron gRPC client comes with tracing, but without Prometheus metrics. Having these metrics in place could prove particularly useful in some scenarios, e.g. when the RPC network is unreliable.

The Patron HTTP client already has Prometheus metrics - See [PR 354](https://github.com/beatlabs/patron/pull/354)

## Short description of the changes

Added Prometheus metrics to Patron gRPC client.

- Prometheus Histogram Vector with appropriate labels
- Updating Histogram accordingly for Unary RPC using existing unary interceptor
- Minor refactoring (imports, comments)
- Associated tests

## Note
The gRPC client provides a unary interceptor, which wraps RPC calls with the appropriate tracing mechanism, but _does not_ provide a stream interceptor. This PR provides Prometheus metrics for unary RPC - stream RPC would need to be handled separately.
