### PR TITLE
Update GoDoc of group.Retries

### DIFF
--- a/component/kafka/group/option.go
+++ b/component/kafka/group/option.go
@@ -28,9 +28,10 @@ func FailureStrategy(fs kafka.FailStrategy) OptionFunc {
 }
 
 // Retries sets the number of time a component should retry in case of an error.
-// These retries are useful when there are temporary connection issues, re-balancing, in the case
-// where a message batch fails to be processed and the failure strategy is set to kafka.ExitStrategy
-// or if there is any other reason that the component needs to reconnect.
+// These retries are depleted in these cases:
+// * when there are temporary connection issues
+// * a message batch fails to be processed through the user-defined processing function and the failure strategy is set to kafka.ExitStrategy
+// * any other reason for which the component needs to reconnect.
 func Retries(count uint) OptionFunc {
 	return func(c *Component) error {
 		c.retries = count


### PR DESCRIPTION
## Which problem is this PR solving?

Small GoDoc update, it currently mentions that retries in the Kafka consumer component are used for re-balancing but they are no more since v0.52.2.