### PR TITLE
Fix command label in redis histogram metrics

### DIFF
--- a/client/redis/redis.go
+++ b/client/redis/redis.go
@@ -62,14 +62,14 @@ type tracingHook struct {
 }
 
 func (th tracingHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
-	_, ctx = startSpan(ctx, th.address, rediscmd.CmdString(cmd))
+	_, ctx = startSpan(ctx, th.address, cmd.FullName())
 	return context.WithValue(ctx, duration{}, time.Now()), nil
 }
 
 func (th tracingHook) AfterProcess(ctx context.Context, cmd redis.Cmder) error {
 	span := opentracing.SpanFromContext(ctx)
 	trace.SpanComplete(span, cmd.Err())
-	observeDuration(ctx, rediscmd.CmdString(cmd), cmd.Err())
+	observeDuration(ctx, cmd.FullName(), cmd.Err())
 	return nil
 }
 

--- a/test/docker/redis/integration_test.go
+++ b/test/docker/redis/integration_test.go
@@ -126,6 +126,6 @@ func TestClient(t *testing.T) {
 	assert.Equal(t, mtr.FinishedSpans()[0].Tags()["component"], "redis")
 	assert.Equal(t, mtr.FinishedSpans()[0].Tags()["error"], false)
 	assert.Regexp(t, `:\d+`, mtr.FinishedSpans()[0].Tags()["db.instance"])
-	assert.Equal(t, mtr.FinishedSpans()[0].Tags()["db.statement"], "set key value")
+	assert.Equal(t, mtr.FinishedSpans()[0].Tags()["db.statement"], "set")
 	assert.Equal(t, mtr.FinishedSpans()[0].Tags()["db.type"], "kv")
 }


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Closes #474.

## Short description of the changes

This change fixes the above issue by using only the command fullname.

Signed-off-by: Siavash Safi <siavash.safi@gmail.com>
