### PR TITLE
Update to Go 1.16

### DIFF
--- a/.github/workflows/examples-go.yml
+++ b/.github/workflows/examples-go.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
 
       - name: Check out source code
         uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
 
       - name: Check out source code
         uses: actions/checkout@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,50 @@
+run:
+  concurrency: 4
+  timeout: 5m
+  issues-exit-code: 1
+  tests: true
+
+  skip-dirs:
+    - vendor
+  skip-files:
+
+  modules-download-mode: vendor
+
+  # list of build tags, all linters use it. Default is empty list
+  build-tags:
+    - integration
+
+# output configuration options
+output:
+  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
+  format: colored-line-number
+
+  # print lines of code with issue, default is true
+  print-issued-lines: true
+
+  # print linter name in the end of issue text, default is true
+  print-linter-name: true
+
+  uniq-by-line: false
+
+linters:
+  disable-all: true
+  enable:
+    - golint
+    - gofmt
+    - gosec
+    - unparam
+    - goconst
+    - prealloc
+    - stylecheck
+    - unconvert
+    - staticcheck
+    - gosec
+  fast: false
+
+issues:
+  exclude-rules:
+    # Exclude some staticcheck messages
+    - linters:
+        - staticcheck
+      text: "SA1019:"

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ fmtcheck:
 	@sh -c "'$(CURDIR)/script/gofmtcheck.sh'"
 
 lint: fmtcheck
-	$(DOCKER) run --env=GOFLAGS=-mod=vendor --rm -v $(CURDIR):/app -w /app golangci/golangci-lint:v1.34.1 golangci-lint run --enable golint,gofmt,gosec,unparam,goconst,prealloc,stylecheck,unconvert,staticcheck,gosec --exclude-use-default=false --deadline=5m  --build-tags integration
+	$(DOCKER) run --env=GOFLAGS=-mod=vendor --rm -v $(CURDIR):/app -w /app golangci/golangci-lint:v1.42.1 golangci-lint run -v
 
 deeplint: fmtcheck
-	$(DOCKER) run --env=GOFLAGS=-mod=vendor --rm -v $(CURDIR):/app -w /app golangci/golangci-lint:v1.34.1 golangci-lint run --exclude-use-default=false --enable-all -D dupl --build-tags integration
+	$(DOCKER) run --env=GOFLAGS=-mod=vendor --rm -v $(CURDIR):/app -w /app golangci/golangci-lint:v1.42.1 golangci-lint run --exclude-use-default=false --enable-all -D dupl --build-tags integration
 
 ci: fmtcheck lint coverci
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The entry point of the framework is the `Service`. The `Service` uses `Component
 - logging
 
 `Patron` provides the same defaults for making the usage as simple as possible.
-`Patron` needs Go 1.14 as a minimum.
+`Patron` needs Go 1.16 as a minimum.
 
 ## Table of Contents
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/beatlabs/patron
 
+go 1.16
+
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.0 // indirect
 	github.com/Shopify/sarama v1.28.0
@@ -29,5 +31,3 @@ require (
 	google.golang.org/grpc v1.27.1
 	google.golang.org/protobuf v1.26.0
 )
-
-go 1.13

--- a/go.sum
+++ b/go.sum
@@ -120,9 +120,7 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.4 h1:0ecGp3skIrHWPNGPJDaBIghfA6Sp7Ruo2Io8eLKzWm0=
 github.com/google/uuid v1.1.4/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
-github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -290,7 +288,6 @@ golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136 h1:A1gGSx58LAGVHUUsOf7IiR0u8Xb6W51gRwfDBhkdcaw=
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
@@ -303,7 +300,6 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -383,9 +379,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
-gonum.org/v1/gonum v0.8.2 h1:CCXrcPKiGGotvnN6jfUsKk4rRqm7q09/YbKb5xCEvtM=
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
-gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0 h1:OE9mWmgKkjJyEmDAAtGMPjXu+YNeGvK9VTSHY6+Qihc=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/test/docker/amqp/amqp_test.go
+++ b/test/docker/amqp/amqp_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package amqp

--- a/test/docker/amqp/component_integration_test.go
+++ b/test/docker/amqp/component_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package amqp

--- a/test/docker/aws/aws_test.go
+++ b/test/docker/aws/aws_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package aws

--- a/test/docker/aws/component_integration_test.go
+++ b/test/docker/aws/component_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package aws

--- a/test/docker/aws/sns_integration_test.go
+++ b/test/docker/aws/sns_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package aws

--- a/test/docker/aws/sqs_integration_test.go
+++ b/test/docker/aws/sqs_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package aws

--- a/test/docker/integration_test.go
+++ b/test/docker/integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package docker

--- a/test/docker/kafka/client_integration_test.go
+++ b/test/docker/kafka/client_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package kafka

--- a/test/docker/kafka/component_async_package_integration_test.go
+++ b/test/docker/kafka/component_async_package_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package kafka

--- a/test/docker/kafka/component_integration_test.go
+++ b/test/docker/kafka/component_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package kafka

--- a/test/docker/kafka/consumer_group_integration_test.go
+++ b/test/docker/kafka/consumer_group_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package kafka

--- a/test/docker/kafka/consumer_simple_integration_test.go
+++ b/test/docker/kafka/consumer_simple_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package kafka

--- a/test/docker/kafka/kafka_test.go
+++ b/test/docker/kafka/kafka_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package kafka

--- a/test/docker/redis/integration_test.go
+++ b/test/docker/redis/integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package redis

--- a/test/docker/sql/integration_test.go
+++ b/test/docker/sql/integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sql

--- a/test/docker/sql/sql_test.go
+++ b/test/docker/sql/sql_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package sql

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,14 +1,18 @@
 # github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
 github.com/Azure/go-ansiterm
 github.com/Azure/go-ansiterm/winterm
+# github.com/HdrHistogram/hdrhistogram-go v1.1.0
+## explicit
 # github.com/Microsoft/go-winio v0.4.14
 github.com/Microsoft/go-winio
 github.com/Microsoft/go-winio/pkg/guid
 # github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5
 github.com/Nvveen/Gotty
 # github.com/Shopify/sarama v1.28.0
+## explicit
 github.com/Shopify/sarama
 # github.com/aws/aws-sdk-go v1.38.17
+## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/awserr
 github.com/aws/aws-sdk-go/aws/awsutil
@@ -60,6 +64,7 @@ github.com/cenkalti/backoff/v4
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
 # github.com/containerd/continuity v0.0.0-20200228182428-0f16d7a0959c
+## explicit
 github.com/containerd/continuity/pathdriver
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
@@ -95,13 +100,16 @@ github.com/eapache/go-xerial-snappy
 # github.com/eapache/queue v1.1.0
 github.com/eapache/queue
 # github.com/elastic/go-elasticsearch/v8 v8.0.0-20190731061900-ea052088db25
+## explicit
 github.com/elastic/go-elasticsearch/v8
 github.com/elastic/go-elasticsearch/v8/esapi
 github.com/elastic/go-elasticsearch/v8/estransport
 github.com/elastic/go-elasticsearch/v8/internal/version
 # github.com/go-redis/redis/extra/rediscmd v0.2.0
+## explicit
 github.com/go-redis/redis/extra/rediscmd
 # github.com/go-redis/redis/v8 v8.11.3
+## explicit
 github.com/go-redis/redis/v8
 github.com/go-redis/redis/v8/internal
 github.com/go-redis/redis/v8/internal/hashtag
@@ -111,10 +119,12 @@ github.com/go-redis/redis/v8/internal/proto
 github.com/go-redis/redis/v8/internal/rand
 github.com/go-redis/redis/v8/internal/util
 # github.com/go-sql-driver/mysql v1.6.0
+## explicit
 github.com/go-sql-driver/mysql
 # github.com/gogo/protobuf v1.3.2
 github.com/gogo/protobuf/proto
 # github.com/golang/protobuf v1.5.2
+## explicit
 github.com/golang/protobuf/proto
 github.com/golang/protobuf/ptypes
 github.com/golang/protobuf/ptypes/any
@@ -125,10 +135,12 @@ github.com/golang/snappy
 # github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 github.com/google/shlex
 # github.com/google/uuid v1.1.4
+## explicit
 github.com/google/uuid
 # github.com/hashicorp/go-uuid v1.0.2
 github.com/hashicorp/go-uuid
 # github.com/hashicorp/golang-lru v0.5.3
+## explicit
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
 # github.com/imdario/mergo v0.3.12
@@ -177,6 +189,7 @@ github.com/jcmturner/rpc/v2/ndr
 # github.com/jmespath/go-jmespath v0.4.0
 github.com/jmespath/go-jmespath
 # github.com/julienschmidt/httprouter v1.3.0
+## explicit
 github.com/julienschmidt/httprouter
 # github.com/klauspost/compress v1.11.7
 github.com/klauspost/compress/fse
@@ -186,6 +199,8 @@ github.com/klauspost/compress/zstd
 github.com/klauspost/compress/zstd/internal/xxhash
 # github.com/konsorten/go-windows-terminal-sequences v1.0.2
 github.com/konsorten/go-windows-terminal-sequences
+# github.com/lib/pq v1.0.0
+## explicit
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/mitchellh/mapstructure v1.4.1
@@ -201,13 +216,16 @@ github.com/opencontainers/image-spec/specs-go/v1
 # github.com/opencontainers/runc v1.0.0-rc9
 github.com/opencontainers/runc/libcontainer/user
 # github.com/opentracing-contrib/go-stdlib v0.0.0-20180313041242-367231351874
+## explicit
 github.com/opentracing-contrib/go-stdlib/nethttp
 # github.com/opentracing/opentracing-go v1.1.0
+## explicit
 github.com/opentracing/opentracing-go
 github.com/opentracing/opentracing-go/ext
 github.com/opentracing/opentracing-go/log
 github.com/opentracing/opentracing-go/mocktracer
 # github.com/ory/dockertest/v3 v3.7.0
+## explicit
 github.com/ory/dockertest/v3
 github.com/ory/dockertest/v3/docker
 github.com/ory/dockertest/v3/docker/opts
@@ -239,6 +257,7 @@ github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.5.1
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
@@ -256,16 +275,20 @@ github.com/prometheus/procfs/internal/util
 # github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 github.com/rcrowley/go-metrics
 # github.com/rs/zerolog v1.5.0
+## explicit
 github.com/rs/zerolog
 github.com/rs/zerolog/internal/json
 # github.com/sirupsen/logrus v1.4.2
 github.com/sirupsen/logrus
 # github.com/streadway/amqp v0.0.0-20180315184602-8e4aba63da9f
+## explicit
 github.com/streadway/amqp
 # github.com/stretchr/testify v1.7.0
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/uber/jaeger-client-go v2.22.1+incompatible
+## explicit
 github.com/uber/jaeger-client-go
 github.com/uber/jaeger-client-go/config
 github.com/uber/jaeger-client-go/internal/baggage
@@ -285,6 +308,7 @@ github.com/uber/jaeger-client-go/thrift-gen/zipkincore
 github.com/uber/jaeger-client-go/transport
 github.com/uber/jaeger-client-go/utils
 # github.com/uber/jaeger-lib v2.4.2-0.20210604143007-135cf5605a6d+incompatible
+## explicit
 github.com/uber/jaeger-lib/metrics
 github.com/uber/jaeger-lib/metrics/prometheus
 # github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f
@@ -294,6 +318,7 @@ github.com/xeipuuv/gojsonreference
 # github.com/xeipuuv/gojsonschema v1.2.0
 github.com/xeipuuv/gojsonschema
 # go.uber.org/atomic v1.6.0
+## explicit
 go.uber.org/atomic
 # golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 golang.org/x/crypto/md4
@@ -318,10 +343,13 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 # golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
+## explicit
 golang.org/x/time/rate
 # google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
+## explicit
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.27.1
+## explicit
 google.golang.org/grpc
 google.golang.org/grpc/attributes
 google.golang.org/grpc/backoff
@@ -360,6 +388,7 @@ google.golang.org/grpc/status
 google.golang.org/grpc/tap
 google.golang.org/grpc/test/bufconn
 # google.golang.org/protobuf v1.26.0
+## explicit
 google.golang.org/protobuf/encoding/prototext
 google.golang.org/protobuf/encoding/protowire
 google.golang.org/protobuf/internal/descfmt


### PR DESCRIPTION
## Which problem is this PR solving?

Go 1.16 is needed by latest Sarama (v1.30.0).

## Short description of the changes

This PR introduces all the necessary changes to compile Patron with Go 1.16 and makes sure that the CI also uses it.