### PR TITLE
Test parallel CI execution with isolated Docker Compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
 
       - name: Start dependencies
         run: task deps-start
+        env:
+          COMPOSE_PROJECT_NAME: patron-ci-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Running CI
         run: |
@@ -89,3 +91,7 @@ jobs:
 
       - name: Stop dependencies
         run: task deps-stop
+        if: always()
+        env:
+          COMPOSE_PROJECT_NAME: patron-ci-${{ github.run_id }}-${{ github.run_attempt }}
+


### PR DESCRIPTION
## Summary
- Tests whether lint and build jobs can run in parallel without Docker Compose port conflicts
- Adds unique COMPOSE_PROJECT_NAME to isolate Docker Compose stacks
- Uses github.run_id and github.run_attempt for uniqueness

## Testing
This PR is a proof-of-concept to verify that jobs can run in parallel. Will watch CI execution to confirm no conflicts occur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline reliability with improved dependency management and cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->