### PR TITLE
refactor: move DSN regex to package level, remove dead code, preallocate slice

### DIFF
--- a/client/sql/sql.go
+++ b/client/sql/sql.go
@@ -18,6 +18,12 @@ import (
 
 const packageName = "sql"
 
+var dsnPattern = regexp.MustCompile(
+	`^(?P<driver>.*:\/\/)?(?:(?P<username>.*?)(?::(.*))?@)?` +
+		`(?:(?P<protocol>[^\(]*)(?:\((?P<address>[^\)]*)\))?)?` +
+		`\/(?P<dbname>.*?)` +
+		`(?:\?(?P<params>[^\?]*))?$`)
+
 var durationHistogram metric.Int64Histogram
 
 func init() {
@@ -479,12 +485,6 @@ func (tx *Tx) Stmt(ctx context.Context, stmt *Stmt) *Stmt {
 
 func parseDSN(dsn string) DSNInfo {
 	res := DSNInfo{}
-
-	dsnPattern := regexp.MustCompile(
-		`^(?P<driver>.*:\/\/)?(?:(?P<username>.*?)(?::(.*))?@)?` + // [driver://][user[:password]@]
-			`(?:(?P<protocol>[^\(]*)(?:\((?P<address>[^\)]*)\))?)?` + // [net[(addr)]]
-			`\/(?P<dbname>.*?)` + // /dbname
-			`(?:\?(?P<params>[^\?]*))?$`) // [?param1=value1&paramN=valueN]
 
 	matches := dsnPattern.FindStringSubmatch(dsn)
 	fields := dsnPattern.SubexpNames()

--- a/component/http/middleware/middleware.go
+++ b/component/http/middleware/middleware.go
@@ -100,7 +100,6 @@ func NewRecovery() Func {
 					default:
 						err = errors.New("unknown panic")
 					}
-					_ = err
 					slog.Error("recovering from a failure", log.ErrorAttr(err), slog.String("stack", string(debug.Stack())))
 					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				}

--- a/examples/service/main.go
+++ b/examples/service/main.go
@@ -37,7 +37,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	var components []patron.Component
+	components := make([]patron.Component, 0, 5)
 
 	// Setup HTTP
 	cmp, err := createHTTPRouter()


### PR DESCRIPTION
## Summary

Non-breaking code quality improvements:

- **Move DSN regex to package-level var** (`client/sql/sql.go`): `parseDSN` was calling `regexp.MustCompile` on every invocation. Moved to a package-level `var` so the regex is compiled once.
- **Remove dead `_ = err`** (`component/http/middleware/middleware.go`): The recovery middleware had a no-op `_ = err` assignment before the `slog.Error` call that actually uses `err`. Removed the dead line.
- **Preallocate slice** (`examples/service/main.go`): Changed `var components []patron.Component` to `make([]patron.Component, 0, 5)` to satisfy the `prealloc` linter.

## Stack
- Base: #981 (`fix/correctness-issues`)