### PR TITLE
Log source fix

### DIFF
--- a/log/zerolog/logger.go
+++ b/log/zerolog/logger.go
@@ -38,8 +38,8 @@ type Logger struct {
 
 // New creates a new logger.
 func New(out io.Writer, lvl log.Level, f map[string]interface{}) log.Logger {
-	zl := zerolog.New(out).With().Timestamp().Logger().Hook(sourceHook{skip: 4})
-	zlf := zerolog.New(out).With().Timestamp().Logger().Hook(sourceHook{skip: 5})
+	zl := zerolog.New(out).With().Timestamp().Logger().Hook(sourceHook{skip: 6})
+	zlf := zerolog.New(out).With().Timestamp().Logger().Hook(sourceHook{skip: 7})
 
 	if len(f) == 0 {
 		f = make(map[string]interface{})

--- a/log/zerolog/logger_test.go
+++ b/log/zerolog/logger_test.go
@@ -135,7 +135,11 @@ func assertLog(t *testing.T, b bytes.Buffer, lvl log.Level, msg string) {
 	assert.Contains(t, b.String(), `"key":"value"`, b.String())
 	assert.Contains(t, b.String(), fmt.Sprintf(`"msg":"%s"`, msg), b.String())
 	assert.Regexp(t, regexp.MustCompile(`"time":".*"`), b.String())
-	assert.Regexp(t, regexp.MustCompile(`"src":"zerolog/logger_test.go:.*"`), b.String())
+	if lvl == log.PanicLevel {
+		assert.Regexp(t, regexp.MustCompile(`"src":"assert/assertions.go:.*"`), b.String())
+	} else {
+		assert.Regexp(t, regexp.MustCompile(`"src":"runtime/asm_amd64.s:.*"`), b.String())
+	}
 }
 
 func TestLog_Level(t *testing.T) {

--- a/log/zerolog/logger_test.go
+++ b/log/zerolog/logger_test.go
@@ -135,6 +135,8 @@ func assertLog(t *testing.T, b bytes.Buffer, lvl log.Level, msg string) {
 	assert.Contains(t, b.String(), `"key":"value"`, b.String())
 	assert.Contains(t, b.String(), fmt.Sprintf(`"msg":"%s"`, msg), b.String())
 	assert.Regexp(t, regexp.MustCompile(`"time":".*"`), b.String())
+	// Although the sources do not make sense, if we change them they will report wrong locations in the service.
+	// Pls leave them as they are.
 	if lvl == log.PanicLevel {
 		assert.Regexp(t, regexp.MustCompile(`"src":"assert/assertions.go:.*"`), b.String())
 	} else {


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Running the logger in a service revealed that we log as source the logger and not hte calling method.

## Short description of the changes

Increase skip on the logger and adjusted the tests accordingly. The tests log a source that is much lower because we are using the zerologger directly and not via patron's logger.
