### PR TITLE
Enable parallel CI execution with isolated Docker Compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
 
       - name: Start dependencies
         run: task deps-start
+        env:
+          COMPOSE_PROJECT_NAME: patron-ci-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Running CI
         run: |
@@ -89,3 +91,6 @@ jobs:
 
       - name: Stop dependencies
         run: task deps-stop
+        if: always()
+        env:
+          COMPOSE_PROJECT_NAME: patron-ci-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
         env:
           GOFLAGS: -mod=vendor
 
-  build:
-    name: CI on Go
+  integration-tests:
+    name: Integration Tests
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
@@ -68,7 +68,7 @@ jobs:
       - name: Start dependencies
         run: task deps-start
         env:
-          COMPOSE_PROJECT_NAME: patron-ci-${{ github.run_id }}-${{ github.run_attempt }}
+          COMPOSE_PROJECT_NAME: patron-integration-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Running CI
         run: |
@@ -80,7 +80,42 @@ jobs:
           fail_ci_if_error: true # optional (default = false)
           files: ./coverage.txt
 
-      - name: e2e
+      - name: Stop dependencies
+        run: task deps-stop
+        if: always()
+        env:
+          COMPOSE_PROJECT_NAME: patron-integration-${{ github.run_id }}-${{ github.run_attempt }}
+
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            vendor/modules.txt
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+
+      - name: Validate Taskfile
+        run: task validate
+
+      - name: Start dependencies
+        run: task deps-start
+        env:
+          COMPOSE_PROJECT_NAME: patron-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Run e2e tests
         run: |
           go build -o service ./service/
           nohup ./service/service &
@@ -93,4 +128,4 @@ jobs:
         run: task deps-stop
         if: always()
         env:
-          COMPOSE_PROJECT_NAME: patron-ci-${{ github.run_id }}-${{ github.run_attempt }}
+          COMPOSE_PROJECT_NAME: patron-e2e-${{ github.run_id }}-${{ github.run_attempt }}


### PR DESCRIPTION
## Summary
- Enables lint and build jobs to run in parallel without Docker Compose port conflicts
- Adds unique `COMPOSE_PROJECT_NAME` using `github.run_id` and `github.run_attempt`
- Ensures cleanup runs even on failure with `if: always()`

## Technical Details
Each job that uses Docker Compose now gets an isolated environment by setting the `COMPOSE_PROJECT_NAME` environment variable. This prevents container name and port conflicts when jobs run concurrently.

## Testing
This PR tests whether the CI infrastructure can handle parallel job execution. Will monitor:
- Job start times to verify parallel execution
- Docker Compose logs for port conflicts
- Test success rates
- Cleanup completion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured CI pipeline with separate integration and end-to-end test workflows
  * Enhanced dependency lifecycle management with dedicated startup and cleanup steps for each test suite

<!-- end of auto-generated comment: release notes by coderabbit.ai -->