### PR TITLE
fix: preserve message ordering in deduplication and implement TextMapCarrier Keys()

### DIFF
--- a/client/amqp/amqp.go
+++ b/client/amqp/amqp.go
@@ -134,5 +134,9 @@ func (c producerMessageCarrier) Set(key, val string) {
 
 // Keys returns a slice of all key identifiers in the carrier.
 func (c producerMessageCarrier) Keys() []string {
-	return nil
+	keys := make([]string, 0, len(c.msg.Headers))
+	for key := range c.msg.Headers {
+		keys = append(keys, key)
+	}
+	return keys
 }

--- a/client/amqp/amqp_test.go
+++ b/client/amqp/amqp_test.go
@@ -257,7 +257,7 @@ func TestProducerMessageCarrier_Set(t *testing.T) {
 func TestProducerMessageCarrier_Keys(t *testing.T) {
 	t.Parallel()
 
-	t.Run("returns nil", func(t *testing.T) {
+	t.Run("returns nil for empty headers", func(t *testing.T) {
 		t.Parallel()
 
 		msg := &amqp.Publishing{}
@@ -265,7 +265,24 @@ func TestProducerMessageCarrier_Keys(t *testing.T) {
 
 		keys := carrier.Keys()
 
-		assert.Nil(t, keys)
+		assert.Empty(t, keys)
+	})
+
+	t.Run("returns all header keys", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &amqp.Publishing{
+			Headers: amqp.Table{
+				"key1": "val1",
+				"key2": "val2",
+			},
+		}
+		carrier := producerMessageCarrier{msg: msg}
+
+		keys := carrier.Keys()
+
+		assert.Len(t, keys, 2)
+		assert.ElementsMatch(t, []string{"key1", "key2"}, keys)
 	})
 }
 

--- a/client/kafka/kafka.go
+++ b/client/kafka/kafka.go
@@ -185,5 +185,9 @@ func (c producerMessageCarrier) Set(key, val string) {
 
 // Keys returns a slice of all key identifiers in the carrier.
 func (c producerMessageCarrier) Keys() []string {
-	return nil
+	keys := make([]string, 0, len(c.msg.Headers))
+	for _, header := range c.msg.Headers {
+		keys = append(keys, string(header.Key))
+	}
+	return keys
 }

--- a/client/kafka/kafka_test.go
+++ b/client/kafka/kafka_test.go
@@ -222,7 +222,7 @@ func TestProducerMessageCarrier_Set(t *testing.T) {
 func TestProducerMessageCarrier_Keys(t *testing.T) {
 	t.Parallel()
 
-	t.Run("returns nil", func(t *testing.T) {
+	t.Run("returns nil for empty headers", func(t *testing.T) {
 		t.Parallel()
 
 		msg := &sarama.ProducerMessage{}
@@ -230,7 +230,23 @@ func TestProducerMessageCarrier_Keys(t *testing.T) {
 
 		keys := carrier.Keys()
 
-		assert.Nil(t, keys)
+		assert.Empty(t, keys)
+	})
+
+	t.Run("returns all header keys", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &sarama.ProducerMessage{
+			Headers: []sarama.RecordHeader{
+				{Key: []byte("key1"), Value: []byte("val1")},
+				{Key: []byte("key2"), Value: []byte("val2")},
+			},
+		}
+		carrier := producerMessageCarrier{msg: msg}
+
+		keys := carrier.Keys()
+
+		assert.Equal(t, []string{"key1", "key2"}, keys)
 	})
 }
 

--- a/client/mqtt/publisher.go
+++ b/client/mqtt/publisher.go
@@ -139,5 +139,12 @@ func (c producerMessageCarrier) Set(key, val string) {
 
 // Keys returns a slice of all key identifiers in the carrier.
 func (c producerMessageCarrier) Keys() []string {
-	return nil
+	if c.pub.Properties == nil {
+		return nil
+	}
+	keys := make([]string, 0, len(c.pub.Properties.User))
+	for _, prop := range c.pub.Properties.User {
+		keys = append(keys, prop.Key)
+	}
+	return keys
 }

--- a/client/mqtt/publisher_test.go
+++ b/client/mqtt/publisher_test.go
@@ -227,14 +227,31 @@ func TestProducerMessageCarrier_Set(t *testing.T) {
 func TestProducerMessageCarrier_Keys(t *testing.T) {
 	t.Parallel()
 
-	t.Run("returns nil", func(t *testing.T) {
+	t.Run("returns nil for empty properties", func(t *testing.T) {
 		t.Parallel()
 
 		pub := &paho.Publish{}
 		carrier := producerMessageCarrier{pub: pub}
 		keys := carrier.Keys()
 
-		assert.Nil(t, keys)
+		assert.Empty(t, keys)
+	})
+
+	t.Run("returns all user property keys", func(t *testing.T) {
+		t.Parallel()
+
+		pub := &paho.Publish{
+			Properties: &paho.PublishProperties{
+				User: paho.UserProperties{
+					{Key: "key1", Value: "val1"},
+					{Key: "key2", Value: "val2"},
+				},
+			},
+		}
+		carrier := producerMessageCarrier{pub: pub}
+		keys := carrier.Keys()
+
+		assert.Equal(t, []string{"key1", "key2"}, keys)
 	})
 }
 

--- a/component/amqp/component.go
+++ b/component/amqp/component.go
@@ -327,5 +327,9 @@ func (c consumerMessageCarrier) Set(key, val string) {
 
 // Keys returns a slice of all key identifiers in the carrier.
 func (c consumerMessageCarrier) Keys() []string {
-	return nil
+	keys := make([]string, 0, len(c.msg.Headers))
+	for key := range c.msg.Headers {
+		keys = append(keys, key)
+	}
+	return keys
 }

--- a/component/kafka/component.go
+++ b/component/kafka/component.go
@@ -400,14 +400,17 @@ func getCorrelationID(hh []*sarama.RecordHeader) string {
 // partitions. This is the default behaviour from Kafka unless the Producer altered the partition hashing behaviour in
 // a nondeterministic way.
 func deduplicateMessages(messages []Message) []Message {
-	m := map[string]Message{}
+	latest := map[string]Message{}
 	for _, message := range messages {
-		m[string(message.Message().Key)] = message
+		latest[string(message.Message().Key)] = message
 	}
 
-	deduplicated := make([]Message, 0, len(m))
-	for _, message := range m {
-		deduplicated = append(deduplicated, message)
+	deduplicated := make([]Message, 0, len(latest))
+	for _, message := range messages {
+		key := string(message.Message().Key)
+		if latest[key] == message {
+			deduplicated = append(deduplicated, message)
+		}
 	}
 
 	return deduplicated
@@ -440,5 +443,9 @@ func (c consumerMessageCarrier) Set(key, val string) {
 
 // Keys returns a slice of all key identifiers in the carrier.
 func (c consumerMessageCarrier) Keys() []string {
-	return nil
+	keys := make([]string, 0, len(c.msg.Headers))
+	for _, header := range c.msg.Headers {
+		keys = append(keys, string(header.Key))
+	}
+	return keys
 }

--- a/component/kafka/component.go
+++ b/component/kafka/component.go
@@ -407,8 +407,7 @@ func deduplicateMessages(messages []Message) []Message {
 
 	deduplicated := make([]Message, 0, len(latest))
 	for _, message := range messages {
-		key := string(message.Message().Key)
-		if latest[key] == message {
+		if latest[string(message.Message().Key)] == message {
 			deduplicated = append(deduplicated, message)
 		}
 	}

--- a/component/kafka/component_test.go
+++ b/component/kafka/component_test.go
@@ -401,14 +401,6 @@ func Test_deduplicateMessages(t *testing.T) {
 			nil,
 			&sarama.ConsumerMessage{Key: []byte(key), Value: []byte(val)})
 	}
-	find := func(collection []Message, key string) Message {
-		for _, m := range collection {
-			if string(m.Message().Key) == key {
-				return m
-			}
-		}
-		return nil
-	}
 
 	// Given
 	original := []Message{
@@ -422,6 +414,10 @@ func Test_deduplicateMessages(t *testing.T) {
 	cleaned := deduplicateMessages(original)
 
 	assert.Len(t, cleaned, 2)
-	assert.Equal(t, []byte("v1.3"), find(cleaned, "k1").Message().Value)
-	assert.Equal(t, []byte("v2.2"), find(cleaned, "k2").Message().Value)
+	// Verify ordering is preserved based on the position of the winning (last) message:
+	// k2's last occurrence is at index 3, k1's last occurrence is at index 4
+	assert.Equal(t, []byte("k2"), cleaned[0].Message().Key)
+	assert.Equal(t, []byte("v2.2"), cleaned[0].Message().Value)
+	assert.Equal(t, []byte("k1"), cleaned[1].Message().Key)
+	assert.Equal(t, []byte("v1.3"), cleaned[1].Message().Value)
 }

--- a/component/sqs/component.go
+++ b/component/sqs/component.go
@@ -325,5 +325,9 @@ func (c consumerMessageCarrier) Set(key, val string) {
 
 // Keys returns a slice of all key identifiers in the carrier.
 func (c consumerMessageCarrier) Keys() []string {
-	return nil
+	keys := make([]string, 0, len(c.msg.Attributes))
+	for key := range c.msg.Attributes {
+		keys = append(keys, key)
+	}
+	return keys
 }


### PR DESCRIPTION
## Summary

- **Fix `deduplicateMessages` ordering**: The function was iterating over a map to build the output slice, producing non-deterministic ordering. Now iterates the original slice and emits only winning messages, preserving Kafka partition ordering guarantees.
- **Implement `Keys()` on all `TextMapCarrier` implementations**: All 6 carrier implementations (3 consumer, 3 producer across kafka/amqp/sqs/mqtt) returned `nil` from `Keys()`. This breaks any OTel propagator that relies on key enumeration (e.g. Baggage, B3). Now properly enumerates header/attribute keys.

## Changes

| File | Change |
|---|---|
| `component/kafka/component.go` | Fix dedup ordering + implement consumer carrier `Keys()` |
| `component/amqp/component.go` | Implement consumer carrier `Keys()` |
| `component/sqs/component.go` | Implement consumer carrier `Keys()` |
| `client/kafka/kafka.go` | Implement producer carrier `Keys()` |
| `client/amqp/amqp.go` | Implement producer carrier `Keys()` |
| `client/mqtt/publisher.go` | Implement producer carrier `Keys()` (with nil-safety for Properties) |
| 4 test files | Updated tests to verify actual key enumeration + ordering |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed header and property key extraction across messaging protocols (AMQP, Kafka, MQTT, SQS) to return actual keys instead of null values, improving message header visibility and propagation.
  * Improved message deduplication in Kafka to preserve the latest message occurrence per key while maintaining original order.

* **Tests**
  * Enhanced test coverage to validate header key extraction for both empty and populated message scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->