### PR TITLE
Remove Content-Length when using compression

### DIFF
--- a/component/http/middleware.go
+++ b/component/http/middleware.go
@@ -404,6 +404,7 @@ func (w *dynamicCompressionResponseWriter) WriteHeader(statusCode int) {
 		case gzipHeader:
 			w.writer = gzip.NewWriter(w.ResponseWriter)
 			w.ResponseWriter.Header().Set(encoding.ContentEncodingHeader, gzipHeader)
+			w.ResponseWriter.Header().Del("Content-Length")
 		case deflateHeader:
 			var err error
 			w.writer, err = flate.NewWriter(w.ResponseWriter, w.deflateLevel)
@@ -411,6 +412,7 @@ func (w *dynamicCompressionResponseWriter) WriteHeader(statusCode int) {
 				w.writer = w.ResponseWriter
 			} else {
 				w.ResponseWriter.Header().Set(encoding.ContentEncodingHeader, deflateHeader)
+				w.ResponseWriter.Header().Del("Content-Length")
 			}
 		case identityHeader, "":
 			w.ResponseWriter.Header().Set(encoding.ContentEncodingHeader, identityHeader)

--- a/component/http/middleware_test.go
+++ b/component/http/middleware_test.go
@@ -269,7 +269,10 @@ func TestNewCompressionMiddleware(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(202) })
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Add("Content-Length", "123")
+				w.WriteHeader(202)
+			})
 			req, err := http.NewRequest("GET", "/test", nil)
 			assert.NoError(t, err)
 
@@ -281,8 +284,10 @@ func TestNewCompressionMiddleware(t *testing.T) {
 			rc := httptest.NewRecorder()
 			compressionMiddleware(handler).ServeHTTP(rc, req)
 			actual := rc.Header().Get("Content-Encoding")
-			assert.NotNil(t, actual)
 			assert.Equal(t, name, actual)
+
+			cl := rc.Header().Get("Content-Length")
+			assert.Equal(t, "", cl)
 		})
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

#451 Compression middleware Content-Length bug

## Short description of the changes

Implements the solution proposed in the issue.
