### PR TITLE
feat: add OpenTelemetry metrics instrumentation for Elasticsearch client

### DIFF
--- a/client/es/benchmark_test.go
+++ b/client/es/benchmark_test.go
@@ -1,0 +1,68 @@
+package es
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"go.opentelemetry.io/otel"
+	metricsdk "go.opentelemetry.io/otel/sdk/metric"
+)
+
+// BenchmarkIndicesCreate measures the overhead of the ES client with OTEL tracing+metrics.
+func BenchmarkIndicesCreate(b *testing.B) {
+	b.ReportAllocs()
+
+	// Use a manual metrics reader to avoid exporter costs during the benchmark.
+	read := metricsdk.NewManualReader()
+	provider := metricsdk.NewMeterProvider(metricsdk.WithReader(read))
+	otel.SetMeterProvider(provider)
+
+	// Fake transport to avoid network I/O and isolate instrumentation overhead.
+	rt := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		hdr := make(http.Header)
+		hdr.Set("X-Elastic-Product", "Elasticsearch")
+		return &http.Response{
+			StatusCode: 200,
+			Header:     hdr,
+			Body:       io.NopCloser(bytes.NewReader([]byte(`{"acknowledged": true}`))),
+			Request:    req,
+		}, nil
+	})
+
+	cfg := elasticsearch.Config{Transport: rt, Addresses: []string{"http://es.local"}}
+	client, err := New(cfg, "1.0.0")
+	if err != nil {
+		b.Fatalf("failed to create client: %v", err)
+	}
+
+	ctx := context.Background()
+	queryBody := `{"mappings": {"_doc": {"properties": {"field1": {"type": "integer"}}}}}`
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rsp, err := client.Indices.Create(
+			"bench_index",
+			client.Indices.Create.WithBody(strings.NewReader(queryBody)),
+			client.Indices.Create.WithContext(ctx),
+		)
+		if err != nil {
+			b.Fatalf("request failed: %v", err)
+		}
+		if rsp != nil && rsp.Body != nil {
+			_ = rsp.Body.Close()
+		}
+	}
+	b.StopTimer()
+
+	// Shutdown provider outside of the measured section.
+	_ = provider.Shutdown(ctx)
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/client/es/benchmark_test.go
+++ b/client/es/benchmark_test.go
@@ -41,7 +41,7 @@ func BenchmarkIndicesCreate(b *testing.B) {
 	}
 
 	ctx := context.Background()
-	queryBody := `{"mappings": {"_doc": {"properties": {"field1": {"type": "integer"}}}}}`
+	queryBody := `{"mappings": {"_doc": {"properties": {"field1": {"type": "integer"}}}}}` //nolint:goconst
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/client/es/benchmark_test.go
+++ b/client/es/benchmark_test.go
@@ -27,7 +27,7 @@ func BenchmarkIndicesCreate(b *testing.B) {
 		hdr := make(http.Header)
 		hdr.Set("X-Elastic-Product", "Elasticsearch")
 		return &http.Response{
-			StatusCode: 200,
+			StatusCode: http.StatusOK,
 			Header:     hdr,
 			Body:       io.NopCloser(bytes.NewReader([]byte(`{"acknowledged": true}`))),
 			Request:    req,

--- a/client/es/elasticsearch.go
+++ b/client/es/elasticsearch.go
@@ -2,13 +2,13 @@
 package es
 
 import (
-	"github.com/elastic/elastic-transport-go/v8/elastictransport"
 	"github.com/elastic/go-elasticsearch/v8"
 )
 
 // New creates a new elasticsearch client with tracing capabilities.
 func New(cfg elasticsearch.Config, version string) (*elasticsearch.Client, error) {
-	cfg.Instrumentation = elastictransport.NewOtelInstrumentation(nil, false, version)
+	// Enable tracing via upstream OTEL instrumentation and record metrics via our wrapper
+	cfg.Instrumentation = newMetricInstrumentation(version)
 
 	return elasticsearch.NewClient(cfg)
 }

--- a/client/es/elasticsearch_test.go
+++ b/client/es/elasticsearch_test.go
@@ -118,7 +118,7 @@ func TestNew_FailureMetrics(t *testing.T) {
 	require.NoError(t, tracePublisher.ForceFlush(context.Background()))
 
 	// Metrics: ensure our ES histogram is emitted even on failure
-	rm := collectMetrics(1)
+	rm := collectMetrics(1) // Expect 1 metric
 	found := false
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {

--- a/client/es/elasticsearch_test.go
+++ b/client/es/elasticsearch_test.go
@@ -52,7 +52,7 @@ func TestNew(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, client)
 
-	queryBody := `{"mappings": {"_doc": {"properties": {"field1": {"type": "integer"}}}}}`
+	queryBody := `{"mappings": {"_doc": {"properties": {"field1": {"type": "integer"}}}}}` //nolint: goconst
 
 	rsp, err := client.Indices.Create(
 		indexName,

--- a/client/es/elasticsearch_test.go
+++ b/client/es/elasticsearch_test.go
@@ -22,7 +22,7 @@ func TestNew(t *testing.T) {
 
 	ctx := context.Background()
 
-	shutdownProvider, _ := test.SetupMetrics(ctx, t)
+	shutdownProvider, collectMetrics := test.SetupMetrics(ctx, t)
 	defer shutdownProvider()
 
 	responseMsg := `[{"acknowledged": true, "shards_acknowledged": true, "index": "test"}]`
@@ -65,4 +65,67 @@ func TestNew(t *testing.T) {
 	// Traces
 	require.NoError(t, tracePublisher.ForceFlush(context.Background()))
 	assert.Len(t, exp.GetSpans(), 1)
+
+	// Metrics: ensure our ES histogram is emitted
+	rm := collectMetrics(1)
+	found := false
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == "es.request.duration" {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "expected es.request.duration metric to be recorded")
+}
+
+func TestNew_FailureMetrics(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tracePublisher := trace.Setup("test", nil, exp)
+
+	ctx := context.Background()
+
+	shutdownProvider, collectMetrics := test.SetupMetrics(ctx, t)
+	defer shutdownProvider()
+
+	// ES test server returning 500
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Add("X-Elastic-Product", "Elasticsearch")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": true}`))
+	}))
+	defer ts.Close()
+
+	cfg := elasticsearch.Config{
+		Addresses: []string{ts.URL},
+	}
+
+	client, err := New(cfg, "1.0.0")
+	require.NoError(t, err)
+
+	// Make a typed API request (uses instrumentation Start/Close) that will return 500
+	queryBody := `{"mappings": {"_doc": {"properties": {"field1": {"type": "integer"}}}}}`
+	rsp, err := client.Indices.Create(
+		"failed_index",
+		client.Indices.Create.WithBody(strings.NewReader(queryBody)),
+		client.Indices.Create.WithContext(ctx),
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, rsp)
+	_ = rsp.Body.Close()
+
+	// Traces
+	require.NoError(t, tracePublisher.ForceFlush(context.Background()))
+
+	// Metrics: ensure our ES histogram is emitted even on failure
+	rm := collectMetrics(1)
+	found := false
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == "es.request.duration" {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "expected es.request.duration metric to be recorded on failure")
 }

--- a/client/es/elasticsearch_test.go
+++ b/client/es/elasticsearch_test.go
@@ -32,7 +32,8 @@ func TestNew(t *testing.T) {
 		_, err := w.Write([]byte(responseMsg))
 		assert.NoError(t, err)
 	}))
-	listener, err := net.Listen("tcp", ":9200") //nolint:gosec
+	listenCfg := &net.ListenConfig{}
+	listener, err := listenCfg.Listen(context.Background(), "tcp", ":9200") //nolint:gosec
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/es/instrumentation.go
+++ b/client/es/instrumentation.go
@@ -62,7 +62,11 @@ func newMetricInstrumentation(version string) elastictransport.Instrumentation {
 
 func (o *otelMetricInstrumentation) Start(ctx context.Context, name string) context.Context {
 	ctx = o.delegate.Start(ctx, name)
-	st := requestStatePool.Get().(*requestState)
+	v := requestStatePool.Get()
+	st, ok := v.(*requestState)
+	if !ok || st == nil {
+		st = &requestState{}
+	}
 	st.reset()
 	st.startTime = time.Now()
 	st.endpoint = name

--- a/client/es/instrumentation.go
+++ b/client/es/instrumentation.go
@@ -22,17 +22,10 @@ const (
 	metricDescription = "Elasticsearch request duration."
 )
 
-var (
-	errStatusCode     = errors.New("elasticsearch request failed")
-	histogramOnce     sync.Once
-	durationHistogram metric.Int64Histogram
-)
+var errStatusCode = errors.New("elasticsearch request failed")
 
 func getDurationHistogram() metric.Int64Histogram {
-	histogramOnce.Do(func() {
-		durationHistogram = patronmetric.Int64Histogram(packageName, metricName, metricDescription, "ms")
-	})
-	return durationHistogram
+	return patronmetric.Int64Histogram(packageName, metricName, metricDescription, "ms")
 }
 
 // otelMetricInstrumentation wraps the upstream OpenTelemetry instrumentation to add metrics.

--- a/client/es/instrumentation.go
+++ b/client/es/instrumentation.go
@@ -1,0 +1,127 @@
+package es
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/beatlabs/patron/observability"
+	patronmetric "github.com/beatlabs/patron/observability/metric"
+	"github.com/elastic/elastic-transport-go/v8/elastictransport"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	packageName       = "es"
+	endpointAttrKey   = "endpoint"
+	metricName        = "es.request.duration"
+	metricDescription = "Elasticsearch request duration."
+)
+
+var (
+	errStatusCode     = errors.New("elasticsearch request failed")
+	durationHistogram metric.Int64Histogram
+)
+
+func init() {
+	durationHistogram = patronmetric.Int64Histogram(packageName, metricName, metricDescription, "ms")
+}
+
+// otelMetricInstrumentation wraps the upstream OpenTelemetry instrumentation to add metrics.
+type otelMetricInstrumentation struct {
+	delegate elastictransport.Instrumentation
+}
+
+type stateKey struct{}
+
+type requestState struct {
+	startTime  time.Time
+	endpoint   string
+	statusCode int
+	err        error
+}
+
+func (st *requestState) reset() {
+	st.startTime = time.Time{}
+	st.endpoint = ""
+	st.statusCode = 0
+	st.err = nil
+}
+
+// newMetricInstrumentation creates an instrumentation that records OTEL metrics
+// and delegates tracing to the upstream implementation.
+func newMetricInstrumentation(version string) elastictransport.Instrumentation {
+	return &otelMetricInstrumentation{
+		delegate: elastictransport.NewOtelInstrumentation(nil, false, version),
+	}
+}
+
+func (o *otelMetricInstrumentation) Start(ctx context.Context, name string) context.Context {
+	ctx = o.delegate.Start(ctx, name)
+	st := requestStatePool.Get().(*requestState)
+	st.reset()
+	st.startTime = time.Now()
+	st.endpoint = name
+	return context.WithValue(ctx, stateKey{}, st)
+}
+
+func (o *otelMetricInstrumentation) Close(ctx context.Context) {
+	// Record metrics before ending the span
+	if st, ok := ctx.Value(stateKey{}).(*requestState); ok && !st.startTime.IsZero() {
+		attrSet := attribute.NewSet(
+			observability.ClientAttribute(packageName),
+			attribute.String(endpointAttrKey, st.endpoint),
+			observability.StatusAttribute(st.finalErr()),
+		)
+		durationHistogram.Record(ctx, time.Since(st.startTime).Milliseconds(), metric.WithAttributeSet(attrSet))
+		st.reset()
+		requestStatePool.Put(st)
+	}
+	o.delegate.Close(ctx)
+}
+
+func (o *otelMetricInstrumentation) RecordError(ctx context.Context, err error) {
+	if st, ok := ctx.Value(stateKey{}).(*requestState); ok {
+		st.err = err
+	}
+	o.delegate.RecordError(ctx, err)
+}
+
+func (o *otelMetricInstrumentation) RecordPathPart(ctx context.Context, pathPart, value string) {
+	o.delegate.RecordPathPart(ctx, pathPart, value)
+}
+
+func (o *otelMetricInstrumentation) RecordRequestBody(ctx context.Context, endpoint string, query io.Reader) io.ReadCloser {
+	return o.delegate.RecordRequestBody(ctx, endpoint, query)
+}
+
+func (o *otelMetricInstrumentation) BeforeRequest(req *http.Request, endpoint string) {
+	o.delegate.BeforeRequest(req, endpoint)
+}
+
+func (o *otelMetricInstrumentation) AfterRequest(req *http.Request, system, endpoint string) {
+	o.delegate.AfterRequest(req, system, endpoint)
+}
+
+func (o *otelMetricInstrumentation) AfterResponse(ctx context.Context, res *http.Response) {
+	if st, ok := ctx.Value(stateKey{}).(*requestState); ok && res != nil {
+		st.statusCode = res.StatusCode
+	}
+	o.delegate.AfterResponse(ctx, res)
+}
+
+func (st *requestState) finalErr() error {
+	if st.err != nil {
+		return st.err
+	}
+	if st.statusCode >= 400 {
+		return errStatusCode
+	}
+	return nil
+}
+
+var requestStatePool = sync.Pool{New: func() any { return &requestState{} }}

--- a/client/es/instrumentation_test.go
+++ b/client/es/instrumentation_test.go
@@ -27,7 +27,8 @@ func TestInstrumentation_SuccessEmitsMetric(t *testing.T) {
 	// Close should record a histogram sample
 	instr.Close(ctx)
 
-	rm := collect(1)
+	rm := collect(1) // Expect 1 metric
+
 	// Verify the metric exists
 	found := false
 	for _, sm := range rm.ScopeMetrics {
@@ -58,7 +59,7 @@ func TestInstrumentation_FailureEmitsMetric(t *testing.T) {
 	// Close should record a histogram sample even on error
 	instr.Close(ctx)
 
-	rm := collect(1)
+	rm := collect(1) // Expect 1 metric  // Don't expect any metrics initially
 	// Verify the metric exists
 	found := false
 	for _, sm := range rm.ScopeMetrics {

--- a/client/es/instrumentation_test.go
+++ b/client/es/instrumentation_test.go
@@ -1,0 +1,74 @@
+package es
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/beatlabs/patron/internal/test"
+)
+
+// Unit tests for the instrumentation wrapper to ensure metrics are emitted.
+
+func TestInstrumentation_SuccessEmitsMetric(t *testing.T) {
+	ctx := context.Background()
+	shutdown, collect := test.SetupMetrics(ctx, t)
+	defer shutdown()
+
+	instr := newMetricInstrumentation("1.0.0")
+
+	// Start a request span/context
+	ctx = instr.Start(ctx, "indices.create")
+
+	// Simulate a response with 200 OK
+	res := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}}
+	instr.AfterResponse(ctx, res)
+
+	// Close should record a histogram sample
+	instr.Close(ctx)
+
+	rm := collect(1)
+	// Verify the metric exists
+	found := false
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == metricName { // es.request.duration
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected %s metric to be recorded", metricName)
+	}
+}
+
+func TestInstrumentation_FailureEmitsMetric(t *testing.T) {
+	ctx := context.Background()
+	shutdown, collect := test.SetupMetrics(ctx, t)
+	defer shutdown()
+
+	instr := newMetricInstrumentation("1.0.0")
+
+	// Start a request span/context
+	ctx = instr.Start(ctx, "indices.create")
+
+	// Simulate an error before response
+	instr.RecordError(ctx, errStatusCode)
+
+	// Close should record a histogram sample even on error
+	instr.Close(ctx)
+
+	rm := collect(1)
+	// Verify the metric exists
+	found := false
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == metricName { // es.request.duration
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected %s metric to be recorded on failure", metricName)
+	}
+}

--- a/client/grpc/integration_test.go
+++ b/client/grpc/integration_test.go
@@ -112,7 +112,8 @@ func TestSayHello(t *testing.T) {
 }
 
 func testServerAndClient(t *testing.T) (examples.GreeterClient, func(), error) {
-	lis, err := net.Listen("tcp", "localhost:0")
+	listenCfg := &net.ListenConfig{}
+	lis, err := listenCfg.Listen(context.Background(), "tcp", "localhost:0")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/component/amqp/component.go
+++ b/component/amqp/component.go
@@ -99,7 +99,8 @@ func New(url, queue string, proc ProcessorFunc, oo ...OptionFunc) (*Component, e
 			Heartbeat: defaultHeartbeat,
 			Locale:    defaultLocale,
 			Dial: func(network, addr string) (net.Conn, error) {
-				return net.DialTimeout(network, addr, defaultConnectionTimeout)
+				d := &net.Dialer{Timeout: defaultConnectionTimeout}
+				return d.DialContext(context.Background(), network, addr)
 			},
 		},
 		statsCfg: statsConfig{

--- a/component/grpc/component.go
+++ b/component/grpc/component.go
@@ -60,7 +60,8 @@ func (c *Component) Server() *grpc.Server {
 
 // Run the gRPC service.
 func (c *Component) Run(ctx context.Context) error {
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", c.port))
+	listenCfg := &net.ListenConfig{}
+	lis, err := listenCfg.Listen(ctx, "tcp", fmt.Sprintf(":%d", c.port))
 	if err != nil {
 		return fmt.Errorf("failed to listen: %w", err)
 	}

--- a/component/http/component_test.go
+++ b/component/http/component_test.go
@@ -116,7 +116,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestComponent_ListenAndServe_DefaultRoutes_Shutdown(t *testing.T) {
-	listener, err := net.Listen("tcp", ":0") //nolint:gosec
+	listenCfg := &net.ListenConfig{}
+	listener, err := listenCfg.Listen(context.Background(), "tcp", ":0") //nolint:gosec
 	require.NoError(t, err)
 	port, ok := listener.Addr().(*net.TCPAddr)
 	assert.True(t, ok)

--- a/observability/metric/integration_test.go
+++ b/observability/metric/integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package observability
+package metric
 
 import (
 	"context"

--- a/observability/metric/meter.go
+++ b/observability/metric/meter.go
@@ -1,4 +1,4 @@
-package observability
+package metric
 
 import (
 	"context"


### PR DESCRIPTION
- Implemented a new metrics instrumentation for the Elasticsearch client using OpenTelemetry.
- Added a benchmark test for the `Indices.Create` method to measure performance with tracing and metrics.
- Introduced a manual metrics reader to avoid exporter costs during benchmarks.
- Enhanced request state management for better metric recording.

<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which an issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Resolves #702 

## Short description of the changes

<!-- REQUIRED -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced OpenTelemetry-based instrumentation for Elasticsearch requests, enabling detailed tracing and request duration metrics collection.
  * Introduced new benchmark tests to measure the performance impact of instrumentation.
  * Added tests verifying metrics emission for both successful and failed Elasticsearch requests.

* **Refactor**
  * Updated the Elasticsearch client to use a custom instrumentation wrapper for improved metrics and tracing integration.
  * Improved network listener creation across components to use context-aware methods for better control and configurability.
  * Updated AMQP connection dialing to use context-aware dialing with timeout support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->