### PR TITLE
docs: document HTTP component and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ The entry point of the framework is the `Service`. The `Service` uses `Component
 
 - Components
   - [AMQP component](docs/api/components/amqp.md)
+  - [HTTP component](docs/api/components/http.md)
   - [Kafka component](docs/api/components/kafka.md)
   - [gRPC component](docs/api/components/grpc.md)
   - [SQS component](docs/api/components/sqs.md)
 - Clients
   - [AMQP client](docs/api/clients/amqp.md)
+  - [HTTP client](docs/api/clients/http.md)
   - [Kafka client](docs/api/clients/kafka.md)
   - [gRPC client](docs/api/clients/grpc.md)
   - [SQS client](docs/api/clients/sqs.md)

--- a/docs/api/clients/http.md
+++ b/docs/api/clients/http.md
@@ -1,0 +1,41 @@
+# HTTP client
+
+Traced HTTP client with correlation propagation, optional circuit breaker, and auto-decompression helpers.
+
+- Package: `github.com/beatlabs/patron/client/http`
+- Type: `TracedClient`, implements `Do(req *http.Request) (*http.Response, error)`
+
+## Quick start
+
+```go
+import (
+  clienthttp "github.com/beatlabs/patron/client/http"
+)
+
+cl, _ := clienthttp.New(
+  clienthttp.WithTimeout(30*time.Second),
+)
+
+req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com/api", nil)
+req.Header.Set("Accept-Encoding", "gzip")
+
+rsp, err := cl.Do(req)
+if err != nil { /* handle */ }
+
+defer rsp.Body.Close()
+```
+
+Notes
+
+- Tracing: uses `otelhttp.NewTransport` under the hood; spans are created for outbound requests.
+- Correlation: adds the `X-Correlation-ID` header from request context automatically.
+- Decompression: if `Accept-Encoding` is set to `gzip` or `deflate`, response body is decompressed.
+
+## Options
+
+- `WithTimeout(d time.Duration)`
+- `WithCircuitBreaker(name string, set circuitbreaker.Setting)`
+- `WithTransport(rt http.RoundTripper)` (wrapped with `otelhttp.NewTransport`)
+- `WithCheckRedirect(func(req *http.Request, via []*http.Request) error)`
+
+See tests in `client/http` and usage in examples for more.

--- a/docs/api/components/http.md
+++ b/docs/api/components/http.md
@@ -1,0 +1,69 @@
+# HTTP component (server)
+
+Serve HTTP endpoints with built-in profiling, health checks, middleware, and tracing/logging.
+
+- Component: `github.com/beatlabs/patron/component/http`
+- Router: `github.com/beatlabs/patron/component/http/router`
+- Type: component implementing `Run(ctx context.Context) error`
+
+## Quick start
+
+```go
+import (
+  "context"
+  "net/http"
+  patronhttp "github.com/beatlabs/patron/component/http"
+  httprouter "github.com/beatlabs/patron/component/http/router"
+)
+
+hello, _ := patronhttp.NewRoute("GET /api/hello", func(w http.ResponseWriter, r *http.Request) {
+  w.WriteHeader(http.StatusOK)
+  _, _ = w.Write([]byte("hello"))
+})
+
+mux, _ := httprouter.New(
+  httprouter.WithRoutes(hello),
+)
+
+cmp, _ := patronhttp.New(mux, patronhttp.WithPort(8080))
+_ = cmp.Run(context.Background()) // usually managed by Service
+```
+
+See `examples/service/` for a full setup.
+
+## Component options
+
+- `WithPort(port int)`
+- `WithTLS(certFile, keyFile string)`
+- `WithReadTimeout(d time.Duration)`
+- `WithWriteTimeout(d time.Duration)`
+- `WithHandlerTimeout(d time.Duration)`
+- `WithShutdownGracePeriod(d time.Duration)`
+
+Env overrides: `PATRON_HTTP_DEFAULT_PORT`, `PATRON_HTTP_READ_TIMEOUT`, `PATRON_HTTP_WRITE_TIMEOUT`.
+
+## Router options
+
+- `WithRoutes(routes...)`
+- `WithAliveCheck(func() AliveStatus)` (defaults to Alive)
+- `WithReadyCheck(func() ReadyStatus)` (defaults to Ready)
+- `WithDeflateLevel(level int)` (compression)
+- `WithMiddlewares(mm ...)`
+- `WithExpVarProfiling()` (adds `/debug/vars`)
+- `WithAppNameHeaders(name, version)` (adds X-App-Name/X-App-Version)
+
+Management routes: `/debug/pprof/*`, `/alive`, `/ready`.
+
+## Route helpers
+
+- `WithMiddlewares(mm ...)`
+- `WithRateLimiting(limit, burst)`
+- `WithAuth(authenticator)`
+- `WithCache(cache, httpcache.Age)` (GET routes)
+- `router.NewFileServerRoute("GET /", "./public", "./public/index.html")`
+
+## Observability
+
+- Logging/tracing middleware is applied to user routes.
+- Configure error-status logging via `PATRON_HTTP_STATUS_ERROR_LOGGING` (comma-separated status codes).
+- Change log level at runtime: `POST /debug/log/{level}`.


### PR DESCRIPTION
This PR adds documentation for the HTTP component and HTTP client, and updates README links.\n\n- docs/api/components/http.md\n- docs/api/clients/http.md\n- README.md (API docs section)\n\nCloses #567.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added API docs for the HTTP server component, including a quick start, configuration (ports, timeouts, TLS, shutdown), router options (health/readiness checks, middlewares, profiling), management routes, and observability/log-level controls.
  - Added API docs for a traced HTTP client with a quick start, outbound request tracing, correlation headers, response decompression, and configurable options (timeouts, circuit breaker, redirect handling, transport customization).
  - Updated README to reference the new documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->