### PR TITLE
chore: pin Docker images and GitHub Actions to specific versions

### DIFF
--- a/.github/prompts/upgrade.prompt.md
+++ b/.github/prompts/upgrade.prompt.md
@@ -7,7 +7,7 @@ model: Claude Sonnet 4.5 (Preview) (copilot)
 - Upgrade all Go modules, tidy and vendor.
 - Upgrade all Docker images in the docker-compose files. Always pin to a specific version that depicts the highest major one.
 - Upgrade Github Action workflows to the latest versions. Always pin to a specific version that depicts the highest major one.
-- Run unit and integration tests to ensure everything works as expected.
+- Run unit and integration tests with no caching to ensure everything works as expected.
 - Commit changes and push the branch to origin.
-- Create a pull request to merge the changes into the master branch.
-- After CI checks are successful, merge (squash and merge) the pull request with admin privileges.
+- Create a pull request and wait for the CI to succeed.
+- Report the overall changes that were made in the upgrade.

--- a/.github/prompts/upgrade.prompt.md
+++ b/.github/prompts/upgrade.prompt.md
@@ -1,10 +1,12 @@
 ---
 mode: agent
+model: Claude Sonnet 4.5 (Preview) (copilot)
 ---
 
 - Create a branch to work on.
 - Upgrade all Go modules, tidy and vendor.
-- Upgrade all Docker images in the docker-compose files.
+- Upgrade all Docker images in the docker-compose files. Always pin to a specific version that depicts the highest major one.
+- Upgrade Github Action workflows to the latest versions. Always pin to a specific version that depicts the highest major one.
 - Run unit and integration tests to ensure everything works as expected.
 - Commit changes and push the branch to origin.
 - Create a pull request to merge the changes into the master branch.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: "go.mod"
           
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version-file: "go.mod"
 
@@ -41,7 +41,7 @@ jobs:
           make ci
 
       - name: Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@af09b5e394c93991b95a5e7646aeb90c1917f78f # v5.5.1
         with:
           fail_ci_if_error: true # optional (default = false)
           files: ./coverage.txt

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -17,10 +17,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Run opencode
-        uses: sst/opencode/github@latest
+        uses: sst/opencode/github@83afcb9c427a1b7df7081f0b8e2f8ef2edd3601a # latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       retries: 5
       start_period: 15s
   rabbitmq:
-    image: rabbitmq:4.1.4-management
+    image: rabbitmq:4-management
     restart: always
     ports:
       - "4369:4369"
@@ -53,7 +53,7 @@ services:
       retries: 5
       start_period: 15s
   mysql:
-    image: mysql:8.0.43
+    image: mysql:9
     restart: always
     environment:
       MYSQL_DATABASE: "patrondb"
@@ -88,7 +88,7 @@ services:
       retries: 5
       start_period: 15s
   localstack:
-    image: localstack/localstack:4.9.2
+    image: localstack/localstack:4
     restart: always
     ports:
       - "127.0.0.1:4566:4566" # LocalStack Gateway
@@ -127,7 +127,7 @@ services:
       timeout: 10s
       retries: 3
   mongo:
-    image: mongo:8.0.15
+    image: mongo:8
     restart: always
     ports:
       - "27017:27017"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   kafka:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:8.0.2
     restart: always
     hostname: broker
     ports:
@@ -32,7 +32,7 @@ services:
       retries: 5
       start_period: 15s
   rabbitmq:
-    image: rabbitmq:4-management
+    image: rabbitmq:4.1.4-management
     restart: always
     ports:
       - "4369:4369"
@@ -53,7 +53,7 @@ services:
       retries: 5
       start_period: 15s
   mysql:
-    image: mysql:latest
+    image: mysql:8.0.43
     restart: always
     environment:
       MYSQL_DATABASE: "patrondb"
@@ -74,7 +74,7 @@ services:
       retries: 5
       start_period: 15s
   valkey:
-    image: valkey/valkey:latest
+    image: valkey/valkey:9.0
     restart: always
     command: ["valkey-server", "--bind", "0.0.0.0"]
     ports:
@@ -88,7 +88,7 @@ services:
       retries: 5
       start_period: 15s
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:4.9.2
     restart: always
     ports:
       - "127.0.0.1:4566:4566" # LocalStack Gateway
@@ -106,7 +106,7 @@ services:
       retries: 5
       start_period: 15s
   hivemq:
-    image: hivemq/hivemq4:latest
+    image: hivemq/hivemq4:4.45.0
     restart: always
     ports:
       - target: 1883
@@ -127,7 +127,7 @@ services:
       timeout: 10s
       retries: 3
   mongo:
-    image: mongo:latest
+    image: mongo:8.0.15
     restart: always
     ports:
       - "27017:27017"
@@ -141,7 +141,7 @@ services:
       retries: 5
       start_period: 15s
   otelcol:
-    image: otel/opentelemetry-collector-contrib:latest
+    image: otel/opentelemetry-collector-contrib:0.137.0
     restart: always
     command: ["--config=/etc/otelcol-config.yaml"]
     volumes:


### PR DESCRIPTION
Pin all versions to avoid unexpected updates and improve reproducibility.

## Docker Images Pinned

Using highest major version tags where available:
- **MySQL**: 8.0.43 → **9** (major version upgrade to MySQL 9)
- **MongoDB**: 8.0.15 → **8** (major version tag)
- **RabbitMQ**: 4.1.4-management → **4-management** (major version tag)
- **LocalStack**: 4.9.2 → **4** (major version tag)

Specific versions (no major-only tags available):
- **Kafka**: confluentinc/cp-kafka:**8.0.2** (highest in major 8)
- **Valkey**: valkey/valkey:**9.0** (9 not available, using 9.0)
- **HiveMQ**: hivemq/hivemq4:**4.45.0** (no major-only tag)
- **OpenTelemetry Collector**: otel/opentelemetry-collector-contrib:**0.137.0** (semver)

## GitHub Actions Pinned (with commit SHAs)

- actions/checkout@**08c6903** (v5.0.0)
- actions/setup-go@**4469467** (v6.0.0)
- codecov/codecov-action@**af09b5e** (v5.5.1)
- sst/opencode/github@**83afcb9** (latest)

## Testing

- ✅ Unit tests: All pass
- ✅ Integration tests: All pass (including with MySQL 9 upgrade)

This follows best practices for dependency management by pinning to specific versions that depict the highest major version, rather than using floating tags like \`latest\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Pinned Docker service images to specific major versions for reproducible local environments.
  - Anchored CI workflows and actions to exact revisions for greater stability and traceability.
  - Configured test runs to execute without cache for unit and integration tests.

- Documentation
  - Added a model annotation to the upgrade prompt header.
  - Updated upgrade guidance to prefer explicit version-pinning for Docker images and CI actions.
  - Clarified PR flow: wait for CI to pass and report overall upgrade changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->