### PR TITLE
feat(docs): document SQS component

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The entry point of the framework is the `Service`. The `Service` uses `Component
 - Components
   - [AMQP component](docs/api/components/amqp.md)
   - [gRPC component](docs/api/components/grpc.md)
+  - [SQS component](docs/api/components/sqs.md)
 - Clients
   - [AMQP client](docs/api/clients/amqp.md)
   - [gRPC client](docs/api/clients/grpc.md)
+  - [SQS client](docs/api/clients/sqs.md)

--- a/docs/api/clients/sqs.md
+++ b/docs/api/clients/sqs.md
@@ -1,0 +1,17 @@
+# SQS client (AWS SQS)
+
+Use your AWS SDK v2 SQS client directly; Patron provides a consumer component but no custom SQS client wrapper. The example app shows how to create the AWS client and send messages.
+
+- Example producer: `examples/client/main.go` (sendSQSMessage)
+- Example consumer: `examples/service/sqs.go`
+
+## Quick start (producer)
+
+```go
+cfg, _ := examples.CreateSQSConfig(ctx)
+client := sqs.NewFromConfig(cfg, sqs.WithEndpointResolverV2(&examples.SQSCustomResolver{}))
+url, _ := client.GetQueueUrl(ctx, &sqs.GetQueueUrlInput{QueueName: aws.String(queue)})
+_, _ = client.SendMessage(ctx, &sqs.SendMessageInput{QueueUrl: url.QueueUrl, MessageBody: aws.String("hello")})
+```
+
+Tracing is enabled through the general OpenTelemetry setup in this repo (see `observability/`), plus aws-sdk-v2 instrumentation vendored with the project.

--- a/docs/api/components/sqs.md
+++ b/docs/api/components/sqs.md
@@ -1,0 +1,60 @@
+# SQS component (AWS SQS consumer)
+
+Consumes messages from AWS SQS with long polling, visibility timeouts, retries, and observability.
+
+- Package: `github.com/beatlabs/patron/component/sqs`
+- Type: component implementing `Run(ctx context.Context) error`
+- Built-ins: OpenTelemetry tracing/metrics, correlation propagation, periodic queue stats, batch ack/nack helpers
+
+## Quick start
+
+```go
+import (
+  patronsqs "github.com/beatlabs/patron/component/sqs"
+)
+
+proc := func(ctx context.Context, batch patronsqs.Batch) {
+  for _, m := range batch.Messages() {
+    // handle m.Body() or use the raw message via m.Message()
+    _ = m.ACK() // or m.NACK()
+  }
+}
+
+cmp, err := patronsqs.New("sqs-cmp", "queue-name", sqsClient, proc,
+  patronsqs.WithPollWaitSeconds(5), // long polling
+)
+// add cmp to a Service and Run
+```
+
+See the runnable example: `examples/service/sqs.go`.
+
+## Options
+
+```go
+// Max messages per receive (1..10)
+patronsqs.WithMaxMessages(n)
+
+// Long polling wait seconds (0..20)
+patronsqs.WithPollWaitSeconds(seconds)
+
+// Visibility timeout in seconds (0..43200)
+patronsqs.WithVisibilityTimeout(seconds)
+
+// Stats interval for queue metrics
+patronsqs.WithQueueStatsInterval(interval)
+
+// Retry settings for transient failures
+patronsqs.WithRetries(count)
+patronsqs.WithRetryWait(interval)
+
+// Queue owner AWS account ID (for cross-account usage)
+patronsqs.WithQueueOwner(ownerID)
+```
+
+Notes
+
+- Batching: a batch is built from a receive call; you can call `Batch.ACK()`/`Batch.NACK()` to ack/nack multiple messages; returns any failures and a joined error.
+- Each message has `Context()` with a logger and correlation ID and a `Span()`; calling `ACK()`/`NACK()` ends the span and records success/error.
+- `WithPollWaitSeconds` enables long polling; prefer >0 to reduce empty receives and costs.
+- `WithVisibilityTimeout` should exceed your processing time to avoid redeliveries.
+- Stats use `GetQueueAttributes` to publish gauges for available/delayed/invisible counts.


### PR DESCRIPTION
Adds SQS component documentation under docs/api/components and links from README, plus a client note page pointing to example usage with AWS SDK v2.
Resolves #569.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SQS Component docs outlining consumer capabilities (long polling, visibility timeout, retries, batching, observability) with configuration options and behavioral notes.
  * Introduced SQS Client docs showing how to use the AWS SDK v2 client, including quick start guidance and messaging flow.
  * Included quick start examples for both component and client, with links to runnable examples.
  * Clarified tracing/metrics integration and queue statistics publishing.
  * No code or public API changes; updates are documentation-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->