### PR TITLE
Partitions offset by timestamp

### DIFF
--- a/component/async/kafka/kafka.go
+++ b/component/async/kafka/kafka.go
@@ -15,7 +15,7 @@ import (
 	"github.com/beatlabs/patron/log"
 	"github.com/beatlabs/patron/trace"
 	"github.com/google/uuid"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -93,6 +93,8 @@ type ConsumerConfig struct {
 	DurationBasedConsumer   bool
 	DurationOffset          time.Duration
 	TimeExtractor           func(*sarama.ConsumerMessage) (time.Time, error)
+	TimestampBasedConsumer  bool
+	TimestampOffset         int64
 	SaramaConfig            *sarama.Config
 	LatestOffsetReachedChan chan<- struct{}
 }

--- a/component/async/kafka/simple/simple.go
+++ b/component/async/kafka/simple/simple.go
@@ -362,7 +362,7 @@ func (c *consumer) partitionsSinceTimestamp(_ context.Context) ([]sarama.Partiti
 	pcs := make([]sarama.PartitionConsumer, len(partitions))
 
 	ts := c.config.TimestampOffset
-	c.startingOffsets = make(map[int32]int64)
+	c.startingOffsets = make(map[int32]int64, len(partitions))
 
 	for i, partition := range partitions {
 		offset, err := client.GetOffset(c.topic, partition, ts)

--- a/component/async/kafka/simple/simple.go
+++ b/component/async/kafka/simple/simple.go
@@ -15,7 +15,7 @@ import (
 	"github.com/beatlabs/patron/log"
 )
 
-// unixNanoToTimestampDivider divides unix nano seconds to valid timestamp for kafka messages
+// unixNanoToTimestampDivider divides unix nano seconds to valid timestamp for kafka messages.
 const unixNanoToTimestampDivider = 1000_000
 
 // TimeExtractor defines a function extracting a time from a Kafka message.

--- a/component/async/kafka/simple/simple.go
+++ b/component/async/kafka/simple/simple.go
@@ -15,6 +15,9 @@ import (
 	"github.com/beatlabs/patron/log"
 )
 
+// unixNanoToTimestampDivider divides unix nano seconds to valid timestamp for kafka messages
+const unixNanoToTimestampDivider = 1000_000
+
 // TimeExtractor defines a function extracting a time from a Kafka message.
 type TimeExtractor func(*sarama.ConsumerMessage) (time.Time, error)
 
@@ -42,7 +45,7 @@ func WithTimestampOffset(since time.Duration) kafka.OptionFunc {
 			return errors.New("duration must be positive")
 		}
 		c.TimestampBasedConsumer = true
-		c.TimestampOffset = time.Now().Add(-since).UnixNano() / 1000_000
+		c.TimestampOffset = time.Now().Add(-since).UnixNano() / unixNanoToTimestampDivider
 		return nil
 	}
 }

--- a/component/async/kafka/simple/simple.go
+++ b/component/async/kafka/simple/simple.go
@@ -367,7 +367,7 @@ func (c *consumer) partitionsSinceTimestamp(_ context.Context) ([]sarama.Partiti
 	for i, partition := range partitions {
 		offset, err := client.GetOffset(c.topic, partition, ts)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get offset by timestamp %d for partition %d", ts, partition)
+			return nil, fmt.Errorf("failed to get offset by timestamp %d for partition %d: %w", ts, partition, err)
 		}
 		c.startingOffsets[partition] = offset
 


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which an issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Use kafka feature to search offset by timestamp. [Issue](https://github.com/beatlabs/patron/issues/493) in patron repository

## Short description of the changes

Leverage kafka [feature](https://kafka.apache.org/0101/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#offsetsForTimes(java.util.Map)) to find offset by given timestamp. Sarama supports this.

> Starting in Sarama v1.11.0, the method Client.GetOffset() will automatically use the new precise timestamp fetching if your Config.Version is at least kafka version 0.10.1.

Simple measurements showed that binary search is much slower
