### PR TITLE
feat: add ability to set custom headers to http error response

### DIFF
--- a/component/http/errors.go
+++ b/component/http/errors.go
@@ -9,6 +9,7 @@ import (
 type Error struct {
 	code    int
 	payload interface{}
+	headers map[string]string
 }
 
 // Error returns the actual message of the error.
@@ -19,62 +20,68 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("HTTP error with code: %d payload: %v", e.code, e.payload)
 }
 
+// WithHeaders adds headers to the error which will be added to the http response.
+func (e *Error) WithHeaders(headers map[string]string) *Error {
+	e.headers = headers
+	return e
+}
+
 // NewValidationError creates a new validation error with default payload.
 func NewValidationError() *Error {
-	return &Error{http.StatusBadRequest, http.StatusText(http.StatusBadRequest)}
+	return &Error{code: http.StatusBadRequest, payload: http.StatusText(http.StatusBadRequest)}
 }
 
 // NewValidationErrorWithPayload creates a new validation error with the specified payload.
 func NewValidationErrorWithPayload(payload interface{}) *Error {
-	return &Error{http.StatusBadRequest, payload}
+	return &Error{code: http.StatusBadRequest, payload: payload}
 }
 
 // NewUnauthorizedError creates a new validation error with default payload.
 func NewUnauthorizedError() *Error {
-	return &Error{http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized)}
+	return &Error{code: http.StatusUnauthorized, payload: http.StatusText(http.StatusUnauthorized)}
 }
 
 // NewUnauthorizedErrorWithPayload creates a new unauthorized error with the specified payload.
 func NewUnauthorizedErrorWithPayload(payload interface{}) *Error {
-	return &Error{http.StatusUnauthorized, payload}
+	return &Error{code: http.StatusUnauthorized, payload: payload}
 }
 
 // NewForbiddenError creates a new forbidden error with default payload.
 func NewForbiddenError() *Error {
-	return &Error{http.StatusForbidden, http.StatusText(http.StatusForbidden)}
+	return &Error{code: http.StatusForbidden, payload: http.StatusText(http.StatusForbidden)}
 }
 
 // NewForbiddenErrorWithPayload creates a new forbidden error with the specified payload.
 func NewForbiddenErrorWithPayload(payload interface{}) *Error {
-	return &Error{http.StatusForbidden, payload}
+	return &Error{code: http.StatusForbidden, payload: payload}
 }
 
 // NewNotFoundError creates a new not found error with default payload.
 func NewNotFoundError() *Error {
-	return &Error{http.StatusNotFound, http.StatusText(http.StatusNotFound)}
+	return &Error{code: http.StatusNotFound, payload: http.StatusText(http.StatusNotFound)}
 }
 
 // NewNotFoundErrorWithPayload creates a new not found error with the specified payload.
 func NewNotFoundErrorWithPayload(payload interface{}) *Error {
-	return &Error{http.StatusNotFound, payload}
+	return &Error{code: http.StatusNotFound, payload: payload}
 }
 
 // NewServiceUnavailableError creates a new service unavailable error with default payload.
 func NewServiceUnavailableError() *Error {
-	return &Error{http.StatusServiceUnavailable, http.StatusText(http.StatusServiceUnavailable)}
+	return &Error{code: http.StatusServiceUnavailable, payload: http.StatusText(http.StatusServiceUnavailable)}
 }
 
 // NewServiceUnavailableErrorWithPayload creates a new service unavailable error with the specified payload.
 func NewServiceUnavailableErrorWithPayload(payload interface{}) *Error {
-	return &Error{http.StatusServiceUnavailable, payload}
+	return &Error{code: http.StatusServiceUnavailable, payload: payload}
 }
 
 // NewError creates a new error with default Internal Server Error payload.
 func NewError() *Error {
-	return &Error{http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError)}
+	return &Error{code: http.StatusInternalServerError, payload: http.StatusText(http.StatusInternalServerError)}
 }
 
 // NewErrorWithCodeAndPayload creates a fully customizable error with the specified status code and payload.
 func NewErrorWithCodeAndPayload(code int, payload interface{}) *Error {
-	return &Error{code, payload}
+	return &Error{code: code, payload: payload}
 }

--- a/component/http/errors_test.go
+++ b/component/http/errors_test.go
@@ -1,10 +1,20 @@
 package http
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestError_WithHeaders(t *testing.T) {
+	header := "Retry-After"
+	err := NewErrorWithCodeAndPayload(http.StatusTooManyRequests, "wait").
+		WithHeaders(map[string]string{header: "1628002707"})
+	assert.EqualError(t, err, "HTTP error with code: 429 payload: wait")
+	assert.Equal(t, 429, err.code)
+	assert.Equal(t, "1628002707", err.headers[header])
+}
 
 func TestValidationError(t *testing.T) {
 	err := NewValidationError()

--- a/component/http/handler.go
+++ b/component/http/handler.go
@@ -188,6 +188,9 @@ func handleError(logger log.Logger, w http.ResponseWriter, enc encoding.EncodeFu
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
+		for k, v := range err.headers {
+			w.Header().Set(k, v)
+		}
 		w.WriteHeader(err.code)
 		if _, err := w.Write(p); err != nil {
 			logger.Errorf("failed to write Response: %v", err)

--- a/component/http/handler_test.go
+++ b/component/http/handler_test.go
@@ -215,10 +215,8 @@ func Test_handleError(t *testing.T) {
 			rsp := httptest.NewRecorder()
 			handleError(log.Sub(nil), rsp, tt.args.enc, tt.args.err)
 			assert.Equal(t, tt.expectedCode, rsp.Code)
-			if tt.expectedHeaders != nil {
-				for k, v := range tt.expectedHeaders {
-					assert.Equal(t, v, rsp.Header().Get(k))
-				}
+			for k, v := range tt.expectedHeaders {
+				assert.Equal(t, v, rsp.Header().Get(k))
 			}
 		})
 	}

--- a/component/http/handler_test.go
+++ b/component/http/handler_test.go
@@ -195,24 +195,31 @@ func Test_handleError(t *testing.T) {
 		enc encoding.EncodeFunc
 	}
 	tests := []struct {
-		name         string
-		args         args
-		expectedCode int
+		name            string
+		args            args
+		expectedCode    int
+		expectedHeaders map[string]string
 	}{
-		{"bad request", args{err: NewValidationError(), enc: json.Encode}, http.StatusBadRequest},
-		{"unauthorized request", args{err: NewUnauthorizedError(), enc: json.Encode}, http.StatusUnauthorized},
-		{"forbidden request", args{err: NewForbiddenError(), enc: json.Encode}, http.StatusForbidden},
-		{"not found error", args{err: NewNotFoundError(), enc: json.Encode}, http.StatusNotFound},
-		{"service unavailable error", args{err: NewServiceUnavailableError(), enc: json.Encode}, http.StatusServiceUnavailable},
-		{"internal server error", args{err: NewError(), enc: json.Encode}, http.StatusInternalServerError},
-		{"default error", args{err: errors.New("test"), enc: json.Encode}, http.StatusInternalServerError},
-		{"Payload encoding error", args{err: NewErrorWithCodeAndPayload(http.StatusBadRequest, make(chan int)), enc: json.Encode}, http.StatusInternalServerError},
+		{name: "bad request", args: args{err: NewValidationError(), enc: json.Encode}, expectedCode: http.StatusBadRequest},
+		{name: "too many requests with header", args: args{err: NewErrorWithCodeAndPayload(http.StatusTooManyRequests, "test").WithHeaders(map[string]string{"Retry-After": "1628027625"}), enc: json.Encode}, expectedCode: http.StatusTooManyRequests, expectedHeaders: map[string]string{"Retry-After": "1628027625"}},
+		{name: "unauthorized request", args: args{err: NewUnauthorizedError(), enc: json.Encode}, expectedCode: http.StatusUnauthorized},
+		{name: "forbidden request", args: args{err: NewForbiddenError(), enc: json.Encode}, expectedCode: http.StatusForbidden},
+		{name: "not found error", args: args{err: NewNotFoundError(), enc: json.Encode}, expectedCode: http.StatusNotFound},
+		{name: "service unavailable error", args: args{err: NewServiceUnavailableError(), enc: json.Encode}, expectedCode: http.StatusServiceUnavailable},
+		{name: "internal server error", args: args{err: NewError(), enc: json.Encode}, expectedCode: http.StatusInternalServerError},
+		{name: "default error", args: args{err: errors.New("test"), enc: json.Encode}, expectedCode: http.StatusInternalServerError},
+		{name: "Payload encoding error", args: args{err: NewErrorWithCodeAndPayload(http.StatusBadRequest, make(chan int)), enc: json.Encode}, expectedCode: http.StatusInternalServerError},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rsp := httptest.NewRecorder()
 			handleError(log.Sub(nil), rsp, tt.args.enc, tt.args.err)
 			assert.Equal(t, tt.expectedCode, rsp.Code)
+			if tt.expectedHeaders != nil {
+				for k, v := range tt.expectedHeaders {
+					assert.Equal(t, v, rsp.Header().Get(k))
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

The absence of the capability to set custom headers for an error HTTP response.

Actual response with new code
<img width="1295" alt="Screen Shot 2021-08-03 at 16 52 42" src="https://user-images.githubusercontent.com/6284234/128164771-67460c9f-0457-4c09-9872-846468913d5e.png">


## Short description of the changes

This PR adds a `headers` property to the HTTP `Error` struct. It adds a method to set those headers when initializing the `Error` instance and then sets the headers when writing the response.
