### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/beatlabs/patron/security/code-scanning/16](https://github.com/beatlabs/patron/security/code-scanning/16)

In general, the problem is fixed by explicitly defining a `permissions` block in the workflow (either at the top level to apply to all jobs, or per-job) and granting only the scopes actually needed. For a typical CI workflow that only checks out code, runs tests, and uploads coverage, `contents: read` is sufficient; if future steps need more (for example, commenting on PRs), additional fine-grained permissions can be added then.

The single best way to fix this without changing existing functionality is to add a top-level `permissions:` block just under the workflow `name:` or `on:` section, setting `contents: read`. This will apply to all three jobs (`lint`, `integration-tests`, and `e2e-tests`) and ensures the `GITHUB_TOKEN` is restricted to read-only repository contents. None of the current steps need extra scopes (they mainly run local commands and use third-party actions that read the repo and upload coverage to Codecov), so this change will not break behavior.

Concretely, in `.github/workflows/ci.yml`, between line 1 (`name: CI`) and line 2 (`on:`), insert:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed, since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
