### PR TITLE
Fixed broken test race condition

### DIFF
--- a/log/log_test.go
+++ b/log/log_test.go
@@ -35,7 +35,6 @@ func TestLevelOrder(t *testing.T) {
 }
 
 func TestSetup(t *testing.T) {
-	t.Parallel()
 	tests := map[string]struct {
 		logger  Logger
 		wantErr bool
@@ -46,7 +45,6 @@ func TestSetup(t *testing.T) {
 	for name, tt := range tests {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			err := Setup(tt.logger)
 			if tt.wantErr {
 				assert.Error(t, err, "expected error")
@@ -58,7 +56,6 @@ func TestSetup(t *testing.T) {
 }
 
 func TestFromContext(t *testing.T) {
-	t.Parallel()
 	logger = &nilLogger{}
 	lg := &nilLogger{}
 	ctxWith := WithContext(context.Background(), logger)
@@ -77,7 +74,6 @@ func TestFromContext(t *testing.T) {
 	for name, tt := range tests {
 		tt := tt
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			got := FromContext(tt.args.ctx)
 			assert.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

The logger is actually a singleton, which makes parallel testing impossible.
The logger setup in application is only called once so there is no need to add a mutex to sync it.

## Short description of the changes

Made tests sequential.
