### PR TITLE
Removing accept type from JSON client helper function

### DIFF
--- a/client/http/encoding/json/json.go
+++ b/client/http/encoding/json/json.go
@@ -29,7 +29,6 @@ func NewRequest(ctx context.Context, method string, url string, payload interfac
 
 	req.Header.Set(encoding.ContentTypeHeader, json.Type)
 	req.Header.Set(encoding.ContentLengthHeader, strconv.FormatInt(int64(len(buf)), 10))
-	req.Header.Set(encoding.AcceptHeader, json.Type)
 
 	return req, nil
 }

--- a/client/http/encoding/json/json_test.go
+++ b/client/http/encoding/json/json_test.go
@@ -23,7 +23,6 @@ func TestNewRequest(t *testing.T) {
 	got, err := NewRequest(context.Background(), http.MethodPost, "/api/customer", customer{Name: "John Wick"})
 	assert.NoError(t, err)
 	assert.Equal(t, json.Type, got.Header.Get(encoding.ContentTypeHeader))
-	assert.Equal(t, json.Type, got.Header.Get(encoding.AcceptHeader))
 	assert.Equal(t, "20", got.Header.Get(encoding.ContentLengthHeader))
 }
 


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which an issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

When creating a request we assume that the response should also be json.
This is done by setting the accept header.
There are cases where this is not true and we should not enforce this.

## Short description of the changes

Removed the accept header.
