### PR TITLE
Add newlines with default logger

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -234,80 +234,87 @@ func (fl *fmtLogger) Sub(map[string]interface{}) Logger {
 // Panic logging.
 func (fl *fmtLogger) Panic(args ...interface{}) {
 	IncreasePanicCounter()
-	fmt.Print(args...)
+	fmt.Println(args...)
 	panic(args)
 }
 
 // Panicf logging.
 func (fl *fmtLogger) Panicf(msg string, args ...interface{}) {
 	IncreasePanicCounter()
-	fmt.Printf(msg, args...)
+	fmt.Printf(appendNewLine(msg), args...)
 	panic(args)
 }
 
 // Fatal logging.
 func (fl *fmtLogger) Fatal(args ...interface{}) {
 	IncreaseFatalCounter()
-	fmt.Print(args...)
+	fmt.Println(args...)
 	os.Exit(1)
 }
 
 // Fatalf logging.
 func (fl *fmtLogger) Fatalf(msg string, args ...interface{}) {
 	IncreaseFatalCounter()
-	fmt.Printf(msg, args...)
+	fmt.Printf(appendNewLine(msg), args...)
 	os.Exit(1)
 }
 
 // Error logging.
 func (fl *fmtLogger) Error(args ...interface{}) {
 	IncreaseErrorCounter()
-	fmt.Print(args...)
+	fmt.Println(args...)
 }
 
 // Errorf logging.
 func (fl *fmtLogger) Errorf(msg string, args ...interface{}) {
 	IncreaseErrorCounter()
-	fmt.Printf(msg, args...)
+	fmt.Printf(appendNewLine(msg), args...)
 }
 
 // Warn logging.
 func (fl *fmtLogger) Warn(args ...interface{}) {
 	IncreaseWarnCounter()
-	fmt.Print(args...)
+	fmt.Println(args...)
 }
 
 // Warnf logging.
 func (fl *fmtLogger) Warnf(msg string, args ...interface{}) {
 	IncreaseWarnCounter()
-	fmt.Printf(msg, args...)
+	fmt.Printf(appendNewLine(msg), args...)
 }
 
 // Info logging.
 func (fl *fmtLogger) Info(args ...interface{}) {
 	IncreaseInfoCounter()
-	fmt.Print(args...)
+	fmt.Println(args...)
 }
 
 // Infof logging.
 func (fl *fmtLogger) Infof(msg string, args ...interface{}) {
 	IncreaseInfoCounter()
-	fmt.Printf(msg, args...)
+	fmt.Printf(appendNewLine(msg), args...)
 }
 
 // Debug logging.
 func (fl *fmtLogger) Debug(args ...interface{}) {
 	IncreaseDebugCounter()
-	fmt.Print(args...)
+	fmt.Println(args...)
 }
 
 // Debugf logging.
 func (fl *fmtLogger) Debugf(msg string, args ...interface{}) {
 	IncreaseDebugCounter()
-	fmt.Printf(msg, args...)
+	fmt.Printf(appendNewLine(msg), args...)
 }
 
 // Level returns the debug level of the nil logger.
 func (fl *fmtLogger) Level() Level {
 	return DebugLevel
+}
+
+func appendNewLine(msg string) string {
+	if len(msg) == 0 || msg[len(msg)-1] != '\n' {
+		return msg + "\n"
+	}
+	return msg
 }


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which an issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

The deauld logger is based on `fmt` and does not append new lines at the end of the log which creates issues when Patron is not initialized e.g. tests.

## Short description of the changes

- Use fmt.Println
- Introduced a function to append new lines char on formated lines
<!-- REQUIRED -->
