### PR TITLE
Require Sarama configuration for all producers/consumers [breaking]

### DIFF
--- a/client/kafka/v2/kafka_test.go
+++ b/client/kafka/v2/kafka_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/Shopify/sarama"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,14 +19,14 @@ func TestBuilder_Create(t *testing.T) {
 		expectedErr string
 	}{
 		"missing brokers": {args: args{brokers: nil, cfg: sarama.NewConfig()}, expectedErr: "brokers are empty or have an empty value\n"},
-		"missing config":  {args: args{brokers: []string{"123"}, cfg: nil}, expectedErr: "config is nil\n"},
+		"missing config":  {args: args{brokers: []string{"123"}, cfg: nil}, expectedErr: "no Sarama configuration specified\n"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := New(tt.args.brokers).WithConfig(tt.args.cfg).Create()
+			got, err := New(tt.args.brokers, tt.args.cfg).Create()
 
-			assert.EqualError(t, err, tt.expectedErr)
-			assert.Nil(t, got)
+			require.EqualError(t, err, tt.expectedErr)
+			require.Nil(t, got)
 		})
 	}
 }
@@ -42,15 +41,15 @@ func TestBuilder_CreateAsync(t *testing.T) {
 		expectedErr string
 	}{
 		"missing brokers": {args: args{brokers: nil, cfg: sarama.NewConfig()}, expectedErr: "brokers are empty or have an empty value\n"},
-		"missing config":  {args: args{brokers: []string{"123"}, cfg: nil}, expectedErr: "config is nil\n"},
+		"missing config":  {args: args{brokers: []string{"123"}, cfg: nil}, expectedErr: "no Sarama configuration specified\n"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, chErr, err := New(tt.args.brokers).WithConfig(tt.args.cfg).CreateAsync()
+			got, chErr, err := New(tt.args.brokers, tt.args.cfg).CreateAsync()
 
-			assert.EqualError(t, err, tt.expectedErr)
-			assert.Nil(t, got)
-			assert.Nil(t, chErr)
+			require.EqualError(t, err, tt.expectedErr)
+			require.Nil(t, got)
+			require.Nil(t, chErr)
 		})
 	}
 }

--- a/client/kafka/v2/kafka_test.go
+++ b/client/kafka/v2/kafka_test.go
@@ -1,10 +1,13 @@
 package v2
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Shopify/sarama"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuilder_Create(t *testing.T) {
@@ -50,4 +53,26 @@ func TestBuilder_CreateAsync(t *testing.T) {
 			assert.Nil(t, chErr)
 		})
 	}
+}
+
+func Test_DefaultConsumerSaramaConfig(t *testing.T) {
+	sc, err := DefaultConsumerSaramaConfig("name", true)
+	require.NoError(t, err)
+	require.True(t, strings.HasSuffix(sc.ClientID, fmt.Sprintf("-%s", "name")))
+	require.Equal(t, sarama.ReadCommitted, sc.Consumer.IsolationLevel)
+
+	sc, err = DefaultConsumerSaramaConfig("name", false)
+	require.NoError(t, err)
+	require.NotEqual(t, sarama.ReadCommitted, sc.Consumer.IsolationLevel)
+}
+
+func TestDefaultProducerSaramaConfig(t *testing.T) {
+	sc, err := DefaultProducerSaramaConfig("name", true)
+	require.NoError(t, err)
+	require.True(t, strings.HasSuffix(sc.ClientID, fmt.Sprintf("-%s", "name")))
+	require.True(t, sc.Producer.Idempotent)
+
+	sc, err = DefaultProducerSaramaConfig("name", false)
+	require.NoError(t, err)
+	require.False(t, sc.Producer.Idempotent)
 }

--- a/component/async/kafka/group/group_test.go
+++ b/component/async/kafka/group/group_test.go
@@ -18,13 +18,19 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Parallel()
+
+	defaultSaramaCfg, err := v2.DefaultConsumerSaramaConfig("test-consumer", false)
+	require.Nil(t, err)
+
 	brokers := []string{"192.168.1.1"}
 	type args struct {
-		name    string
-		brokers []string
-		topics  []string
-		group   string
-		options []kafka.OptionFunc
+		name      string
+		brokers   []string
+		topics    []string
+		group     string
+		saramaCfg *sarama.Config
+		options   []kafka.OptionFunc
 	}
 	tests := []struct {
 		name    string
@@ -33,49 +39,54 @@ func TestNew(t *testing.T) {
 	}{
 		{
 			name:    "fails with missing name",
-			args:    args{name: "", brokers: brokers, topics: []string{"topic1"}, group: "group1"},
+			args:    args{name: "", brokers: brokers, topics: []string{"topic1"}, group: "group1", saramaCfg: defaultSaramaCfg},
 			wantErr: true,
 		},
 		{
 			name:    "fails with missing brokers",
-			args:    args{name: "test", brokers: []string{}, topics: []string{"topic1"}, group: "group1"},
+			args:    args{name: "test", brokers: []string{}, topics: []string{"topic1"}, group: "group1", saramaCfg: defaultSaramaCfg},
 			wantErr: true,
 		},
 		{
 			name:    "fails with empty broker",
-			args:    args{name: "test", brokers: []string{" "}, topics: []string{"topic1"}, group: "group1"},
+			args:    args{name: "test", brokers: []string{" "}, topics: []string{"topic1"}, group: "group1", saramaCfg: defaultSaramaCfg},
 			wantErr: true,
 		},
 		{
 			name:    "fails with missing topics",
-			args:    args{name: "test", brokers: brokers, topics: nil, group: "group1"},
+			args:    args{name: "test", brokers: brokers, topics: nil, group: "group1", saramaCfg: defaultSaramaCfg},
 			wantErr: true,
 		},
 		{
 			name:    "fails with one empty topic",
-			args:    args{name: "test", brokers: brokers, topics: []string{"topic1", ""}, group: "group1"},
+			args:    args{name: "test", brokers: brokers, topics: []string{"topic1", ""}, group: "group1", saramaCfg: defaultSaramaCfg},
 			wantErr: true,
 		},
 		{
 			name:    "fails with missing group",
-			args:    args{name: "test", brokers: brokers, topics: []string{"topic1"}, group: ""},
+			args:    args{name: "test", brokers: brokers, topics: []string{"topic1"}, group: "", saramaCfg: defaultSaramaCfg},
+			wantErr: true,
+		},
+		{
+			name:    "fails with nil Sarama config",
+			args:    args{name: "test", brokers: brokers, topics: []string{"topic1"}, group: "group1", saramaCfg: nil},
 			wantErr: true,
 		},
 		{
 			name:    "success",
-			args:    args{name: "test", brokers: brokers, topics: []string{"topic1"}, group: "group1"},
+			args:    args{name: "test", brokers: brokers, topics: []string{"topic1"}, group: "group1", saramaCfg: defaultSaramaCfg},
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := New(tt.args.name, tt.args.group, tt.args.topics, tt.args.brokers, tt.args.options...)
+			got, err := New(tt.args.name, tt.args.group, tt.args.topics, tt.args.brokers, tt.args.saramaCfg, tt.args.options...)
 			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Nil(t, got)
+				require.Error(t, err)
+				require.Nil(t, got)
 			} else {
-				assert.NoError(t, err)
-				assert.NotNil(t, got)
+				require.NoError(t, err)
+				require.NotNil(t, got)
 			}
 		})
 	}
@@ -83,12 +94,6 @@ func TestNew(t *testing.T) {
 
 func TestFactory_Create(t *testing.T) {
 	t.Parallel()
-
-	cfgOpt := func(cc *kafka.ConsumerConfig) error {
-		var err error
-		cc.SaramaConfig, err = v2.DefaultConsumerSaramaConfig("test-consumer", false)
-		return err
-	}
 
 	type fields struct {
 		clientName string
@@ -105,7 +110,6 @@ func TestFactory_Create(t *testing.T) {
 				clientName: "clientA",
 				topics:     []string{"topicA"},
 				brokers:    []string{"192.168.1.1"},
-				oo:         []kafka.OptionFunc{cfgOpt},
 			},
 			wantErr: false,
 		},
@@ -114,16 +118,7 @@ func TestFactory_Create(t *testing.T) {
 				clientName: "clientB",
 				topics:     []string{"topicA"},
 				brokers:    []string{"192.168.1.1"},
-				oo:         []kafka.OptionFunc{cfgOpt, kafka.Buffer(-100)},
-			},
-			wantErr: true,
-		},
-		"failed with missing Sarama configuration": {
-			fields: fields{
-				clientName: "clientB",
-				topics:     []string{"topicA"},
-				brokers:    []string{"192.168.1.1"},
-				oo:         []kafka.OptionFunc{},
+				oo:         []kafka.OptionFunc{kafka.Buffer(-100)},
 			},
 			wantErr: true,
 		},
@@ -132,12 +127,12 @@ func TestFactory_Create(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			f := &Factory{
-				name:    tt.fields.clientName,
-				topics:  tt.fields.topics,
-				brokers: tt.fields.brokers,
-				oo:      tt.fields.oo,
-			}
+			saramaCfg, err := v2.DefaultConsumerSaramaConfig(tt.fields.clientName, false)
+			require.Nil(t, err)
+
+			f, err := New(tt.fields.clientName, "no-group", tt.fields.topics, tt.fields.brokers, saramaCfg, tt.fields.oo...)
+			require.NoError(t, err)
+
 			got, err := f.Create()
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -149,7 +144,7 @@ func TestFactory_Create(t *testing.T) {
 				assert.True(t, ok, "consumer is not of type group.consumer")
 				assert.Equal(t, tt.fields.brokers, consumer.config.Brokers)
 				assert.Equal(t, tt.fields.topics, consumer.topics)
-				assert.True(t, strings.HasSuffix(consumer.config.SaramaConfig.ClientID, tt.fields.clientName))
+				assert.True(t, strings.HasSuffix(consumer.config.SaramaConfig.ClientID, tt.fields.clientName), "clientID %q does not have suffix %q", consumer.config.SaramaConfig.ClientID, tt.fields.clientName)
 				assert.False(t, got.OutOfOrder())
 			}
 		})
@@ -187,6 +182,7 @@ func (m *mockConsumerSession) MarkMessage(*sarama.ConsumerMessage, string) {}
 func (m *mockConsumerSession) Context() context.Context                    { return context.Background() }
 
 func TestHandler_ConsumeClaim(t *testing.T) {
+	t.Parallel()
 
 	tests := []struct {
 		name    string
@@ -201,17 +197,19 @@ func TestHandler_ConsumeClaim(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			chMsg := make(chan async.Message, 1)
 			h := handler{messages: chMsg, consumer: &consumer{}}
 
 			err := h.ConsumeClaim(&mockConsumerSession{}, &mockConsumerClaim{tt.msgs})
 
 			if tt.wantErr {
-				assert.Error(t, err, tt.error)
+				require.Error(t, err, tt.error)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				ch := <-chMsg
-				assert.NotNil(t, ch)
+				require.NotNil(t, ch)
 			}
 		})
 	}
@@ -251,16 +249,14 @@ func versionedConsumerMessage(value string, header *sarama.RecordHeader, version
 }
 
 func TestConsumer_ConsumeFailedBroker(t *testing.T) {
-	f, err := New("name", "group", []string{"topic"}, []string{"1", "2"}, func(cc *kafka.ConsumerConfig) error {
-		var err error
-		cc.SaramaConfig, err = v2.DefaultConsumerSaramaConfig("test-consumer", false)
-		return err
-	})
-	assert.NoError(t, err)
+	saramaCfg, err := v2.DefaultConsumerSaramaConfig("test-consumer", false)
+	require.NoError(t, err)
+	f, err := New("name", "group", []string{"topic"}, []string{"1", "2"}, saramaCfg)
+	require.NoError(t, err)
 	c, err := f.Create()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	chMsg, chErr, err := c.Consume(context.Background())
-	assert.Nil(t, chMsg)
-	assert.Nil(t, chErr)
-	assert.Error(t, err)
+	require.Nil(t, chMsg)
+	require.Nil(t, chErr)
+	require.Error(t, err)
 }

--- a/component/async/kafka/kafka.go
+++ b/component/async/kafka/kafka.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"time"
 
@@ -146,21 +145,6 @@ func (m *message) Payload() []byte {
 // Raw returns tha Kafka message.
 func (m *message) Raw() interface{} {
 	return m.msg
-}
-
-// DefaultSaramaConfig function creates a sarama config object with the default configuration set up.
-func DefaultSaramaConfig(name string) (*sarama.Config, error) {
-	host, err := os.Hostname()
-	if err != nil {
-		return nil, errors.New("failed to get hostname")
-	}
-
-	config := sarama.NewConfig()
-	config.ClientID = fmt.Sprintf("%s-%s", host, name)
-	config.Consumer.Return.Errors = true
-	config.Version = sarama.V0_11_0_0
-
-	return config, nil
 }
 
 // ClaimMessage transforms a sarama.ConsumerMessage to an async.Message.

--- a/component/async/kafka/kafka_test.go
+++ b/component/async/kafka/kafka_test.go
@@ -21,12 +21,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDefaultSaramaConfig(t *testing.T) {
-	sc, err := DefaultSaramaConfig("name")
-	assert.NoError(t, err)
-	assert.True(t, strings.HasSuffix(sc.ClientID, fmt.Sprintf("-%s", "name")))
-}
-
 func Test_determineContentType(t *testing.T) {
 	type args struct {
 		hdr []*sarama.RecordHeader

--- a/component/async/kafka/simple/simple_test.go
+++ b/component/async/kafka/simple/simple_test.go
@@ -15,12 +15,18 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Parallel()
+
+	defaultSaramaCfg, err := v2.DefaultConsumerSaramaConfig("test-consumer", false)
+	require.Nil(t, err)
+
 	brokers := []string{"192.168.1.1"}
 	type args struct {
-		name    string
-		brokers []string
-		topic   string
-		options []kafka.OptionFunc
+		name      string
+		brokers   []string
+		topic     string
+		saramaCfg *sarama.Config
+		options   []kafka.OptionFunc
 	}
 	tests := []struct {
 		name    string
@@ -29,12 +35,12 @@ func TestNew(t *testing.T) {
 	}{
 		{
 			name:    "fails with missing name",
-			args:    args{name: "", brokers: brokers, topic: "topic1"},
+			args:    args{name: "", brokers: brokers, topic: "topic1", saramaCfg: defaultSaramaCfg},
 			wantErr: true,
 		},
 		{
 			name:    "fails with missing brokers",
-			args:    args{name: "test", brokers: []string{}, topic: "topic1"},
+			args:    args{name: "test", brokers: []string{}, topic: "topic1", saramaCfg: defaultSaramaCfg},
 			wantErr: true,
 		},
 		{
@@ -44,40 +50,45 @@ func TestNew(t *testing.T) {
 		},
 		{
 			name:    "fails with two brokers - one of the is empty",
-			args:    args{name: "test", brokers: []string{" ", "broker2"}, topic: "topic1"},
+			args:    args{name: "test", brokers: []string{" ", "broker2"}, topic: "topic1", saramaCfg: defaultSaramaCfg},
 			wantErr: true,
 		},
 		{
 			name:    "fails with missing topics",
-			args:    args{name: "test", brokers: brokers, topic: ""},
+			args:    args{name: "test", brokers: brokers, topic: "", saramaCfg: defaultSaramaCfg},
+			wantErr: true,
+		},
+		{
+			name:    "fails with nil Sarama config",
+			args:    args{name: "test", brokers: brokers, topic: "", saramaCfg: nil},
 			wantErr: true,
 		},
 		{
 			name:    "success",
-			args:    args{name: "test", brokers: brokers, topic: "topic1"},
+			args:    args{name: "test", brokers: brokers, topic: "topic1", saramaCfg: defaultSaramaCfg},
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := New(tt.args.name, tt.args.topic, tt.args.brokers, tt.args.options...)
+			t.Parallel()
+
+			got, err := New(tt.args.name, tt.args.topic, tt.args.brokers, tt.args.saramaCfg, tt.args.options...)
 			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Nil(t, got)
+				require.Error(t, err)
+				require.Nil(t, got)
 			} else {
-				assert.NoError(t, err)
-				assert.NotNil(t, got)
+				require.NoError(t, err)
+				require.NotNil(t, got)
 			}
 		})
 	}
 }
 
 func TestFactory_Create(t *testing.T) {
-	cfgOpt := func(cc *kafka.ConsumerConfig) error {
-		var err error
-		cc.SaramaConfig, err = v2.DefaultConsumerSaramaConfig("test-consumer", false)
-		return err
-	}
+	saramaCfg, err := v2.DefaultConsumerSaramaConfig("test-consumer", false)
+	require.Nil(t, err)
+
 	type fields struct {
 		oo []kafka.OptionFunc
 	}
@@ -86,17 +97,14 @@ func TestFactory_Create(t *testing.T) {
 		fields  fields
 		wantErr bool
 	}{
-		{name: "success", wantErr: false, fields: fields{oo: []kafka.OptionFunc{cfgOpt}}},
+		{name: "success", wantErr: false},
 		{name: "failed with invalid option", fields: fields{oo: []kafka.OptionFunc{kafka.Buffer(-100)}}, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := &Factory{
-				name:    "test",
-				topic:   "topic",
-				brokers: []string{"192.168.1.1"},
-				oo:      tt.fields.oo,
-			}
+			f, err := New("test", "topic", []string{"192.168.1.1"}, saramaCfg, tt.fields.oo...)
+			require.NoError(t, err)
+
 			got, err := f.Create()
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/component/async/kafka/simple/simple_test.go
+++ b/component/async/kafka/simple/simple_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	v2 "github.com/beatlabs/patron/client/kafka/v2"
 	"github.com/beatlabs/patron/component/async/kafka"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,6 +73,11 @@ func TestNew(t *testing.T) {
 }
 
 func TestFactory_Create(t *testing.T) {
+	cfgOpt := func(cc *kafka.ConsumerConfig) error {
+		var err error
+		cc.SaramaConfig, err = v2.DefaultConsumerSaramaConfig("test-consumer", false)
+		return err
+	}
 	type fields struct {
 		oo []kafka.OptionFunc
 	}
@@ -80,7 +86,7 @@ func TestFactory_Create(t *testing.T) {
 		fields  fields
 		wantErr bool
 	}{
-		{name: "success", wantErr: false},
+		{name: "success", wantErr: false, fields: fields{oo: []kafka.OptionFunc{cfgOpt}}},
 		{name: "failed with invalid option", fields: fields{oo: []kafka.OptionFunc{kafka.Buffer(-100)}}, wantErr: true},
 	}
 	for _, tt := range tests {

--- a/component/kafka/group/component.go
+++ b/component/kafka/group/component.go
@@ -100,7 +100,7 @@ func messageStatusCountInc(status, group, topic string) {
 // The default failure strategy is the ExitStrategy.
 // The default batch size is 1 and the batch timeout is 100ms.
 // The default number of retries is 0 and the retry wait is 0.
-func New(name, group string, brokers, topics []string, proc kafka.BatchProcessorFunc, oo ...OptionFunc) (*Component, error) {
+func New(name, group string, brokers, topics []string, proc kafka.BatchProcessorFunc, saramaCfg *sarama.Config, oo ...OptionFunc) (*Component, error) {
 	var errs []error
 	if name == "" {
 		errs = append(errs, errors.New("name is required"))
@@ -108,6 +108,10 @@ func New(name, group string, brokers, topics []string, proc kafka.BatchProcessor
 
 	if group == "" {
 		errs = append(errs, errors.New("consumer group is required"))
+	}
+
+	if saramaCfg == nil {
+		return nil, errors.New("no Sarama configuration specified")
 	}
 
 	if validation.IsStringSliceEmpty(brokers) {
@@ -137,6 +141,7 @@ func New(name, group string, brokers, topics []string, proc kafka.BatchProcessor
 		batchSize:    defaultBatchSize,
 		batchTimeout: defaultBatchTimeout,
 		failStrategy: defaultFailureStrategy,
+		saramaConfig: saramaCfg,
 	}
 
 	for _, optionFunc := range oo {
@@ -144,10 +149,6 @@ func New(name, group string, brokers, topics []string, proc kafka.BatchProcessor
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	if cmp.saramaConfig == nil {
-		return nil, errors.New("sarama configuration option is required")
 	}
 
 	return cmp, nil

--- a/component/kafka/group/component_test.go
+++ b/component/kafka/group/component_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Parallel()
+
 	saramaCfg := sarama.NewConfig()
 	// consumer will commit every batch in a blocking operation
 	saramaCfg.Consumer.Offsets.AutoCommit.Enable = false
@@ -86,22 +88,29 @@ func TestNew(t *testing.T) {
 		},
 		{
 			name:    "failed, invalid retry retry timeout",
-			args:    args{name: "name", group: "grp", brokers: []string{"localhost:9092"}, topics: []string{"topicone"}, p: proc.Process, batchSize: 1, batchTimeout: time.Second, retryWait: -2},
+			args:    args{name: "name", group: "grp", brokers: []string{"localhost:9092"}, topics: []string{"topicone"}, p: proc.Process, batchSize: 1, batchTimeout: time.Second, retryWait: -2, saramaCfg: saramaCfg},
 			wantErr: true,
 		},
 		{
 			name:    "failed, invalid batch size",
-			args:    args{name: "name", group: "grp", brokers: []string{"localhost:9092"}, topics: []string{"topicone"}, p: proc.Process, batchSize: 0, batchTimeout: time.Second, retryWait: 2},
+			args:    args{name: "name", group: "grp", brokers: []string{"localhost:9092"}, topics: []string{"topicone"}, p: proc.Process, batchSize: 0, batchTimeout: time.Second, retryWait: 2, saramaCfg: saramaCfg},
 			wantErr: true,
 		},
 		{
 			name:    "failed, invalid batch timeout",
-			args:    args{name: "name", group: "grp", brokers: []string{"localhost:9092"}, topics: []string{"topicone"}, p: proc.Process, batchSize: 1, batchTimeout: -2, retryWait: 2},
+			args:    args{name: "name", group: "grp", brokers: []string{"localhost:9092"}, topics: []string{"topicone"}, p: proc.Process, batchSize: 1, batchTimeout: -2, retryWait: 2, saramaCfg: saramaCfg},
+			wantErr: true,
+		},
+		{
+			name:    "failed, no sarama configuration",
+			args:    args{name: "name", group: "grp", brokers: []string{"localhost:9092"}, topics: []string{"topicone"}, p: proc.Process, batchSize: 10, batchTimeout: time.Second, retryWait: 2, saramaCfg: nil},
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := New(
 				tt.args.name,
 				tt.args.group,

--- a/component/kafka/group/component_test.go
+++ b/component/kafka/group/component_test.go
@@ -117,12 +117,12 @@ func TestNew(t *testing.T) {
 				tt.args.brokers,
 				tt.args.topics,
 				tt.args.p,
+				tt.args.saramaCfg,
 				FailureStrategy(tt.args.fs),
 				Retries(tt.args.retries),
 				RetryWait(tt.args.retryWait),
 				BatchSize(tt.args.batchSize),
 				BatchTimeout(tt.args.batchTimeout),
-				SaramaConfig(tt.args.saramaCfg),
 				CommitSync())
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/component/kafka/group/option.go
+++ b/component/kafka/group/option.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/Shopify/sarama"
 	"github.com/beatlabs/patron/component/kafka"
 	"github.com/beatlabs/patron/log"
 )
@@ -69,18 +68,6 @@ func BatchTimeout(timeout time.Duration) OptionFunc {
 			return errors.New("batch timeout should greater than or equal to zero")
 		}
 		c.batchTimeout = timeout
-		return nil
-	}
-}
-
-// SaramaConfig specifies a Sarama consumer config. Use this to set consumer config on Sarama level.
-// Check the Sarama config documentation for more config options.
-func SaramaConfig(cfg *sarama.Config) OptionFunc {
-	return func(c *Component) error {
-		if cfg == nil {
-			return errors.New("nil sarama configuration provided")
-		}
-		c.saramaConfig = cfg
 		return nil
 	}
 }

--- a/component/kafka/group/option.go
+++ b/component/kafka/group/option.go
@@ -73,8 +73,8 @@ func BatchTimeout(timeout time.Duration) OptionFunc {
 	}
 }
 
-// SaramaConfig specifies a sarama consumer config. Use this to set consumer config on sarama level.
-// Check the sarama config documentation for more config options.
+// SaramaConfig specifies a Sarama consumer config. Use this to set consumer config on Sarama level.
+// Check the Sarama config documentation for more config options.
 func SaramaConfig(cfg *sarama.Config) OptionFunc {
 	return func(c *Component) error {
 		if cfg == nil {

--- a/component/kafka/group/option_test.go
+++ b/component/kafka/group/option_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Shopify/sarama"
 	"github.com/beatlabs/patron/component/kafka"
 	"github.com/stretchr/testify/assert"
 )
@@ -137,18 +136,4 @@ func TestBatchTimeout(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestSaramaConfig(t *testing.T) {
-	saramaCfg := sarama.NewConfig()
-	// batches will be responsible for committing
-	saramaCfg.Consumer.Offsets.AutoCommit.Enable = false
-	saramaCfg.Consumer.Offsets.Initial = sarama.OffsetOldest
-	saramaCfg.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategySticky
-	saramaCfg.Net.DialTimeout = 15 * time.Second
-	saramaCfg.Version = sarama.V2_6_0_0
-	c := &Component{}
-	err := SaramaConfig(saramaCfg)(c)
-	assert.NoError(t, err)
-	assert.Equal(t, c.saramaConfig, saramaCfg)
 }

--- a/component/kafka/kafka.go
+++ b/component/kafka/kafka.go
@@ -3,9 +3,6 @@ package kafka
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"os"
 
 	"github.com/Shopify/sarama"
 	"github.com/opentracing/opentracing-go"
@@ -86,19 +83,4 @@ type batch struct {
 // Messages of the batch.
 func (b batch) Messages() []Message {
 	return b.messages
-}
-
-// DefaultSaramaConfig function creates a sarama config object with the default configuration set up.
-func DefaultSaramaConfig(name string) (*sarama.Config, error) {
-	host, err := os.Hostname()
-	if err != nil {
-		return nil, errors.New("failed to get hostname")
-	}
-
-	config := sarama.NewConfig()
-	config.ClientID = fmt.Sprintf("%s-%s", host, name)
-	config.Consumer.Return.Errors = true
-	config.Version = sarama.V0_11_0_0
-
-	return config, nil
 }

--- a/component/kafka/kafka_test.go
+++ b/component/kafka/kafka_test.go
@@ -2,8 +2,6 @@ package kafka
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/opentracing/opentracing-go/mocktracer"
@@ -36,12 +34,6 @@ func Test_messageWrapper(t *testing.T) {
 	assert.NotNil(t, consumerMessage)
 	assert.Equal(t, "topicone", consumerMessage.Topic)
 	assert.Equal(t, []byte(`{"key":"value"}`), consumerMessage.Value)
-}
-
-func Test_DefaultSaramaConfig(t *testing.T) {
-	sc, err := DefaultSaramaConfig("name")
-	assert.NoError(t, err)
-	assert.True(t, strings.HasSuffix(sc.ClientID, fmt.Sprintf("-%s", "name")))
 }
 
 func Test_NewBatch(t *testing.T) {

--- a/docs/clients/Clients.md
+++ b/docs/clients/Clients.md
@@ -32,6 +32,7 @@ The Kafka client allows users to create a synchronous or asynchronous Kafka prod
 **Third-party dependencies**  
 github.com/Shopify/sarama v1.30.0
 
+Each instance of a producer or consumer requires the specification of Sarama configuration; you can use `v2.DefaultConsumerSaramaConfig` and `v2.DefaultProducerSaramaConfig` for sane defaults.
 
 ## Redis
 The Redis client allows users to connect to a Redis instance and execute commands. The connection can be configured using [`redis.Options`](https://github.com/go-redis/redis/blob/v7/options.go).

--- a/docs/components/async/AWSSQS.md
+++ b/docs/components/async/AWSSQS.md
@@ -2,7 +2,7 @@
 
 ## Deprecated
 
-The SQS consumer package along with the async component is superseded by the standalone `github.com/beatlabs/component/sqs` package.
+The SQS consumer package along with the async component is superseded by the standalone `github.com/beatlabs/patron/component/sqs` package.
 
 **This package is frozen and no new functionality will be added.**
 

--- a/docs/components/async/Kafka.md
+++ b/docs/components/async/Kafka.md
@@ -6,6 +6,7 @@ The package contains two sub-packages:
 - `group` which uses consumer groups in order to get messages
 
 Both of the packages contain the factory and consumer implementation.
+It is necessary to provide Sarama configuration when creating these consumers; you can use `v2.DefaultConsumerSaramaConfig` for sane defaults.
 
 There is a special feature in the simple package which allows the consumer to go back a specific amount of time in each partition.  
 This allows us to consume the messages from an approximate time onwards.

--- a/examples/http-sec/main.go
+++ b/examples/http-sec/main.go
@@ -52,7 +52,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	asyncComp, err := newAsyncKafkaProducer(kafkaBroker, kafkaTopic)
+	asyncComp, err := newAsyncKafkaProducer(kafkaBroker, kafkaTopic, true)
 	if err != nil {
 		log.Fatalf("failed to create processor %v", err)
 	}
@@ -78,8 +78,13 @@ type kafkaProducer struct {
 }
 
 // newAsyncKafkaProducer creates a new asynchronous kafka producer client
-func newAsyncKafkaProducer(kafkaBroker, topic string) (*kafkaProducer, error) {
-	prd, chErr, err := v2.New([]string{kafkaBroker}).CreateAsync()
+func newAsyncKafkaProducer(kafkaBroker, topic string, readCommitted bool) (*kafkaProducer, error) {
+	saramaCfg, err := v2.DefaultConsumerSaramaConfig("http-sec-consumer", readCommitted)
+	if err != nil {
+		return nil, err
+	}
+
+	prd, chErr, err := v2.New([]string{kafkaBroker}, saramaCfg).CreateAsync()
 	if err != nil {
 		return nil, err
 	}

--- a/examples/kafka-legacy/main.go
+++ b/examples/kafka-legacy/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/beatlabs/patron"
 	patronamqp "github.com/beatlabs/patron/client/amqp/v2"
+	v2 "github.com/beatlabs/patron/client/kafka/v2"
 	"github.com/beatlabs/patron/component/async"
 	"github.com/beatlabs/patron/component/async/kafka"
 	"github.com/beatlabs/patron/component/async/kafka/group"
@@ -86,7 +87,12 @@ func newKafkaComponent(name, broker, topic, groupID string, publisher *patronamq
 		pub: publisher,
 	}
 
-	cf, err := group.New(name, groupID, []string{topic}, []string{broker}, kafka.Decoder(json.DecodeRaw))
+	saramaCfg, err := v2.DefaultConsumerSaramaConfig("kafka-legacy", false)
+	if err != nil {
+		return nil, err
+	}
+
+	cf, err := group.New(name, groupID, []string{topic}, []string{broker}, saramaCfg, kafka.Decoder(json.DecodeRaw))
 	if err != nil {
 		return nil, err
 	}

--- a/examples/kafka/main.go
+++ b/examples/kafka/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/beatlabs/patron"
 	patronamqp "github.com/beatlabs/patron/client/amqp/v2"
+	v2 "github.com/beatlabs/patron/client/kafka/v2"
 	"github.com/beatlabs/patron/component/kafka"
 	"github.com/beatlabs/patron/component/kafka/group"
 	"github.com/beatlabs/patron/encoding/json"
@@ -86,9 +87,12 @@ func newKafkaComponent(name, broker, topic, groupID string, publisher *patronamq
 		pub: publisher,
 	}
 
-	saramaCfg := sarama.NewConfig()
-	// consistent reads only
-	saramaCfg.Consumer.IsolationLevel = sarama.ReadCommitted
+	// create a consumer that accepts only consistent reads
+	saramaCfg, err := v2.DefaultConsumerSaramaConfig("kafka-consumer", true)
+	if err != nil {
+		return nil, err
+	}
+
 	// batches will be responsible for committing
 	saramaCfg.Consumer.Offsets.AutoCommit.Enable = false
 	saramaCfg.Consumer.Offsets.Initial = sarama.OffsetOldest
@@ -102,14 +106,13 @@ func newKafkaComponent(name, broker, topic, groupID string, publisher *patronamq
 		[]string{broker},
 		[]string{topic},
 		kafkaCmp.Process,
+		saramaCfg,
 		group.FailureStrategy(kafka.SkipStrategy),
 		group.BatchSize(1),
 		group.BatchTimeout(1*time.Second),
 		group.Retries(10),
 		group.RetryWait(3*time.Second),
-		group.SaramaConfig(saramaCfg),
 		group.CommitSync())
-
 	if err != nil {
 		return nil, err
 	}

--- a/examples/kafka/main.go
+++ b/examples/kafka/main.go
@@ -87,6 +87,8 @@ func newKafkaComponent(name, broker, topic, groupID string, publisher *patronamq
 	}
 
 	saramaCfg := sarama.NewConfig()
+	// consistent reads only
+	saramaCfg.Consumer.IsolationLevel = sarama.ReadCommitted
 	// batches will be responsible for committing
 	saramaCfg.Consumer.Offsets.AutoCommit.Enable = false
 	saramaCfg.Consumer.Offsets.Initial = sarama.OffsetOldest

--- a/test/docker/kafka/client_integration_test.go
+++ b/test/docker/kafka/client_integration_test.go
@@ -22,7 +22,10 @@ const (
 )
 
 func TestNewAsyncProducer_Success_v2(t *testing.T) {
-	ap, chErr, err := v2.New(Brokers()).CreateAsync()
+	saramaCfg, err := v2.DefaultProducerSaramaConfig("test-producer", true)
+	require.Nil(t, err)
+
+	ap, chErr, err := v2.New(Brokers(), saramaCfg).CreateAsync()
 	assert.NoError(t, err)
 	assert.NotNil(t, ap)
 	assert.NotNil(t, chErr)
@@ -36,7 +39,10 @@ func TestNewAsyncProducer_Success_v1(t *testing.T) {
 }
 
 func TestNewSyncProducer_Success_v2(t *testing.T) {
-	p, err := v2.New(Brokers()).Create()
+	saramaCfg, err := v2.DefaultProducerSaramaConfig("test-producer", true)
+	require.Nil(t, err)
+
+	p, err := v2.New(Brokers(), saramaCfg).Create()
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
 }
@@ -48,10 +54,13 @@ func TestNewSyncProducer_Success_v1(t *testing.T) {
 }
 
 func TestAsyncProducer_SendMessage_Close_v2(t *testing.T) {
+	saramaCfg, err := v2.DefaultProducerSaramaConfig("test-consumer", false)
+	require.Nil(t, err)
+
 	mtr := mocktracer.New()
 	defer mtr.Reset()
 	opentracing.SetGlobalTracer(mtr)
-	ap, chErr, err := v2.New(Brokers()).CreateAsync()
+	ap, chErr, err := v2.New(Brokers(), saramaCfg).CreateAsync()
 	assert.NoError(t, err)
 	assert.NotNil(t, ap)
 	assert.NotNil(t, chErr)
@@ -101,10 +110,13 @@ func TestAsyncProducer_SendMessage_Close_v1(t *testing.T) {
 }
 
 func TestSyncProducer_SendMessage_Close_v2(t *testing.T) {
+	saramaCfg, err := v2.DefaultProducerSaramaConfig("test-producer", true)
+	require.NoError(t, err)
+
 	mtr := mocktracer.New()
 	defer mtr.Reset()
 	opentracing.SetGlobalTracer(mtr)
-	p, err := v2.New(Brokers()).Create()
+	p, err := v2.New(Brokers(), saramaCfg).Create()
 	require.NoError(t, err)
 	assert.NotNil(t, p)
 	msg := &sarama.ProducerMessage{
@@ -130,10 +142,13 @@ func TestSyncProducer_SendMessage_Close_v2(t *testing.T) {
 }
 
 func TestSyncProducer_SendMessages_Close_v2(t *testing.T) {
+	saramaCfg, err := v2.DefaultProducerSaramaConfig("test-producer", true)
+	require.NoError(t, err)
+
 	mtr := mocktracer.New()
 	defer mtr.Reset()
 	opentracing.SetGlobalTracer(mtr)
-	p, err := v2.New(Brokers()).Create()
+	p, err := v2.New(Brokers(), saramaCfg).Create()
 	require.NoError(t, err)
 	assert.NotNil(t, p)
 	msg1 := &sarama.ProducerMessage{
@@ -185,7 +200,10 @@ func TestSyncProducer_SendMessage_Close_v1(t *testing.T) {
 }
 
 func TestAsyncProducerActiveBrokers_v2(t *testing.T) {
-	ap, chErr, err := v2.New(Brokers()).CreateAsync()
+	saramaCfg, err := v2.DefaultProducerSaramaConfig("test-producer", true)
+	require.NoError(t, err)
+
+	ap, chErr, err := v2.New(Brokers(), saramaCfg).CreateAsync()
 	assert.NoError(t, err)
 	assert.NotNil(t, ap)
 	assert.NotNil(t, chErr)
@@ -203,7 +221,10 @@ func TestAsyncProducerActiveBrokers_v1(t *testing.T) {
 }
 
 func TestSyncProducerActiveBrokers_v2(t *testing.T) {
-	ap, err := v2.New(Brokers()).Create()
+	saramaCfg, err := v2.DefaultProducerSaramaConfig("test-producer", true)
+	require.NoError(t, err)
+
+	ap, err := v2.New(Brokers(), saramaCfg).Create()
 	assert.NoError(t, err)
 	assert.NotNil(t, ap)
 	assert.NotEmpty(t, ap.ActiveBrokers())

--- a/test/docker/kafka/component_async_package_integration_test.go
+++ b/test/docker/kafka/component_async_package_integration_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/beatlabs/patron"
+	v2 "github.com/beatlabs/patron/client/kafka/v2"
 	"github.com/beatlabs/patron/component/async"
 	"github.com/beatlabs/patron/component/async/kafka"
 	"github.com/beatlabs/patron/component/async/kafka/group"
@@ -209,11 +210,16 @@ func newKafkaAsyncPackageComponent(t *testing.T, name string, retries uint, proc
 		*p = tmp
 		return nil
 	}
+
+	saramaCfg, err := v2.DefaultConsumerSaramaConfig(name, true)
+	require.NoError(t, err)
+
 	factory, err := group.New(
 		name,
 		name+"-group",
 		[]string{name},
 		[]string{fmt.Sprintf("%s:%s", kafkaHost, kafkaPort)},
+		saramaCfg,
 		kafka.Decoder(decode),
 		kafka.Start(sarama.OffsetOldest))
 	require.NoError(t, err)

--- a/test/docker/kafka/consumer_simple_integration_test.go
+++ b/test/docker/kafka/consumer_simple_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	v2 "github.com/beatlabs/patron/client/kafka/v2"
 	"github.com/beatlabs/patron/component/async/kafka"
 	"github.com/beatlabs/patron/component/async/kafka/simple"
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,10 @@ func TestSimpleConsume(t *testing.T) {
 	chErr := make(chan error)
 	go func() {
 
-		factory, err := simple.New("test1", simpleTopic1, Brokers(), kafka.DecoderJSON(), kafka.Version(sarama.V2_1_0_0.String()),
+		saramaCfg, err := v2.DefaultConsumerSaramaConfig("test-simple-consumer", true)
+		require.NoError(t, err)
+
+		factory, err := simple.New("test1", simpleTopic1, Brokers(), saramaCfg, kafka.DecoderJSON(), kafka.Version(sarama.V2_1_0_0.String()),
 			kafka.StartFromNewest())
 		if err != nil {
 			chErr <- err
@@ -72,7 +76,10 @@ func TestSimpleConsume_ClaimMessageError(t *testing.T) {
 	chErr := make(chan error)
 	go func() {
 
-		factory, err := simple.New("test1", simpleTopic2, Brokers(), kafka.Version(sarama.V2_1_0_0.String()),
+		saramaCfg, err := v2.DefaultConsumerSaramaConfig("test-simple-consumer-claim", true)
+		require.NoError(t, err)
+
+		factory, err := simple.New("test1", simpleTopic2, Brokers(), saramaCfg, kafka.Version(sarama.V2_1_0_0.String()),
 			kafka.StartFromNewest())
 		if err != nil {
 			chErr <- err
@@ -131,7 +138,10 @@ func TestSimpleConsume_WithDurationOffset(t *testing.T) {
 	chMessages := make(chan []string)
 	chErr := make(chan error)
 	go func() {
-		factory, err := simple.New("test1", simpleTopic3, Brokers(), kafka.DecoderJSON(), kafka.Version(sarama.V2_1_0_0.String()),
+		saramaCfg, err := v2.DefaultConsumerSaramaConfig("test-simple-consumer-w-duration", true)
+		require.NoError(t, err)
+
+		factory, err := simple.New("test1", simpleTopic3, Brokers(), saramaCfg, kafka.DecoderJSON(), kafka.Version(sarama.V2_1_0_0.String()),
 			kafka.StartFromNewest(), simple.WithDurationOffset(4*time.Hour, timestampExtractor))
 		if err != nil {
 			chErr <- err
@@ -183,7 +193,10 @@ func TestSimpleConsume_WithNotificationOnceReachingLatestOffset(t *testing.T) {
 	chErr := make(chan error)
 	chNotif := make(chan struct{})
 	go func() {
-		factory, err := simple.New("test4", simpleTopic4, Brokers(), kafka.DecoderJSON(), kafka.Version(sarama.V2_1_0_0.String()),
+		saramaCfg, err := v2.DefaultConsumerSaramaConfig("test-simple-consumer-w-notif", true)
+		require.NoError(t, err)
+
+		factory, err := simple.New("test4", simpleTopic4, Brokers(), saramaCfg, kafka.DecoderJSON(), kafka.Version(sarama.V2_1_0_0.String()),
 			kafka.StartFromOldest(), simple.WithNotificationOnceReachingLatestOffset(chNotif))
 		if err != nil {
 			chErr <- err
@@ -231,7 +244,10 @@ func TestSimpleConsume_WithNotificationOnceReachingLatestOffset_NoMessages(t *te
 	chErr := make(chan error)
 	chNotif := make(chan struct{})
 	go func() {
-		factory, err := simple.New("test5", simpleTopic5, Brokers(), kafka.DecoderJSON(), kafka.Version(sarama.V2_1_0_0.String()),
+		saramaCfg, err := v2.DefaultConsumerSaramaConfig("test-simple-consumer", true)
+		require.NoError(t, err)
+
+		factory, err := simple.New("test5", simpleTopic5, Brokers(), saramaCfg, kafka.DecoderJSON(), kafka.Version(sarama.V2_1_0_0.String()),
 			kafka.StartFromOldest(), simple.WithNotificationOnceReachingLatestOffset(chNotif))
 		if err != nil {
 			chErr <- err


### PR DESCRIPTION
## Which problem is this PR solving?

The default Sarama configurations are not using consistent reads nor idempotent producers.

## Short description of the changes

This PR introduces breaking changes that make it mandatory to make a choice regarding:
* read-committed consumers
* idempotent producers

For both these `false` means eventual consistency, `true` means transaction behavior; see https://www.confluent.io/blog/transactions-apache-kafka/ for more information.

## Section for release notes

This release introduces multiple breaking changes related to specifying a Sarama configuration for all consumer/producer use cases.

As an user of Patron you will now have to make a choice about which consumer or producer configuration to use; you can use the utility functions `client/kafka/v2`.`DefaultConsumerConfig` or `DefaultProducerConfig`, or create and provide your own using `sarama.NewConfig`.

For more information about eventual consistency and transactions behavior in Kafka, please see https://www.confluent.io/blog/transactions-apache-kafka/

This new behavior in Patron coincidentally now matches what the official Java Kafka client does, see: https://blogs.apache.org/kafka/entry/what-s-new-in-apache6

Follows a comprehensive list of the introduced breaking changes:

* `client/kafka/v2`: `New` now requires Sarama configuration
* `client/kafka/v2`: `Builder.WithConfig` is deleted
* `component/async/kafka/group`: `New` requires a new parameter for Sarama configuration
* `component/async/kafka`: DefaultSaramaConfig deleted, use `client/kafka/v2`.`DefaultConsumerConfig` or `DefaultProducerConfig` instead
* `component/async/kafka`: `New` requires a new parameter for Sarama configuration
* `component/kafka/group`: `New` requires a new parameter for Sarama configuration
* `component/kafka/group`: SaramaConfig option func deleted
* `component/kafka`: `DefaultSaramaConfig` deleted, use `client/kafka/v2`.`DefaultConsumerConfig` or `DefaultProducerConfig` instead
