### PR TITLE
fix sql client metric label: 'success' should be true on success

### DIFF
--- a/client/sql/sql.go
+++ b/client/sql/sql.go
@@ -493,5 +493,5 @@ func parseDSN(dsn string) DSNInfo {
 
 func observeDuration(span opentracing.Span, start time.Time, op string, err error) {
 	trace.SpanComplete(span, err)
-	opDurationMetrics.WithLabelValues(op, strconv.FormatBool(err != nil)).Observe(time.Since(start).Seconds())
+	opDurationMetrics.WithLabelValues(op, strconv.FormatBool(err == nil)).Observe(time.Since(start).Seconds())
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Incorrect value for label `success` when sending metrics from the SQL client: the boolean value is inverted (`false` on success and `true` on errors)

## Short description of the changes

Fix the typo when sending metric.
