### PR TITLE
Set status code in dynamicCompressionResponseWriter early exit

### DIFF
--- a/component/http/middleware.go
+++ b/component/http/middleware.go
@@ -339,6 +339,7 @@ func (w *dynamicCompressionResponseWriter) WriteHeader(statusCode int) {
 			// no body allowed so can't compress
 			// don't try to write compression header (1f 8b) to body to avoid http.ErrBodyNotAllowed
 			w.writer = w.ResponseWriter
+			w.ResponseWriter.WriteHeader(statusCode)
 			return
 		}
 


### PR DESCRIPTION
Signed-off-by: Paschalis Tsilias <p.tsilias@thebeat.co>

<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

This PR resolves #428 [Returning a nil response results in 200 instead of 204](https://github.com/beatlabs/patron/issues/428)
<!-- REQUIRED -->

## Short description of the changes

<!-- REQUIRED -->
We set the status code for statuses where the body is not allowed, as per RFC 7230, section 3.3.

The recent change, where we introduced `dynamicCompressionResponseWriter` failed to set the header in an early exit branch, so we're fixing that.