### PR TITLE
refactor: remove panics from metric constructor API

### DIFF
--- a/cache/metric.go
+++ b/cache/metric.go
@@ -25,7 +25,11 @@ var (
 // SetupMetricsOnce initializes the cache counter.
 func SetupMetricsOnce() {
 	cacheOnce.Do(func() {
-		cacheCounter = patronmetric.Int64Counter(packageName, "cache.counter", "Number of cache calls.", "1")
+		var err error
+		cacheCounter, err = patronmetric.Int64Counter(packageName, "cache.counter", "Number of cache calls.", "1")
+		if err != nil {
+			panic(err)
+		}
 	})
 }
 

--- a/client/amqp/amqp.go
+++ b/client/amqp/amqp.go
@@ -24,8 +24,12 @@ const packageName = "amqp"
 var publishDurationMetrics metric.Float64Histogram
 
 func init() {
-	publishDurationMetrics = patronmetric.Float64Histogram(packageName, "amqp.publish.duration",
+	var err error
+	publishDurationMetrics, err = patronmetric.Float64Histogram(packageName, "amqp.publish.duration",
 		"AMQP publish duration.", "ms")
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Publisher defines a RabbitMQ publisher with tracing instrumentation.

--- a/client/es/instrumentation.go
+++ b/client/es/instrumentation.go
@@ -25,7 +25,11 @@ const (
 var errStatusCode = errors.New("elasticsearch request failed")
 
 func getDurationHistogram() metric.Int64Histogram {
-	return patronmetric.Int64Histogram(packageName, metricName, metricDescription, "ms")
+	hist, err := patronmetric.Int64Histogram(packageName, metricName, metricDescription, "ms")
+	if err != nil {
+		panic(err)
+	}
+	return hist
 }
 
 // otelMetricInstrumentation wraps the upstream OpenTelemetry instrumentation to add metrics.

--- a/client/kafka/kafka.go
+++ b/client/kafka/kafka.go
@@ -23,7 +23,11 @@ const packageName = "kafka"
 var publishCount metric.Int64Counter
 
 func init() {
-	publishCount = patronmetric.Int64Counter(packageName, "kafka.publish.count", "Kafka message count.", "1")
+	var err error
+	publishCount, err = patronmetric.Int64Counter(packageName, "kafka.publish.count", "Kafka message count.", "1")
+	if err != nil {
+		panic(err)
+	}
 }
 
 func publishCountAdd(ctx context.Context, attrs ...attribute.KeyValue) {

--- a/client/mongo/metric.go
+++ b/client/mongo/metric.go
@@ -15,7 +15,11 @@ const packageName = "mongo"
 var durationHistogram metric.Int64Histogram
 
 func init() {
-	durationHistogram = patronmetric.Int64Histogram(packageName, "mongo.duration", "Mongo command duration.", "ms")
+	var err error
+	durationHistogram, err = patronmetric.Int64Histogram(packageName, "mongo.duration", "Mongo command duration.", "ms")
+	if err != nil {
+		panic(err)
+	}
 }
 
 type observabilityMonitor struct {

--- a/client/mqtt/metric.go
+++ b/client/mqtt/metric.go
@@ -18,7 +18,11 @@ const (
 var durationHistogram metric.Int64Histogram
 
 func init() {
-	durationHistogram = patronmetric.Int64Histogram(packageName, "mqtt.publish.duration", "MQTT publish duration.", "ms")
+	var err error
+	durationHistogram, err = patronmetric.Int64Histogram(packageName, "mqtt.publish.duration", "MQTT publish duration.", "ms")
+	if err != nil {
+		panic(err)
+	}
 }
 
 func topicAttr(topic string) attribute.KeyValue {

--- a/client/sql/sql.go
+++ b/client/sql/sql.go
@@ -21,7 +21,11 @@ const packageName = "sql"
 var durationHistogram metric.Int64Histogram
 
 func init() {
-	durationHistogram = patronmetric.Int64Histogram(packageName, "sql.cmd.duration", "SQL command duration.", "ms")
+	var err error
+	durationHistogram, err = patronmetric.Int64Histogram(packageName, "sql.cmd.duration", "SQL command duration.", "ms")
+	if err != nil {
+		panic(err)
+	}
 }
 
 type connInfo struct {

--- a/component/amqp/metric.go
+++ b/component/amqp/metric.go
@@ -26,9 +26,19 @@ var (
 )
 
 func init() {
-	messageAgeGauge = patronmetric.Float64Gauge(packageName, "amqp.message.age", "AMQP message age.", "s")
-	messageCounter = patronmetric.Int64Counter(packageName, "amqp.message.counter", "AMQP message counter.", "1")
-	messageQueueSizeGauge = patronmetric.Int64Gauge(packageName, "amqp.queue.size", "AMQP message queue size.", "1")
+	var err error
+	messageAgeGauge, err = patronmetric.Float64Gauge(packageName, "amqp.message.age", "AMQP message age.", "s")
+	if err != nil {
+		panic(err)
+	}
+	messageCounter, err = patronmetric.Int64Counter(packageName, "amqp.message.counter", "AMQP message counter.", "1")
+	if err != nil {
+		panic(err)
+	}
+	messageQueueSizeGauge, err = patronmetric.Int64Gauge(packageName, "amqp.queue.size", "AMQP message queue size.", "1")
+	if err != nil {
+		panic(err)
+	}
 }
 
 func observeMessageCountInc(ctx context.Context, queue string, state messageState, err error) {

--- a/component/http/cache/metric.go
+++ b/component/http/cache/metric.go
@@ -25,8 +25,15 @@ var (
 )
 
 func init() {
-	cacheExpirationHistogram = patronmetric.Int64Histogram(packageName, "http.cache.expiration", "HTTP cache expiration.", "s")
-	cacheStatusCounter = patronmetric.Int64Counter(packageName, "http.cache.status", "HTTP cache status.", "1")
+	var err error
+	cacheExpirationHistogram, err = patronmetric.Int64Histogram(packageName, "http.cache.expiration", "HTTP cache expiration.", "s")
+	if err != nil {
+		panic(err)
+	}
+	cacheStatusCounter, err = patronmetric.Int64Counter(packageName, "http.cache.status", "HTTP cache status.", "1")
+	if err != nil {
+		panic(err)
+	}
 }
 
 func observeCacheAdd(path string) {

--- a/component/kafka/metric.go
+++ b/component/kafka/metric.go
@@ -28,9 +28,19 @@ var (
 )
 
 func init() {
-	consumerErrorsGauge = patronmetric.Int64Counter(packageName, "kafka.consumer.errors", "Kafka consumer error counter.", "s")
-	topicPartitionOffsetDiffGauge = patronmetric.Float64Gauge(packageName, "kafka.consumer.offset.diff", "Kafka topic partition diff gauge.", "1")
-	messageStatusCount = patronmetric.Int64Counter(packageName, "kafka.message.status", "Kafka message status counter.", "1")
+	var err error
+	consumerErrorsGauge, err = patronmetric.Int64Counter(packageName, "kafka.consumer.errors", "Kafka consumer error counter.", "s")
+	if err != nil {
+		panic(err)
+	}
+	topicPartitionOffsetDiffGauge, err = patronmetric.Float64Gauge(packageName, "kafka.consumer.offset.diff", "Kafka topic partition diff gauge.", "1")
+	if err != nil {
+		panic(err)
+	}
+	messageStatusCount, err = patronmetric.Int64Counter(packageName, "kafka.message.status", "Kafka message status counter.", "1")
+	if err != nil {
+		panic(err)
+	}
 }
 
 func consumerErrorsInc(ctx context.Context, name string) {

--- a/component/sqs/metric.go
+++ b/component/sqs/metric.go
@@ -28,9 +28,19 @@ var (
 )
 
 func init() {
-	messageAgeGauge = patronmetric.Float64Gauge(packageName, "sqs.message.age", "SQS message age.", "s")
-	messageCounter = patronmetric.Int64Counter(packageName, "sqs.message.counter", "SQS message counter.", "1")
-	messageQueueSizeGauge = patronmetric.Float64Gauge(packageName, "sqs.queue.size", "SQS message queue size.", "1")
+	var err error
+	messageAgeGauge, err = patronmetric.Float64Gauge(packageName, "sqs.message.age", "SQS message age.", "s")
+	if err != nil {
+		panic(err)
+	}
+	messageCounter, err = patronmetric.Int64Counter(packageName, "sqs.message.counter", "SQS message counter.", "1")
+	if err != nil {
+		panic(err)
+	}
+	messageQueueSizeGauge, err = patronmetric.Float64Gauge(packageName, "sqs.queue.size", "SQS message queue size.", "1")
+	if err != nil {
+		panic(err)
+	}
 }
 
 func observerMessageAge(ctx context.Context, queue string, attrs map[string]string) {

--- a/observability/metric/meter.go
+++ b/observability/metric/meter.go
@@ -42,66 +42,66 @@ func newMeterProvider(ctx context.Context, res *resource.Resource) (*sdkmetric.M
 }
 
 // Float64Histogram creates a float64 histogram metric.
-func Float64Histogram(pkg, name, description, unit string) metric.Float64Histogram {
+func Float64Histogram(pkg, name, description, unit string) (metric.Float64Histogram, error) {
 	histogram, err := otel.Meter(pkg).Float64Histogram(name,
 		metric.WithDescription(description),
 		metric.WithUnit(unit),
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return histogram
+	return histogram, nil
 }
 
 // Int64Histogram creates an int64 histogram metric.
-func Int64Histogram(pkg, name, description, unit string) metric.Int64Histogram {
+func Int64Histogram(pkg, name, description, unit string) (metric.Int64Histogram, error) {
 	histogram, err := otel.Meter(pkg).Int64Histogram(name,
 		metric.WithDescription(description),
 		metric.WithUnit(unit),
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return histogram
+	return histogram, nil
 }
 
 // Int64Counter creates an int64 counter metric.
-func Int64Counter(pkg, name, description, unit string) metric.Int64Counter {
+func Int64Counter(pkg, name, description, unit string) (metric.Int64Counter, error) {
 	counter, err := otel.Meter(pkg).Int64Counter(name,
 		metric.WithDescription(description),
 		metric.WithUnit(unit),
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return counter
+	return counter, nil
 }
 
 // Float64Gauge creates a float64 gauge metric.
-func Float64Gauge(pkg, name, description, unit string) metric.Float64Gauge {
+func Float64Gauge(pkg, name, description, unit string) (metric.Float64Gauge, error) {
 	gauge, err := otel.Meter(pkg).Float64Gauge(name,
 		metric.WithDescription(description),
 		metric.WithUnit(unit),
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return gauge
+	return gauge, nil
 }
 
 // Int64Gauge creates an int64 gauge metric.
-func Int64Gauge(pkg, name, description, unit string) metric.Int64Gauge {
+func Int64Gauge(pkg, name, description, unit string) (metric.Int64Gauge, error) {
 	gauge, err := otel.Meter(pkg).Int64Gauge(name,
 		metric.WithDescription(description),
 		metric.WithUnit(unit),
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return gauge
+	return gauge, nil
 }

--- a/reliability/circuitbreaker/breaker.go
+++ b/reliability/circuitbreaker/breaker.go
@@ -39,7 +39,11 @@ var (
 )
 
 func init() {
-	statusCounter = patronmetric.Int64Counter(packageName, "circuit-breaker.status", "Circuit breaker status counter.", "1")
+	var err error
+	statusCounter, err = patronmetric.Int64Counter(packageName, "circuit-breaker.status", "Circuit breaker status counter.", "1")
+	if err != nil {
+		panic(err)
+	}
 }
 
 func breakerCounterInc(name string, st status) {


### PR DESCRIPTION
## Summary
- Refactored all metric constructor functions in `observability/metric` to return `(instrument, error)` instead of panicking
- Updated 13 call sites across cache, client, component, and reliability packages to handle errors explicitly in `init()` functions
- Maintains fail-fast behavior at initialization time while removing panics from the public library API

This change improves code quality by making the metric constructor API safer and more idiomatic, allowing consumers to decide how to handle initialization errors rather than forcing a panic from the library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced metric initialization with explicit error validation across cache, client, component, and reliability modules. Metric creation operations now validate success during startup and fail immediately if any metric cannot be created, preventing applications from running with incomplete observability coverage and ensuring all metrics are properly available before normal operation begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->