### PR TITLE
refactor!: rename OptionFunction to OptionFunc in component/grpc

### DIFF
--- a/client/http/http.go
+++ b/client/http/http.go
@@ -70,7 +70,7 @@ func (tc *TracedClient) do(req *http.Request) (*http.Response, error) {
 		return tc.cl.Do(req)
 	}
 
-	r, err := tc.cb.Execute(func() (any, error) {
+	r, err := tc.cb.Execute(req.Context(), func() (any, error) {
 		return tc.cl.Do(req) // nolint:bodyclose
 	})
 	if err != nil {

--- a/component/grpc/component.go
+++ b/component/grpc/component.go
@@ -23,7 +23,7 @@ type Component struct {
 }
 
 // New creates a gRPC Component on the given port with functional options.
-func New(port int, options ...OptionFunction) (*Component, error) {
+func New(port int, options ...OptionFunc) (*Component, error) {
 	c := new(Component)
 	if port <= 0 || port > 65535 {
 		return nil, fmt.Errorf("port is invalid: %d", port)

--- a/component/grpc/options.go
+++ b/component/grpc/options.go
@@ -6,11 +6,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-// OptionFunction configures the gRPC Component.
-type OptionFunction func(*Component) error
+// OptionFunc configures the gRPC Component.
+type OptionFunc func(*Component) error
 
 // WithServerOptions applies grpc.ServerOption values to the server.
-func WithServerOptions(options ...grpc.ServerOption) OptionFunction {
+func WithServerOptions(options ...grpc.ServerOption) OptionFunc {
 	return func(component *Component) error {
 		if len(options) == 0 {
 			return errors.New("no grpc options provided")
@@ -22,7 +22,7 @@ func WithServerOptions(options ...grpc.ServerOption) OptionFunction {
 }
 
 // WithReflection enables server reflection. Be cautious when exposing to the public internet.
-func WithReflection() OptionFunction {
+func WithReflection() OptionFunc {
 	return func(component *Component) error {
 		component.enableReflection = true
 		return nil

--- a/component/http/cache/cache.go
+++ b/component/http/cache/cache.go
@@ -110,13 +110,13 @@ func getResponse(ctx context.Context, cfg *control, path, key string, now int64,
 
 	rsp := get(ctx, key, rc)
 	if rsp == nil {
-		observeCacheMiss(path)
+		observeCacheMiss(ctx, path)
 		response := exec(now, key)
 		return response
 	}
 	if rsp.Err != nil {
 		slog.Error("failure during cache interaction", log.ErrorAttr(rsp.Err))
-		observeCacheErr(path)
+		observeCacheErr(ctx, path)
 		return exec(now, key)
 	}
 	// if the object has expired
@@ -126,15 +126,15 @@ func getResponse(ctx context.Context, cfg *control, path, key string, now int64,
 		// serve the last cached value, with a Warning Header
 		if cfg.forceCache || tmpRsp.Err != nil {
 			rsp.Warning = "last-valid"
-			observeCacheHit(path)
+			observeCacheHit(ctx, path)
 		} else {
 			rsp = tmpRsp
-			observeCacheEvict(path, cx, now-rsp.LastValid)
+			observeCacheEvict(ctx, path, cx, now-rsp.LastValid)
 		}
 	} else {
 		// add any Warning generated while parsing the headers
 		rsp.Warning = cfg.warning
-		observeCacheHit(path)
+		observeCacheHit(ctx, path)
 	}
 
 	return rsp
@@ -193,15 +193,15 @@ func save(ctx context.Context, path, key string, rsp *response, cache cache.TTLC
 		bytes, err := rsp.encode()
 		if err != nil {
 			slog.Error("could not encode response", slog.String("key", key), log.ErrorAttr(err))
-			observeCacheErr(path)
+			observeCacheErr(ctx, path)
 			return
 		}
 		if err := cache.SetTTL(ctx, key, bytes, maxAge); err != nil {
 			slog.Error("could not cache response", slog.String("key", key), log.ErrorAttr(err))
-			observeCacheErr(path)
+			observeCacheErr(ctx, path)
 			return
 		}
-		observeCacheAdd(path)
+		observeCacheAdd(ctx, path)
 	}
 }
 

--- a/component/http/cache/metric.go
+++ b/component/http/cache/metric.go
@@ -29,25 +29,25 @@ func init() {
 	cacheStatusCounter = patronmetric.Int64Counter(packageName, "http.cache.status", "HTTP cache status.", "1")
 }
 
-func observeCacheAdd(path string) {
-	cacheStatusCounter.Add(context.Background(), 1, metric.WithAttributes(routeAttr(path), statusAddAttr))
+func observeCacheAdd(ctx context.Context, path string) {
+	cacheStatusCounter.Add(ctx, 1, metric.WithAttributes(routeAttr(path), statusAddAttr))
 }
 
-func observeCacheMiss(path string) {
-	cacheStatusCounter.Add(context.Background(), 1, metric.WithAttributes(routeAttr(path), statusMissAttr))
+func observeCacheMiss(ctx context.Context, path string) {
+	cacheStatusCounter.Add(ctx, 1, metric.WithAttributes(routeAttr(path), statusMissAttr))
 }
 
-func observeCacheHit(path string) {
-	cacheStatusCounter.Add(context.Background(), 1, metric.WithAttributes(routeAttr(path), statusHitAttr))
+func observeCacheHit(ctx context.Context, path string) {
+	cacheStatusCounter.Add(ctx, 1, metric.WithAttributes(routeAttr(path), statusHitAttr))
 }
 
-func observeCacheErr(path string) {
-	cacheStatusCounter.Add(context.Background(), 1, metric.WithAttributes(routeAttr(path), statusErrAttr))
+func observeCacheErr(ctx context.Context, path string) {
+	cacheStatusCounter.Add(ctx, 1, metric.WithAttributes(routeAttr(path), statusErrAttr))
 }
 
-func observeCacheEvict(path string, validationContext validationContext, age int64) {
-	cacheExpirationHistogram.Record(context.Background(), age, metric.WithAttributes(routeAttr(path)))
-	cacheStatusCounter.Add(context.Background(), 1, metric.WithAttributes(routeAttr(path), statusEvictAttr,
+func observeCacheEvict(ctx context.Context, path string, validationContext validationContext, age int64) {
+	cacheExpirationHistogram.Record(ctx, age, metric.WithAttributes(routeAttr(path)))
+	cacheStatusCounter.Add(ctx, 1, metric.WithAttributes(routeAttr(path), statusEvictAttr,
 		reasonAttr(validationReason[validationContext])))
 }
 

--- a/reliability/circuitbreaker/breaker.go
+++ b/reliability/circuitbreaker/breaker.go
@@ -42,7 +42,7 @@ func init() {
 	statusCounter = patronmetric.Int64Counter(packageName, "circuit-breaker.status", "Circuit breaker status counter.", "1")
 }
 
-func breakerCounterInc(name string, st status) {
+func breakerCounterInc(ctx context.Context, name string, st status) {
 	stateAttr := closedAttr
 	switch st {
 	case opened:
@@ -50,7 +50,7 @@ func breakerCounterInc(name string, st status) {
 	case closed:
 		stateAttr = closedAttr
 	}
-	statusCounter.Add(context.Background(), 1, metric.WithAttributes(stateAttr, attribute.String("name", name)))
+	statusCounter.Add(ctx, 1, metric.WithAttributes(stateAttr, attribute.String("name", name)))
 }
 
 // Setting definition.
@@ -126,22 +126,22 @@ func (cb *CircuitBreaker) isClose() bool {
 }
 
 // Execute the provided action.
-func (cb *CircuitBreaker) Execute(act Action) (any, error) {
+func (cb *CircuitBreaker) Execute(ctx context.Context, act Action) (any, error) {
 	if cb.isOpen() {
 		return nil, errOpen
 	}
 
 	resp, err := act()
 	if err != nil {
-		cb.incFailure()
+		cb.incFailure(ctx)
 		return nil, err
 	}
-	cb.incSuccess()
+	cb.incSuccess(ctx)
 
 	return resp, err
 }
 
-func (cb *CircuitBreaker) incFailure() {
+func (cb *CircuitBreaker) incFailure(ctx context.Context) {
 	// allow closed and half open to transition to open
 	if cb.isOpen() {
 		return
@@ -152,7 +152,7 @@ func (cb *CircuitBreaker) incFailure() {
 	cb.failures++
 
 	if cb.status == closed && cb.failures >= cb.set.FailureThreshold {
-		cb.transitionToOpen()
+		cb.transitionToOpen(ctx)
 		return
 	}
 
@@ -162,10 +162,10 @@ func (cb *CircuitBreaker) incFailure() {
 		return
 	}
 
-	cb.transitionToOpen()
+	cb.transitionToOpen(ctx)
 }
 
-func (cb *CircuitBreaker) incSuccess() {
+func (cb *CircuitBreaker) incSuccess(ctx context.Context) {
 	// allow only half open in order to transition to closed
 	if !cb.isHalfOpen() {
 		return
@@ -179,23 +179,23 @@ func (cb *CircuitBreaker) incSuccess() {
 	if cb.retries < cb.set.RetrySuccessThreshold {
 		return
 	}
-	cb.transitionToClose()
+	cb.transitionToClose(ctx)
 }
 
-func (cb *CircuitBreaker) transitionToOpen() {
+func (cb *CircuitBreaker) transitionToOpen(ctx context.Context) {
 	cb.status = opened
 	cb.failures = 0
 	cb.executions = 0
 	cb.retries = 0
 	cb.nextRetry = time.Now().Add(cb.set.RetryTimeout).UnixNano()
-	breakerCounterInc(cb.name, cb.status)
+	breakerCounterInc(ctx, cb.name, cb.status)
 }
 
-func (cb *CircuitBreaker) transitionToClose() {
+func (cb *CircuitBreaker) transitionToClose(ctx context.Context) {
 	cb.status = closed
 	cb.failures = 0
 	cb.executions = 0
 	cb.retries = 0
 	cb.nextRetry = tsFuture
-	breakerCounterInc(cb.name, cb.status)
+	breakerCounterInc(ctx, cb.name, cb.status)
 }

--- a/reliability/circuitbreaker/breaker_test.go
+++ b/reliability/circuitbreaker/breaker_test.go
@@ -1,6 +1,7 @@
 package circuitbreaker
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -133,7 +134,7 @@ func TestCircuitBreaker_Close_Open_HalfOpen_Open_HalfOpen_Close(t *testing.T) {
 	set := Setting{FailureThreshold: uint(1), RetryTimeout: retryTimeout, RetrySuccessThreshold: 2, MaxRetryExecutionThreshold: 2}
 	cb, err := New("test", set)
 	require.NoError(t, err)
-	_, err = cb.Execute(testSuccessAction)
+	_, err = cb.Execute(context.Background(), testSuccessAction)
 	require.NoError(t, err)
 	assert.Equal(t, uint(0), cb.failures)
 	assert.Equal(t, uint(0), cb.executions)
@@ -141,7 +142,7 @@ func TestCircuitBreaker_Close_Open_HalfOpen_Open_HalfOpen_Close(t *testing.T) {
 	assert.True(t, cb.isClose())
 	assert.Equal(t, tsFuture, cb.nextRetry)
 	// will transition to open
-	_, err = cb.Execute(testFailureAction)
+	_, err = cb.Execute(context.Background(), testFailureAction)
 	require.EqualError(t, err, "test error")
 	assert.Equal(t, uint(0), cb.failures)
 	assert.Equal(t, uint(0), cb.executions)
@@ -149,7 +150,7 @@ func TestCircuitBreaker_Close_Open_HalfOpen_Open_HalfOpen_Close(t *testing.T) {
 	assert.True(t, cb.isOpen())
 	assert.Less(t, cb.nextRetry, tsFuture)
 	// open, returns err immediately
-	_, err = cb.Execute(testSuccessAction)
+	_, err = cb.Execute(context.Background(), testSuccessAction)
 	require.EqualError(t, err, "circuit is open")
 	assert.Equal(t, uint(0), cb.failures)
 	assert.Equal(t, uint(0), cb.executions)
@@ -158,7 +159,7 @@ func TestCircuitBreaker_Close_Open_HalfOpen_Open_HalfOpen_Close(t *testing.T) {
 	assert.Less(t, cb.nextRetry, tsFuture)
 	// should be half open now and will stay in there
 	time.Sleep(waitRetryTimeout)
-	_, err = cb.Execute(testFailureAction)
+	_, err = cb.Execute(context.Background(), testFailureAction)
 	require.EqualError(t, err, "test error")
 	assert.Equal(t, uint(1), cb.failures)
 	assert.Equal(t, uint(1), cb.executions)
@@ -166,7 +167,7 @@ func TestCircuitBreaker_Close_Open_HalfOpen_Open_HalfOpen_Close(t *testing.T) {
 	assert.True(t, cb.isHalfOpen())
 	assert.Less(t, cb.nextRetry, tsFuture)
 	// should be half open now and will transition to open
-	_, err = cb.Execute(testFailureAction)
+	_, err = cb.Execute(context.Background(), testFailureAction)
 	require.EqualError(t, err, "test error")
 	assert.Equal(t, uint(0), cb.failures)
 	assert.Equal(t, uint(0), cb.executions)
@@ -175,14 +176,14 @@ func TestCircuitBreaker_Close_Open_HalfOpen_Open_HalfOpen_Close(t *testing.T) {
 	assert.Less(t, cb.nextRetry, tsFuture)
 	// should be half open now and will transition to close
 	time.Sleep(waitRetryTimeout)
-	_, err = cb.Execute(testSuccessAction)
+	_, err = cb.Execute(context.Background(), testSuccessAction)
 	require.NoError(t, err)
 	assert.Equal(t, uint(0), cb.failures)
 	assert.Equal(t, uint(1), cb.executions)
 	assert.Equal(t, uint(1), cb.retries)
 	assert.True(t, cb.isHalfOpen())
 	assert.Less(t, cb.nextRetry, tsFuture)
-	_, err = cb.Execute(testSuccessAction)
+	_, err = cb.Execute(context.Background(), testSuccessAction)
 	require.NoError(t, err)
 	assert.Equal(t, uint(0), cb.failures)
 	assert.Equal(t, uint(0), cb.executions)
@@ -201,7 +202,7 @@ func BenchmarkCircuitBreaker_Execute(b *testing.B) {
 	cb, _ := New("test", set)
 
 	for b.Loop() {
-		cb.Execute(testFailureAction) // nolint:errcheck
+		cb.Execute(context.Background(), testFailureAction) // nolint:errcheck
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Rename `OptionFunction` → `OptionFunc`** in `component/grpc` for consistency with all other component/client packages that use `OptionFunc` as the functional option type name.

## Breaking Change

Consumers importing `OptionFunction` from `component/grpc` must update references to `OptionFunc`.

## Stack
- Base: #982 (`fix/code-quality-improvements`) → #981 (`fix/correctness-issues`)