### PR TITLE
docs(amqp): document AMQP component and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The entry point of the framework is the `Service`. The `Service` uses `Component
 ## API docs
 
 - Components
+  - [AMQP component](docs/api/components/amqp.md)
   - [gRPC component](docs/api/components/grpc.md)
 - Clients
+  - [AMQP client](docs/api/clients/amqp.md)
   - [gRPC client](docs/api/clients/grpc.md)

--- a/docs/api/clients/amqp.md
+++ b/docs/api/clients/amqp.md
@@ -1,0 +1,43 @@
+# AMQP client (RabbitMQ publisher)
+
+A minimal publisher with OpenTelemetry tracing/metrics.
+
+- Package: `github.com/beatlabs/patron/client/amqp`
+- Type: `Publisher`
+- Constructor: `New(url string, oo ...OptionFunc) (*Publisher, error)`
+- Publish: `Publish(ctx, exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error`
+
+## Quick start
+
+```go
+import (
+  patronamqp "github.com/beatlabs/patron/client/amqp"
+  amqp "github.com/rabbitmq/amqp091-go"
+)
+
+pub, err := patronamqp.New("amqp://guest:guest@localhost:5672/")
+if err != nil { /* handle */ }
+
+defer pub.Close()
+
+msg := amqp.Publishing{ContentType: "application/octet-stream", Body: []byte("hello")}
+err = pub.Publish(ctx, "exchange-name", "routing-key", false, false, msg)
+```
+
+See `examples/client/main.go` (use `-modes=amqp`).
+
+## Options
+
+```go
+// Provide custom dial configuration (e.g., timeouts, TLS)
+patronamqp.WithConfig(amqp.Config{ /* ... */ })
+```
+
+## Observability
+
+- `Publish` starts a producer span, injects trace and correlation headers into AMQP properties, records duration metrics, and sets error status on failure.
+
+## Errors
+
+- Constructor returns error if URL is empty or connection/channel cannot be established.
+- `Publish` returns error on broker publish failure.

--- a/docs/api/components/amqp.md
+++ b/docs/api/components/amqp.md
@@ -1,0 +1,69 @@
+# AMQP component (RabbitMQ consumer)
+
+Consumes messages from RabbitMQ/AMQP with batching, retries, observability, and correlation out of the box.
+
+- Package: `github.com/beatlabs/patron/component/amqp`
+- Type: component implementing `Run(ctx context.Context) error`
+- Built-ins: OpenTelemetry tracing/metrics, correlation ID propagation, periodic queue stats
+
+## Quick start
+
+```go
+import (
+  patronamqp "github.com/beatlabs/patron/component/amqp"
+)
+
+proc := func(ctx context.Context, batch patronamqp.Batch) {
+  for _, m := range batch.Messages() {
+    // Process m.Body() or m.Message() as needed
+    _ = m.ACK() // or m.NACK()
+  }
+}
+
+cmp, err := patronamqp.New("amqp://guest:guest@localhost:5672/", "queue-name", proc,
+  patronamqp.WithRetry(10, time.Second),
+)
+// add cmp to the service and Run
+```
+
+See the runnable example: `examples/service/amqp.go`.
+
+## Options
+
+```go
+// Batching: deliver messages to your processor in groups
+patronamqp.WithBatching(count /* >1 */, timeout /* >0 */)
+
+// Retries: reconnect on failures
+patronamqp.WithRetry(count, delay)
+
+// Custom AMQP dial config: timeouts, TLS, etc
+patronamqp.WithConfig(amqp.Config{ /* ... */ })
+
+// Stats interval: queue depth gauge cadence
+patronamqp.WithStatsInterval(interval)
+
+// Requeue policy: control NACK requeue behavior
+patronamqp.WithRequeue(true|false)
+```
+
+Notes
+
+- Batching: When either the count is reached or the timeout elapses, the batch is delivered. Use `Batch.ACK()`/`Batch.NACK()` to handle many at once; it returns any failed messages and a joined error.
+- Each message exposes `Context()` with logger/tracing and `Span()`. Call `ACK()` or `NACK()` to end the span; success/error is recorded accordingly.
+- The component auto-reconnects with `WithRetry`; after the configured attempts it returns the last error.
+- Queue size is periodically observed via passive declare and exported as a metric.
+
+## Message API
+
+- `Message.ID() string`
+- `Message.Body() []byte`
+- `Message.Message() amqp.Delivery` (raw access)
+- `Message.Context() context.Context` (contains correlation ID and request-scoped logger)
+- `Message.Span() trace.Span`
+- `Message.ACK() error` / `Message.NACK() error`
+
+## Troubleshooting
+
+- Connection issues: check dial `amqp.Config` (heartbeat, TLS, timeouts). You can inject your own Dialer via `Config.Dial`.
+- Consumer tag and re-delivery: Patron sets a unique tag per subscription and uses manual acks. Use `WithRequeue(false)` to avoid requeue on NACK.


### PR DESCRIPTION
Adds AMQP consumer and publisher documentation under docs/api and links them from README. Includes usage, options, observability, and example references.\n\nResolves #565.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added AMQP Component docs (RabbitMQ consumer): quick start, options (batching, retry, config, stats interval, requeue), message/batch ACK/NACK semantics, observability, troubleshooting, and example reference.
  - Added AMQP Client docs (RabbitMQ publisher): constructor and publish usage, options (custom dial config), observability details, error cases, and quick start with example reference.
  - Updated README to include links to the new AMQP Component and Client documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->