### PR TITLE
Fix status code tracing, where status code could be -1

### DIFF
--- a/component/http/middleware.go
+++ b/component/http/middleware.go
@@ -73,6 +73,11 @@ func (w *responseWriter) Header() http.Header {
 
 // Write to the internal responseWriter and sets the status if not set already.
 func (w *responseWriter) Write(d []byte) (int, error) {
+	if !w.statusHeaderWritten {
+		w.status = http.StatusOK
+		w.statusHeaderWritten = true
+	}
+
 	value, err := w.writer.Write(d)
 	if err != nil {
 		return value, err
@@ -80,11 +85,6 @@ func (w *responseWriter) Write(d []byte) (int, error) {
 
 	if w.capturePayload {
 		w.responsePayload.Write(d)
-	}
-
-	if !w.statusHeaderWritten {
-		w.status = http.StatusOK
-		w.statusHeaderWritten = true
 	}
 
 	return value, err


### PR DESCRIPTION
## Which problem is this PR solving?

Incorrect status code metrics

## Short description of the changes

The `Write` functionality for `responseWriter` and `dynamicCompressionResponseWriter` was implemented differently.
The `dynamicCompressionResponseWriter` will first call `WriteHeader` and `Write` afterwards, whereas the `responseWriter` first called `Write` first and `WriteHeader` afterwards.

Because of that, when we fail to write the response body, the status value in the `responseWriter` will remain `-1`. In order to fix this, this PR makes the `Write` behaviour of `responseWriter` and `dynamicCompressionResponseWriter` identical.

This issue was not visible in the old metrics, because we stored everything in buckets.