### PR TITLE
Feature: Add logfmt support to std logger

### DIFF
--- a/log/performance_test.go
+++ b/log/performance_test.go
@@ -1,0 +1,49 @@
+package log_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/beatlabs/patron/log"
+	"github.com/beatlabs/patron/log/std"
+	"github.com/beatlabs/patron/log/zerolog"
+)
+
+func Benchmark_LogFormatsComplex(b *testing.B) {
+	loggers := map[string]log.Logger{
+		"std":     std.New(&bytes.Buffer{}, log.DebugLevel, nil),
+		"zerolog": zerolog.New(&bytes.Buffer{}, log.DebugLevel, nil),
+	}
+
+	for name, logger := range loggers {
+		b.Run(fmt.Sprintf("logger_%s", name), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				subLog := logger.Sub(map[string]interface{}{
+					"string":  "with spaces",
+					"string2": `with "quoted" part`,
+					"string3": "with \n newline",
+					"string4": `with\slashes\`,
+					"simple":  `value`,
+					"integer": 23748,
+				})
+				subLog.Infof(`testing %d\n\t"`, 1)
+			}
+		})
+	}
+}
+
+func Benchmark_LogFormatsSimple(b *testing.B) {
+	loggers := map[string]log.Logger{
+		"std":     std.New(&bytes.Buffer{}, log.DebugLevel, nil),
+		"zerolog": zerolog.New(&bytes.Buffer{}, log.DebugLevel, nil),
+	}
+
+	for name, logger := range loggers {
+		b.Run(fmt.Sprintf("logger_%s", name), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				logger.Infof(`testing %d"`, 1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which an issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

Resolves https://github.com/beatlabs/patron/issues/544

Current implementation of the `std` logger it not compliant with `logfmt` format which is widely used and is supported out of the box by Grafana Loki.

Example of a log line, produced by current implementation:
```
lvl=INF age=18 name=john doe can not create an entity
```

LogFmt complient version:
```
lvl=INF age=18 name="john doe" message="can not create an entity"
```

## Short description of the changes

This change adjusts current `std` logger implementation in order to have key/value pairs with properly escaped strings for all log line elements. 

## Benchmarks

Comparison between zerolog JSON and adjusted `std` logger.

For complex log lines, `Benchmark_LogFormatsComplex`:
```
goos: darwin
goarch: arm64
pkg: github.com/beatlabs/patron/log
Benchmark_LogFormatsComplex
Benchmark_LogFormatsComplex/logger_std
Benchmark_LogFormatsComplex/logger_std-10         	  475797	      2183 ns/op
Benchmark_LogFormatsComplex/logger_zerolog
Benchmark_LogFormatsComplex/logger_zerolog-10     	  434457	      2844 ns/op
```

For simple log lines `Benchmark_LogFormatsSimple`
```
goos: darwin
goarch: arm64
pkg: github.com/beatlabs/patron/log
Benchmark_LogFormatsSimple
Benchmark_LogFormatsSimple/logger_std
Benchmark_LogFormatsSimple/logger_std-10          2971147       413.8 ns/op
Benchmark_LogFormatsSimple/logger_zerolog
Benchmark_LogFormatsSimple/logger_zerolog-10      1000000      1217 ns/op
```
