### PR TITLE
Feature: new HTTP server metrics with full status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Patron is a framework for creating microservices, originally created by Sotiris 
 
 `Patron` is french for `template` or `pattern`, but it means also `boss` which we found out later (no pun intended).
 
-The entry point of the framework is the `Service`. The `Service` uses `Components` to handle the processing of sync and async requests. The `Service` starts by default an `HTTP Component` which hosts the debug, alive, ready and metric endpoints. Any other endpoints will be added to the default `HTTP Component` as `Routes`. Alongside `Routes` one can specify middleware functions to be applied ordered to all routes as `MiddlewareFunc`. The service set's up by default logging with `zerolog`, tracing and metrics with `jaeger` and `prometheus`.
+The entry point of the framework is the `Service`. The `Service` uses `Components` to handle the processing of sync and async requests. The `Service` starts by default an `HTTP Component` which hosts the `/debug`, `/alive`, `/ready` and `/metrics` endpoints. Any other endpoints will be added to the default `HTTP Component` as `Routes`. Alongside `Routes` one can specify middleware functions to be applied ordered to all routes as `MiddlewareFunc`. The service sets up by default logging with [zerolog](https://github.com/rs/zerolog), tracing and metrics with [Jaeger](https://www.jaegertracing.io/) and [prometheus](https://prometheus.io/).
 
 `Patron` provides abstractions for the following functionality of the framework:
 

--- a/component/http/cache/route.go
+++ b/component/http/cache/route.go
@@ -34,7 +34,7 @@ func NewRouteCache(ttlCache cache.TTLCache, age Age) (*RouteCache, []error) {
 	}
 
 	if hasNoAgeConfig(age.Min.Milliseconds(), age.Max.Milliseconds()) {
-		log.Warnf("route cache for %s is disabled because of empty Age property %v ")
+		log.Warnf("route cache disabled because of empty Age property %v", age)
 	}
 
 	return &RouteCache{

--- a/component/http/middleware.go
+++ b/component/http/middleware.go
@@ -51,6 +51,12 @@ type responseWriter struct {
 	writer              http.ResponseWriter
 }
 
+var (
+	httpStatusTracingInit          sync.Once
+	httpStatusTracingHandledMetric *prometheus.CounterVec
+	httpStatusTracingLatencyMetric *prometheus.HistogramVec
+)
+
 func newResponseWriter(w http.ResponseWriter, capturePayload bool) *responseWriter {
 	return &responseWriter{status: -1, statusHeaderWritten: false, writer: w, capturePayload: capturePayload}
 }
@@ -155,12 +161,6 @@ func NewLoggingTracingMiddleware(path string, statusCodeLogger statusCodeLoggerH
 		})
 	}
 }
-
-var (
-	httpStatusTracingInit          sync.Once
-	httpStatusTracingHandledMetric *prometheus.CounterVec
-	httpStatusTracingLatencyMetric *prometheus.HistogramVec
-)
 
 func initHTTPServerMetrics() {
 	httpStatusTracingHandledMetric = prometheus.NewCounterVec(

--- a/component/http/middleware.go
+++ b/component/http/middleware.go
@@ -1,9 +1,9 @@
 package http
 
 import (
+	"bytes"
 	"compress/flate"
 	"compress/gzip"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -14,6 +14,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"golang.org/x/time/rate"
 
@@ -27,6 +29,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	tracinglog "github.com/opentracing/opentracing-go/log"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -43,12 +46,13 @@ const (
 type responseWriter struct {
 	status              int
 	statusHeaderWritten bool
-	payload             []byte
+	capturePayload      bool
+	responsePayload     bytes.Buffer
 	writer              http.ResponseWriter
 }
 
-func newResponseWriter(w http.ResponseWriter) *responseWriter {
-	return &responseWriter{status: -1, statusHeaderWritten: false, writer: w}
+func newResponseWriter(w http.ResponseWriter, capturePayload bool) *responseWriter {
+	return &responseWriter{status: -1, statusHeaderWritten: false, writer: w, capturePayload: capturePayload}
 }
 
 // Status returns the http response status.
@@ -68,7 +72,9 @@ func (w *responseWriter) Write(d []byte) (int, error) {
 		return value, err
 	}
 
-	w.payload = d
+	if w.capturePayload {
+		w.responsePayload.Write(d)
+	}
 
 	if !w.statusHeaderWritten {
 		w.status = http.StatusOK
@@ -133,17 +139,74 @@ func NewAuthMiddleware(auth auth.Authenticator) MiddlewareFunc {
 }
 
 // NewLoggingTracingMiddleware creates a MiddlewareFunc that continues a tracing span and finishes it.
-// It also logs the HTTP request on debug logging level
+// It uses Jaeger and OpenTracing and will also log the HTTP request on debug level if configured so.
 func NewLoggingTracingMiddleware(path string, statusCodeLogger statusCodeLoggerHandler) MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			corID := getOrSetCorrelationID(r.Header)
 			sp, r := span(path, corID, r)
-			lw := newResponseWriter(w)
+			lw := newResponseWriter(w, true)
 			next.ServeHTTP(lw, r)
-			finishSpan(sp, lw.Status(), lw.payload)
+			finishSpan(sp, lw.Status(), &lw.responsePayload)
 			logRequestResponse(corID, lw, r)
-			statusCodeErrorLogging(r.Context(), statusCodeLogger, lw.Status(), lw.payload, path)
+			if log.Enabled(log.ErrorLevel) && statusCodeLogger.shouldLog(lw.status) {
+				log.FromContext(r.Context()).Errorf("%s %d error: %v", path, lw.status, lw.responsePayload.String())
+			}
+		})
+	}
+}
+
+var (
+	httpStatusTracingInit          sync.Once
+	httpStatusTracingHandledMetric *prometheus.CounterVec
+	httpStatusTracingLatencyMetric *prometheus.HistogramVec
+)
+
+func initHTTPServerMetrics() {
+	httpStatusTracingHandledMetric = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "component",
+			Subsystem: "http",
+			Name:      "handled_total",
+			Help:      "Total number of HTTP responses served by the server.",
+		},
+		[]string{"method", "path", "status_code"},
+	)
+	prometheus.MustRegister(httpStatusTracingHandledMetric)
+	httpStatusTracingLatencyMetric = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "component",
+			Subsystem: "http",
+			Name:      "handled_seconds",
+			Help:      "Latency of a completed HTTP response served by the server.",
+		},
+		[]string{"method", "path", "status_code"})
+	prometheus.MustRegister(httpStatusTracingLatencyMetric)
+}
+
+// NewStatusTracingMiddleware creates a MiddlewareFunc that captures status code and duration metrics about the responses returned.
+// It does not use Jaeger nor OpenTracing but will also log the HTTP request on debug level if configured so.
+func NewStatusTracingMiddleware(method, path string, statusCodeLogger statusCodeLoggerHandler) MiddlewareFunc {
+	// register Promethus metrics on first use
+	httpStatusTracingInit.Do(initHTTPServerMetrics)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			now := time.Now()
+			corID := getOrSetCorrelationID(r.Header)
+			logErrors := log.Enabled(log.ErrorLevel)
+			lw := newResponseWriter(w, logErrors)
+			next.ServeHTTP(lw, r)
+
+			// collect metrics about HTTP server-side handling and latency
+			status := strconv.Itoa(lw.Status())
+			httpStatusTracingHandledMetric.WithLabelValues(method, path, status).Inc()
+			httpStatusTracingLatencyMetric.WithLabelValues(method, path, status).Observe(time.Since(now).Seconds())
+
+			logRequestResponse(corID, lw, r)
+			if logErrors && statusCodeLogger.shouldLog(lw.status) {
+				log.FromContext(r.Context()).Errorf("%s %d error: %v", path, lw.status, lw.responsePayload.String())
+			}
 		})
 	}
 }
@@ -434,16 +497,6 @@ func logRequestResponse(corID string, w *responseWriter, r *http.Request) {
 	log.Sub(info).Debug()
 }
 
-func statusCodeErrorLogging(ctx context.Context, statusCodeLogger statusCodeLoggerHandler, statusCode int, payload []byte, path string) {
-	if !log.Enabled(log.ErrorLevel) {
-		return
-	}
-
-	if statusCodeLogger.shouldLog(statusCode) {
-		log.FromContext(ctx).Errorf("%s %d error: %v", path, statusCode, string(payload))
-	}
-}
-
 func getOrSetCorrelationID(h http.Header) string {
 	cor, ok := h[correlation.HeaderID]
 	if !ok {
@@ -499,11 +552,11 @@ func stripQueryString(path string) (string, error) {
 	return path[:len(path)-len(u.RawQuery)-1], nil
 }
 
-func finishSpan(sp opentracing.Span, code int, payload []byte) {
+func finishSpan(sp opentracing.Span, code int, responsePayload *bytes.Buffer) {
 	ext.HTTPStatusCode.Set(sp, uint16(code))
 	isError := code >= http.StatusInternalServerError
-	if isError && len(payload) != 0 {
-		sp.LogFields(tracinglog.String(fieldNameError, string(payload)))
+	if isError && responsePayload.Len() != 0 {
+		sp.LogFields(tracinglog.String(fieldNameError, responsePayload.String()))
 	}
 	ext.Error.Set(sp, isError)
 	sp.Finish()

--- a/component/http/middleware_test.go
+++ b/component/http/middleware_test.go
@@ -71,7 +71,7 @@ func TestMiddlewareChain(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rc := httptest.NewRecorder()
-			rw := newResponseWriter(rc)
+			rw := newResponseWriter(rc, true)
 			tt.args.next = MiddlewareChain(tt.args.next, tt.args.mws...)
 			tt.args.next.ServeHTTP(rw, r)
 			assert.Equal(t, tt.expectedCode, rw.Status())
@@ -111,7 +111,7 @@ func TestMiddlewares(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rc := httptest.NewRecorder()
-			rw := newResponseWriter(rc)
+			rw := newResponseWriter(rc, true)
 			tt.args.next = MiddlewareChain(tt.args.next, tt.args.mws...)
 			tt.args.next.ServeHTTP(rw, r)
 			assert.Equal(t, tt.expectedCode, rw.Status())
@@ -155,7 +155,7 @@ func TestSpanLogError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mtr.Reset()
 			rc := httptest.NewRecorder()
-			rw := newResponseWriter(rc)
+			rw := newResponseWriter(rc, true)
 			tt.args.next = MiddlewareChain(tt.args.next, tt.args.mws...)
 			tt.args.next.ServeHTTP(rw, r)
 			assert.Equal(t, tt.expectedCode, rw.Status())
@@ -172,7 +172,7 @@ func TestSpanLogError(t *testing.T) {
 
 func TestResponseWriter(t *testing.T) {
 	rc := httptest.NewRecorder()
-	rw := newResponseWriter(rc)
+	rw := newResponseWriter(rc, true)
 
 	_, err := rw.Write([]byte("test"))
 	assert.NoError(t, err)

--- a/component/http/route_cache_test.go
+++ b/component/http/route_cache_test.go
@@ -91,7 +91,7 @@ func TestCachingMiddleware(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rc := httptest.NewRecorder()
-			rw := newResponseWriter(rc)
+			rw := newResponseWriter(rc, true)
 			tt.args.next = MiddlewareChain(tt.args.next, tt.args.mws...)
 			tt.args.next.ServeHTTP(rw, tt.r)
 			assert.Equal(t, tt.expectedCode, rw.Status())

--- a/component/http/route_test.go
+++ b/component/http/route_test.go
@@ -98,7 +98,12 @@ func TestRouteBuilder_WithMethodOptions(t *testing.T) {
 
 func TestRouteBuilder_WithTrace(t *testing.T) {
 	rb := NewRawRouteBuilder("/", func(http.ResponseWriter, *http.Request) {}).WithTrace()
-	assert.True(t, rb.trace)
+	assert.True(t, rb.jaegerTrace)
+}
+
+func TestRouteBuilder_WithStatusTrace(t *testing.T) {
+	rb := NewRawRouteBuilder("/", func(http.ResponseWriter, *http.Request) {}).WithStatusTrace()
+	assert.True(t, rb.statusTrace)
 }
 
 func TestRouteBuilder_WithMiddlewares(t *testing.T) {

--- a/component/http/route_test.go
+++ b/component/http/route_test.go
@@ -101,11 +101,6 @@ func TestRouteBuilder_WithTrace(t *testing.T) {
 	assert.True(t, rb.jaegerTrace)
 }
 
-func TestRouteBuilder_WithStatusTrace(t *testing.T) {
-	rb := NewRawRouteBuilder("/", func(http.ResponseWriter, *http.Request) {}).WithStatusTrace()
-	assert.True(t, rb.statusTrace)
-}
-
 func TestRouteBuilder_WithMiddlewares(t *testing.T) {
 	middleware := func(next http.Handler) http.Handler { return next }
 	mockHandler := func(http.ResponseWriter, *http.Request) {}
@@ -404,7 +399,7 @@ func TestRoute_Getters(t *testing.T) {
 
 	assert.Equal(t, path, r.Path())
 	assert.Equal(t, http.MethodPost, r.Method())
-	assert.Len(t, r.Middlewares(), 1)
+	assert.Len(t, r.Middlewares(), 2)
 
 	// the only way to test do we get the same handler that we provided initially, is to run it explicitly,
 	// since all we have in Route itself is a wrapper function

--- a/docs/components/HTTP.md
+++ b/docs/components/HTTP.md
@@ -96,7 +96,7 @@ It is possible to customize their behaviour by injecting an `http.AliveCheck` an
 
 ## Metrics
 
-The following metrics are automatically provided when using `WithStatusTrace()`:
+The following metrics are automatically provided by default:
 * `component_http_handled_total`
 * `component_http_handled_seconds`
 
@@ -164,9 +164,10 @@ func NewLoggingTracingMiddleware(path string) MiddlewareFunc {
     // ...
 }
 
-// NewStatusTracingMiddleware creates a MiddlewareFunc that captures status code and duration metrics about the responses returned.
-// It does not use Jaeger nor OpenTracing but will also log the HTTP request on debug level if configured so.
-func NewStatusTracingMiddleware(method, path string, statusCodeLogger statusCodeLoggerHandler) MiddlewareFunc {
+// NewRequestObserverMiddleware creates a MiddlewareFunc that captures status code and duration metrics about the responses returned;
+// metrics are exposed via Prometheus.
+// This middleware is enabled by default.
+func NewRequestObserverMiddleware(method, path string) MiddlewareFunc {
 	// ...
 }
 

--- a/docs/components/HTTP.md
+++ b/docs/components/HTTP.md
@@ -94,6 +94,22 @@ Both can return either a `200 OK` or a `503 Service Unavailable` status code (de
 
 It is possible to customize their behaviour by injecting an `http.AliveCheck` and/or an `http.ReadyCheck` `OptionFunc` to the HTTP component constructor.
 
+## Metrics
+
+The following metrics are automatically provided when using `WithStatusTrace()`:
+* `component_http_handled_total`
+* `component_http_handled_seconds`
+
+Example of the associated labels: `status_code="200"`, `method="GET"`, `path="/hello/world"`
+
+### Jaeger-provided metrics
+
+When using `WithTrace()` the following metrics are automatically provided via Jaeger (they are populated together with the spans):
+* `{microservice_name}_http_requests_total`
+* `{microservice_name}_http_requests_latency`
+
+They have labels `endpoint="GET-/hello/world"` and `status_code="2xx"`.
+
 ## HTTP Middlewares
 
 A `MiddlewareFunc` preserves the default net/http middleware pattern.
@@ -143,9 +159,15 @@ func NewAuthMiddleware(auth auth.Authenticator) MiddlewareFunc {
 }
 
 // NewLoggingTracingMiddleware creates a MiddlewareFunc that continues a tracing span and finishes it.
-// It also logs the HTTP request on debug logging level.
+// It uses Jaeger and OpenTracing and will also log the HTTP request on debug level if configured so.
 func NewLoggingTracingMiddleware(path string) MiddlewareFunc {
     // ...
+}
+
+// NewStatusTracingMiddleware creates a MiddlewareFunc that captures status code and duration metrics about the responses returned.
+// It does not use Jaeger nor OpenTracing but will also log the HTTP request on debug level if configured so.
+func NewStatusTracingMiddleware(method, path string, statusCodeLogger statusCodeLoggerHandler) MiddlewareFunc {
+	// ...
 }
 
 // NewCachingMiddleware creates a cache layer as a middleware.

--- a/docs/components/gRPC.md
+++ b/docs/components/gRPC.md
@@ -8,3 +8,11 @@ As the server implements the Patron `component` interface, it also handles grace
 Setting up a gRPC component is done via the Builder (which follows the builder pattern), and supports various configuration values in the form of the `grpc.ServerOption` struct during setup.
 
 Check out the [examples/](/examples) folder for an hands-on tutorial on setting up a server and working with gRPC in Patron.
+
+## Metrics
+
+The following metrics are automatically provided when using `WithTrace()`:
+* `component_grpc_handled_total`
+* `component_grpc_handled_seconds`
+
+Example of the associated labels: `grpc_code="OK"`, `grpc_method="CreateMyEvent"`, `grpc_service="myservice.Service"`, `grpc_type="unary"`.

--- a/examples/check/main.go
+++ b/examples/check/main.go
@@ -33,7 +33,11 @@ func main() {
 		log.Fatal(err)
 	}
 	if resp.StatusCode != http.StatusCreated {
-		log.Fatalf("Response supposed to be status code %d instead it is %d", http.StatusCreated, resp.StatusCode)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Fatalf("Response supposed to be status code %d instead it is %d (body: %q)", http.StatusCreated, resp.StatusCode, string(body))
 	}
 
 	// wait 1 second so that metrics can be flushed to http endpoint

--- a/service.go
+++ b/service.go
@@ -332,7 +332,7 @@ func setupJaegerTracing(name, version string) error {
 	return trace.Setup(name, version, agent, tp, prmVal, buckets)
 }
 
-// WithoutJaeger disables Jaeger integration
+// WithoutJaeger disables Jaeger integration.
 func (b *Builder) WithoutJaeger() *Builder {
 	log.Debug("disabling Jaeger integration")
 	b.enableJaeger = false

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -48,7 +48,7 @@ func Setup(name, ver, agent, typ string, prm float64, buckets []float64) error {
 			LocalAgentHostPort:  agent,
 		},
 	}
-	time.Sleep(100 * time.Millisecond)
+
 	metricsFactory := prometheus.New(
 		prometheus.WithBuckets(buckets),
 	)


### PR DESCRIPTION
## Which problem is this PR solving?

Mainly:

* Prometheus metrics to have the full HTTP status code

We currently use Jaeger metrics which only sport `5xx`, `2xx` and the like; having the full status code in metrics is necessary for tailoring alerts and making more specific Grafana panels.

This PR models the new metrics around the existing server-side gRPC metrics.

Secondarily:
* allowing to disable Jaeger/OpenTracing metrics (NOTE: this also means that the failures at parsing `JAEGER_*` environment variables now would happen when `Run()` is called instead of the constructor)
* do not cache only the last `Write` in the response writer middleware, but all writes
* do not cache written response if unnecessary for error logging purposes

<!-- REQUIRED -->

## Short description of the changes

We currently have:
1. `{microservice_name}_http_requests_total`, `{microservice_name}_http_requests_latency` - these are provided by the Jaeger package and have labels `endpoint="GET-/hello/world"` and `status_code="2xx"`
2.  `component_grpc_handled_total` and  `component_grpc_handled_seconds` with labels `grpc_code="OK"`, `grpc_method="CreateMyEvent"`, `grpc_service="myservice.Service"`, `grpc_type="unary"`

With this PR we would have:
1. same as (1) before, but can be disabled by using `WithoutJaeger()` option
2. same as (2) before
3. `component_http_handled_total` and  `component_http_handled_seconds` with labels `status_code="200"`, `method="GET"`, `path="/hello/world"`, which follows the style of (2)