### PR TITLE
Removing content length from JSON helper

### DIFF
--- a/client/http/encoding/json/json.go
+++ b/client/http/encoding/json/json.go
@@ -52,11 +52,6 @@ func FromResponse(ctx context.Context, rsp *http.Response, payload interface{}) 
 		}
 	}()
 
-	err = validateContentLengthHeader(rsp, len(buf))
-	if err != nil {
-		log.FromContext(ctx).Warn(err)
-	}
-
 	return json.DecodeRaw(buf, payload)
 }
 
@@ -76,26 +71,4 @@ func validateContentTypeHeader(rsp *http.Response) error {
 	default:
 		return fmt.Errorf("invalid content type provided: %s", header[0])
 	}
-}
-
-func validateContentLengthHeader(rsp *http.Response, length int) error {
-	header, ok := rsp.Header[encoding.ContentLengthHeader]
-	if !ok {
-		return nil
-	}
-
-	if len(header) == 0 {
-		return nil
-	}
-
-	expected, err := strconv.Atoi(header[0])
-	if err != nil {
-		return fmt.Errorf("failed to convert content length to int: %w", err)
-	}
-
-	if expected != length {
-		return fmt.Errorf("expected content length is %d but got %d", expected, length)
-	}
-
-	return nil
 }

--- a/client/http/encoding/json/json_test.go
+++ b/client/http/encoding/json/json_test.go
@@ -35,20 +35,18 @@ func TestFromResponse(t *testing.T) {
 	require.NoError(t, err)
 
 	type args struct {
-		contentType   *string
-		contentLength string
-		payload       []byte
+		contentType *string
+		payload     []byte
 	}
 	tests := map[string]struct {
 		args        args
 		expectedErr string
 	}{
-		"success ":                              {args: args{contentType: stringPointer(json.Type), contentLength: "20", payload: buf}},
-		"success with charset":                  {args: args{contentType: stringPointer(json.TypeCharset), contentLength: "20", payload: buf}},
-		"success with invalid content length":   {args: args{contentType: stringPointer(json.Type), contentLength: "20", payload: buf}},
-		"success, invalid content length value": {args: args{contentType: stringPointer(json.Type), contentLength: "a", payload: buf}},
-		"failure, wrong content type":           {args: args{contentType: stringPointer("text/plain"), contentLength: "20", payload: buf}, expectedErr: "invalid content type provided: text/plain"},
-		"failure, empty content type":           {args: args{contentType: stringPointer(""), contentLength: "20", payload: buf}, expectedErr: "invalid content type provided: "},
+		"success ":                            {args: args{contentType: stringPointer(json.Type), payload: buf}},
+		"success with charset":                {args: args{contentType: stringPointer(json.TypeCharset), payload: buf}},
+		"success with invalid content length": {args: args{contentType: stringPointer(json.Type), payload: buf}},
+		"failure, wrong content type":         {args: args{contentType: stringPointer("text/plain"), payload: buf}, expectedErr: "invalid content type provided: text/plain"},
+		"failure, empty content type":         {args: args{contentType: stringPointer(""), payload: buf}, expectedErr: "invalid content type provided: "},
 	}
 	for name, tt := range tests {
 		tt := tt
@@ -60,7 +58,6 @@ func TestFromResponse(t *testing.T) {
 				rsp.Header().Set(encoding.ContentTypeHeader, *tt.args.contentType)
 			}
 
-			rsp.Header().Set(encoding.ContentLengthHeader, tt.args.contentLength)
 			_, err := rsp.Write(tt.args.payload)
 			require.NoError(t, err)
 

--- a/component/http/v2/encoding/json/json.go
+++ b/component/http/v2/encoding/json/json.go
@@ -4,7 +4,6 @@ package json
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/beatlabs/patron/encoding"
@@ -53,7 +52,6 @@ func WriteResponse(w http.ResponseWriter, status int, payload interface{}) error
 
 	w.WriteHeader(status)
 	w.Header().Add(encoding.ContentTypeHeader, json.Type)
-	w.Header().Add(encoding.ContentLengthHeader, strconv.FormatInt(int64(len(buf)), 10))
 
 	_, err = w.Write(buf)
 	if err != nil {

--- a/component/http/v2/encoding/json/json_test.go
+++ b/component/http/v2/encoding/json/json_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/beatlabs/patron/encoding"
@@ -89,7 +88,6 @@ func TestWriteResponse(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rsp.Code)
 	assert.Equal(t, expectedBuf, rsp.Body.Bytes())
 	assert.Equal(t, json.Type, rsp.Header().Get(encoding.ContentTypeHeader))
-	assert.Equal(t, strconv.FormatInt(int64(len(expectedBuf)), 10), rsp.Header().Get(encoding.ContentLengthHeader))
 }
 
 func TestValidateAcceptHeader(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which an issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Fixed an issue with the content-length which affects the client side due to the gzip middleware that reduces the lenth.
Check out #451 which has been also identified in the past.

We need a test that spins up the service and does some e2e test to handle these scenarios. The example we revisit might be a good candidate.

## Short description of the changes

Remove all content length handling
