### PR TITLE
Introduce CI matrix tests for supported Go versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
   pull_request:
+
 jobs:
   lint:
     name: Lint and fmt check
@@ -21,13 +22,16 @@ jobs:
         run: make lint
 
   build:
-    name: CI
-    runs-on: ubuntu-20.04
+    name: CI on Go ${{ matrix.go-image-version}}
+    strategy:
+      matrix:
+        go-image-version: ["1.17", "1.18", "1.19"]
+    runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
+      - name: Set up Go ${{ matrix.go-image-version }}
         uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: ${{ matrix.go-image-version }}
 
       - name: Check out source code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #554.

## Short description of the changes

Introduce CI matrix tests that should run in parallel for supported Go versions (1.17-1.19).
