### PR TITLE
Kafka group logging fix

### DIFF
--- a/component/async/kafka/group/group.go
+++ b/component/async/kafka/group/group.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Shopify/sarama"
 	"github.com/beatlabs/patron/component/async"
@@ -25,7 +26,6 @@ type Factory struct {
 
 // New constructor.
 func New(name, group string, topics, brokers []string, oo ...kafka.OptionFunc) (*Factory, error) {
-
 	if name == "" {
 		return nil, errors.New("name is required")
 	}
@@ -51,9 +51,7 @@ func (c *consumer) OutOfOrder() bool {
 
 // Create a new consumer.
 func (f *Factory) Create() (async.Consumer, error) {
-
 	config, err := kafka.DefaultSaramaConfig(f.name)
-
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +114,7 @@ func (c *consumer) Consume(ctx context.Context) (<-chan async.Message, <-chan er
 		return nil, nil, fmt.Errorf("failed to create consumer: %w", err)
 	}
 	c.cg = cg
-	log.Infof("consuming messages from topics '%#v' using group '%s'", c.topics, c.group)
+	log.Infof("consuming messages from topics '%s' using group '%s'", strings.Join(c.topics, ","), c.group)
 
 	chMsg := make(chan async.Message, c.config.Buffer)
 	chErr := make(chan error, c.config.Buffer)


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Fix logging from this:

```
"msg":"consuming messages from topics '[]string{\"topic1\",\"topic2\"}' using group 'consumer-group'"}
```

to this

```
"msg":"consuming messages from topics 'topic1,topic2' using group 'consumenr-group'"}
```

## Short description of the changes

Fixed logging.
