### PR TITLE
Migrate build system from Make to Task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,16 @@ jobs:
         with:
           go-version-file: "go.mod"
 
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+
+      - name: Validate Taskfile
+        run: task validate
+
       - name: Linting and fmt check
-        run: make lint
+        run: task lint
 
   build:
     name: CI on Go
@@ -33,12 +41,20 @@ jobs:
         with:
           go-version-file: "go.mod"
 
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+
+      - name: Validate Taskfile
+        run: task validate
+
       - name: Start dependencies
-        run: make deps-start
+        run: task deps-start
 
       - name: Running CI
         run: |
-          make ci
+          task ci
 
       - name: Codecov
         uses: codecov/codecov-action@v5
@@ -56,4 +72,4 @@ jobs:
           OTEL_EXPORTER_OTLP_INSECURE: true
 
       - name: Stop dependencies
-        run: make deps-stop
+        run: task deps-stop

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,16 @@
 
 ## Build, test, and development workflows
 
-- Build: `make` (default runs tests). Format: `make fmt` (go fmt). Format check: `make fmtcheck` (script/gofmtcheck.sh). Lint: `make lint` (golangci-lint with vendor mode); deep lint: `make deeplint`.
-- Test all: `make test` → `go test ./... -cover -race -timeout 60s`. Integration tests: `make testint` (or `make testint-nocache`). CI runs with `-tags=integration` excluding `examples` and `encoding/protobuf/test`.
+- Build: `task` (default runs tests). Format: `task fmt` (go fmt). Format check: `task fmtcheck` (script/gofmtcheck.sh). Lint: `task lint` (golangci-lint with vendor mode); deep lint: `task deeplint`.
+- Test all: `task test` → `go test ./... -cover -race -timeout 60s`. Integration tests: `task testint` (or `task testint-nocache`). CI runs with `-tags=integration` excluding `examples` and `encoding/protobuf/test`.
 - Run single test: replace with your package/path and test name:
   - By name: `go test ./path/to/pkg -run ^TestName$ -v -race`.
   - By file: `go test ./path/to/pkg -run ^TestName$ -v -race ./path/to/pkg/file_test.go` (Go filters by package; prefer -run). With integration tags: add `-tags=integration`.
-- Useful env/deps: start external deps for integrations via `make deps-start` (docker compose); stop via `make deps-stop`. Example apps: `make example-service`, `make example-client` (OTEL_EXPORTER_OTLP_INSECURE=true).
-- CI: `.github/workflows/ci.yml` runs lint, format check, tests with integration tags, and e2e example tests. Codecov integration enabled.
+- Useful env/deps: start external deps for integrations via `task deps-start` (docker compose); stop via `task deps-stop`. Example apps: `task example-service`, `task example-client` (OTEL_EXPORTER_OTLP_INSECURE=true).
+- CI: `.github/workflows/ci.yml` validates Taskfile, runs lint, format check, tests with integration tags, and e2e example tests. Codecov integration enabled.
 - Testing: all test files has the `_test.go` suffix. Specifically the integration tests have also the `integration_test.go` suffix.
+- List all tasks: `task --list` to see all available tasks with descriptions.
+- Validate Taskfile: `task validate` to verify Taskfile.yml syntax and schema.
 
 ## Lint configuration
 
@@ -22,7 +24,7 @@
 ## Code style and conventions
 
 - Imports: standard → third-party → module-local; managed by goimports/gofumpt. No unused imports. Keep vendor modules pinned.
-- Formatting: enforce gofmt; CI fails on deviations (use `make fmt`); prefer gofumpt-compatible style. Keep lines simple; avoid long one-liners.
+- Formatting: enforce gofmt; CI fails on deviations (use `task fmt`); prefer gofumpt-compatible style. Keep lines simple; avoid long one-liners.
 - Types and naming: exported identifiers use PascalCase with doc comments; unexported use lowerCamelCase; interfaces named with -er when it makes sense; avoid stutter. Use context.Context as first param when calls may block or are request-scoped.
 - Errors: return sentinel or wrapped errors; never panic in library code; prefer `%w` with fmt.Errorf; use errors.Join when aggregating; check and handle errors (errcheck). Avoid swallowing errors; use errorlint patterns; compare errors with errors.Is/As.
 - Logging/observability: use slog via observability/log; include context-aware logging; use OpenTelemetry for tracing/metrics; avoid global mutable state.

--- a/Makefile
+++ b/Makefile
@@ -1,57 +1,31 @@
-LINT_IMAGE = golangci/golangci-lint:v2.2.1-alpine
+# DEPRECATED: This Makefile has been replaced by Taskfile.yml
+# 
+# Please install Task: https://taskfile.dev/installation/
+# Then use `task` instead of `make`
+#
+# Quick command mapping:
+# - make          → task (or task test)
+# - make test     → task test
+# - make testint  → task testint
+# - make fmt      → task fmt
+# - make fmtcheck → task fmtcheck
+# - make lint     → task lint
+# - make deeplint → task deeplint
+# - make deps-start → task deps-start
+# - make deps-stop  → task deps-stop
+# - make example-service → task example-service
+# - make example-client  → task example-client
+# - make ci       → task ci
+#
+# List all available tasks: task --list
 
-.PHONY: default
-default: test
+.PHONY: help
+help:
+	@echo "DEPRECATED: This Makefile has been replaced by Taskfile.yml"
+	@echo ""
+	@echo "Please install Task: https://taskfile.dev/installation/"
+	@echo "Then use 'task' instead of 'make'"
+	@echo ""
+	@echo "List all available tasks: task --list"
 
-.PHONY: test
-test: fmtcheck
-	go test ./... -cover -race -timeout 60s
-
-.PHONY: testint
-testint: fmtcheck
-	go test ./... -race -cover -tags=integration -timeout 30s
-
-.PHONY: testint-nocache
-testint-nocache: fmtcheck
-	go test ./... -race -cover -tags=integration -timeout 30s -count=1
-
-.PHONY: ci
-ci:
-	go test `go list ./... | grep -v -e 'examples' -e 'encoding/protobuf/test'` -race -cover -coverprofile=coverage.txt -covermode=atomic -tags=integration -timeout 2m 
-
-.PHONY: fmt
-fmt:
-	go fmt ./...
-
-.PHONY: fmtcheck
-fmtcheck:
-	@sh -c "'$(CURDIR)/script/gofmtcheck.sh'"
-
-.PHONY: lint
-lint: fmtcheck
-	docker run --env=GOFLAGS=-mod=vendor --rm -v $(CURDIR):/app -w /app $(LINT_IMAGE) golangci-lint -v run
-
-.PHONY: deeplint
-deeplint: fmtcheck
-	docker run --env=GOFLAGS=-mod=vendor --rm -v $(CURDIR):/app -w /app $(LINT_IMAGE) golangci-lint run --exclude-use-default=false --enable-all -D dupl --build-tags integration
-
-.PHONY: example-service
-example-service:
-	OTEL_EXPORTER_OTLP_INSECURE="true" go run examples/service/*.go
-
-.PHONY: example-client
-example-client:
-	OTEL_EXPORTER_OTLP_INSECURE="true" go run examples/client/main.go
-
-.PHONY: deps-start
-deps-start:
-	docker compose up -d --wait
-
-.PHONY: deps-stop
-deps-stop:
-	docker compose down
-
-# disallow any parallelism (-j) for Make. This is necessary since some
-# commands during the build process create temporary files that collide
-# under parallel conditions.
-.NOTPARALLEL:
+.DEFAULT_GOAL := help

--- a/Makefile.deprecated
+++ b/Makefile.deprecated
@@ -1,0 +1,57 @@
+LINT_IMAGE = golangci/golangci-lint:v2.2.1-alpine
+
+.PHONY: default
+default: test
+
+.PHONY: test
+test: fmtcheck
+	go test ./... -cover -race -timeout 60s
+
+.PHONY: testint
+testint: fmtcheck
+	go test ./... -race -cover -tags=integration -timeout 30s
+
+.PHONY: testint-nocache
+testint-nocache: fmtcheck
+	go test ./... -race -cover -tags=integration -timeout 30s -count=1
+
+.PHONY: ci
+ci:
+	go test `go list ./... | grep -v -e 'examples' -e 'encoding/protobuf/test'` -race -cover -coverprofile=coverage.txt -covermode=atomic -tags=integration -timeout 2m 
+
+.PHONY: fmt
+fmt:
+	go fmt ./...
+
+.PHONY: fmtcheck
+fmtcheck:
+	@sh -c "'$(CURDIR)/script/gofmtcheck.sh'"
+
+.PHONY: lint
+lint: fmtcheck
+	docker run --env=GOFLAGS=-mod=vendor --rm -v $(CURDIR):/app -w /app $(LINT_IMAGE) golangci-lint -v run
+
+.PHONY: deeplint
+deeplint: fmtcheck
+	docker run --env=GOFLAGS=-mod=vendor --rm -v $(CURDIR):/app -w /app $(LINT_IMAGE) golangci-lint run --exclude-use-default=false --enable-all -D dupl --build-tags integration
+
+.PHONY: example-service
+example-service:
+	OTEL_EXPORTER_OTLP_INSECURE="true" go run examples/service/*.go
+
+.PHONY: example-client
+example-client:
+	OTEL_EXPORTER_OTLP_INSECURE="true" go run examples/client/main.go
+
+.PHONY: deps-start
+deps-start:
+	docker compose up -d --wait
+
+.PHONY: deps-stop
+deps-stop:
+	docker compose down
+
+# disallow any parallelism (-j) for Make. This is necessary since some
+# commands during the build process create temporary files that collide
+# under parallel conditions.
+.NOTPARALLEL:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,105 @@
+# https://taskfile.dev
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+vars:
+  LINT_IMAGE: golangci/golangci-lint:v2.2.1-alpine
+  OTEL_INSECURE: "true"
+  TEST_TIMEOUT: 60s
+  INTEGRATION_TIMEOUT: 30s
+  CI_TIMEOUT: 2m
+
+tasks:
+  validate:
+    desc: "Validate Taskfile.yml syntax and schema"
+    cmds:
+      - task --list > /dev/null && echo "✅ Taskfile.yml is valid"
+    silent: true
+
+  default:
+    desc: "Run tests (default task)"
+    cmds:
+      - task: test
+
+  test:
+    desc: "Run unit tests with race detection and coverage"
+    deps:
+      - fmtcheck
+    cmds:
+      - go test ./... -cover -race -timeout {{.TEST_TIMEOUT}}
+
+  testint:
+    desc: "Run integration tests with race detection and coverage"
+    deps:
+      - fmtcheck
+    cmds:
+      - go test ./... -race -cover -tags=integration -timeout {{.INTEGRATION_TIMEOUT}}
+
+  testint-nocache:
+    desc: "Run integration tests without cache"
+    deps:
+      - fmtcheck
+    cmds:
+      - go test ./... -race -cover -tags=integration -timeout {{.INTEGRATION_TIMEOUT}} -count=1
+
+  ci:
+    desc: "Run CI tests with coverage report"
+    cmds:
+      - go test `go list ./... | grep -v -e 'examples' -e 'encoding/protobuf/test'` -race -cover -coverprofile=coverage.txt -covermode=atomic -tags=integration -timeout {{.CI_TIMEOUT}}
+
+  fmt:
+    desc: "Format code with go fmt"
+    cmds:
+      - go fmt ./...
+
+  fmtcheck:
+    desc: "Check code formatting compliance"
+    cmds:
+      - sh -c "{{.CURDIR}}/script/gofmtcheck.sh"
+    vars:
+      CURDIR:
+        sh: pwd
+
+  lint:
+    desc: "Run linter with golangci-lint in Docker"
+    deps:
+      - fmtcheck
+    cmds:
+      - docker run --env=GOFLAGS=-mod=vendor --rm -v {{.CURDIR}}:/app -w /app {{.LINT_IMAGE}} golangci-lint -v run
+    vars:
+      CURDIR:
+        sh: pwd
+
+  deeplint:
+    desc: "Run comprehensive linting with all rules enabled"
+    deps:
+      - fmtcheck
+    cmds:
+      - docker run --env=GOFLAGS=-mod=vendor --rm -v {{.CURDIR}}:/app -w /app {{.LINT_IMAGE}} golangci-lint run --exclude-use-default=false --enable-all -D dupl --build-tags integration
+    vars:
+      CURDIR:
+        sh: pwd
+
+  example-service:
+    desc: "Run example service with OTEL configuration"
+    cmds:
+      - go run examples/service/*.go
+    env:
+      OTEL_EXPORTER_OTLP_INSECURE: "{{.OTEL_INSECURE}}"
+
+  example-client:
+    desc: "Run example client with OTEL configuration"
+    cmds:
+      - go run examples/client/main.go
+    env:
+      OTEL_EXPORTER_OTLP_INSECURE: "{{.OTEL_INSECURE}}"
+
+  deps-start:
+    desc: "Start Docker Compose dependencies"
+    cmds:
+      - docker compose up -d --wait
+
+  deps-stop:
+    desc: "Stop Docker Compose dependencies"
+    cmds:
+      - docker compose down

--- a/docs/ContributionGuidelines.md
+++ b/docs/ContributionGuidelines.md
@@ -24,4 +24,4 @@ PR's should have the following requirements:
 - Coding style (go fmt)
 - Linting we use [golangci-lint](https://github.com/golangci/golangci-lint)
 
-The Make file contains the appropriate command in order to verify all the above.
+The Taskfile contains the appropriate commands in order to verify all the above. Use `task --list` to see all available tasks.


### PR DESCRIPTION
## Summary

- Migrate build system from Make to Taskfile for improved developer experience and cross-platform support
- Update CI workflows to use Task CLI, deprecate Makefile with migration guide, preserve all functionality with enhanced features like validation

## Changes

- Created `Taskfile.yml` with all 14 tasks (12 from Makefile + default + validate)
- Updated `.github/workflows/ci.yml` to install Task CLI and replace all `make` commands
- Replaced `Makefile` with deprecation notice and command mapping guide
- Preserved original Makefile as `Makefile.deprecated` for reference
- Updated documentation: `AGENTS.md` and `docs/ContributionGuidelines.md`

## Benefits

- **Cross-platform**: Works consistently on Windows, macOS, and Linux
- **Modern syntax**: Clean YAML format with better readability
- **Enhanced features**: Native variables, task dependencies, validation
- **Backward compatibility**: Deprecation notice provides clear migration path

## Migration Guide

Install Task:
```bash
# macOS
brew install go-task/tap/go-task

# Linux
sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin

# Windows
choco install go-task
```

Command mapping:
- `make` → `task` or `task test`
- `make test` → `task test`
- `make lint` → `task lint`
- `make fmt` → `task fmt`

List all tasks: `task --list`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated build orchestration from Make to Task; developers should now use `task` commands instead of `make` commands.
  * Updated CI workflow to execute task-based commands.
  * Archived original Makefile with deprecation guidance.

* **Documentation**
  * Updated contribution guidelines to reference Task commands and availability of `task --list` for viewing all available tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->