### PR TITLE
docs(grpc): document gRPC component and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,10 @@ The entry point of the framework is the `Service`. The `Service` uses `Component
 - [Code of Conduct](docs/CodeOfConduct.md)
 - [Contribution Guidelines](docs/ContributionGuidelines.md)
 - [Acknowledgments](docs/ACKNOWLEDGMENTS.md)
+
+## API docs
+
+- Components
+  - [gRPC component](docs/api/components/grpc.md)
+- Clients
+  - [gRPC client](docs/api/clients/grpc.md)

--- a/docs/api/clients/grpc.md
+++ b/docs/api/clients/grpc.md
@@ -1,0 +1,34 @@
+# gRPC client
+
+Patron offers a thin gRPC client helper that wires OpenTelemetry tracing/metrics.
+
+- Package: `github.com/beatlabs/patron/client/grpc`
+- Function: `NewClient(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error)`
+- Defaults: adds `otelgrpc` stats handler to the dial options you provide
+
+## Quick start
+
+```go
+import (
+    patrongrpc "github.com/beatlabs/patron/client/grpc"
+    "google.golang.org/grpc/credentials/insecure"
+)
+
+// Create a client connection to a target (host:port or scheme-based)
+cc, err := patrongrpc.NewClient("localhost:50051",
+    grpc.WithTransportCredentials(insecure.NewCredentials()),
+)
+if err != nil { /* handle */ }
+
+defer cc.Close()
+
+client := examples.NewGreeterClient(cc)
+reply, err := client.SayHello(ctx, &examples.HelloRequest{FirstName: "John", LastName: "Doe"})
+```
+
+A runnable example client is in `examples/client/main.go` (use `-modes=grpc`).
+
+## Notes
+
+- If you pass no dial options, Patron creates an empty slice and then appends the OTel stats handler. You still need to provide transport credentials or other options as required by your environment.
+- Tracing export is handled by your process' OpenTelemetry setup (see `observability/`).

--- a/docs/api/components/grpc.md
+++ b/docs/api/components/grpc.md
@@ -1,0 +1,74 @@
+# gRPC component
+
+This component runs a gRPC server with sane defaults and built‑in observability (OpenTelemetry tracing/metrics) and health.
+
+- Package: `github.com/beatlabs/patron/component/grpc`
+- Component type: implements `Run(ctx context.Context) error`
+- Defaults: registers gRPC health server, adds OTel stats handler, optional server reflection
+
+## Quick start
+
+```go
+import (
+    patrongrpc "github.com/beatlabs/patron/component/grpc"
+)
+
+// Create component and register your service implementations.
+cmp, err := patrongrpc.New(50051)
+if err != nil { /* handle */ }
+
+// Register generated gRPC servers on cmp.Server().
+// examples.RegisterGreeterServer is generated from greeter.proto.
+examples.RegisterGreeterServer(cmp.Server(), greeterImpl)
+
+// Add the component to your Patron service and run.
+svc, _ := patron.New("example-service", patron.WithComponents(cmp))
+_ = svc.Run(ctx)
+```
+
+See a full runnable example in `examples/service/grpc.go`.
+
+## Options
+
+```go
+// WithServerOptions: provide raw grpc.ServerOption values
+cmp, err := patrongrpc.New(50051,
+    patrongrpc.WithServerOptions(
+        // e.g., add interceptors, keepalive, limits, creds, etc.
+        grpc.UnaryInterceptor(myUnaryInterceptor),
+    ),
+)
+
+// WithReflection: opt‑in to server reflection (useful in local/dev tools)
+cmp, err := patrongrpc.New(50051, patrongrpc.WithReflection())
+```
+
+Notes
+
+- Server options you pass replace any previously set options on the component. Patron always appends an OTel `StatsHandler` internally for tracing/metrics.
+- Reflection can be a security risk when exposed publicly. Prefer enabling only in non‑prod or behind auth.
+
+## Observability
+
+- Tracing and metrics are automatically wired via `otelgrpc` stats handlers. Ensure you call `observability.Setup` (done by `Service.Run`) or the helpers in `observability/` to export to your backend.
+- The component logs a startup line with the port and gracefully stops when the service context is canceled.
+
+## Health
+
+A standard gRPC health service is registered by default (`grpc.health.v1.Health`). You can wire your own health reporting using that API if needed.
+
+## Try the example
+
+- Start the example service (includes HTTP, Kafka, etc., but also gRPC):
+
+```sh
+make example-service
+```
+
+- From the example client, run only the gRPC path:
+
+```sh
+make example-client ARGS='-modes=grpc'
+```
+
+The client calls `SayHello` on the example Greeter service defined in `examples/greeter.proto`.


### PR DESCRIPTION
Adds gRPC server and client documentation under docs/api and links them from README. Includes usage, options, observability, and example references.
Resolves #566.