### PR TITLE
Phase 3: Security scanning & stale issue cleanup

### DIFF
--- a/.github/workflows/security-scanner.md
+++ b/.github/workflows/security-scanner.md
@@ -1,0 +1,72 @@
+---
+on:
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths: ["go.mod", "go.sum"]
+permissions:
+  contents: read
+  issues: read
+tools:
+  github: [issues, repos, dependabot]
+  bash: true
+safe-outputs:
+  create-issue:
+    title-prefix: "[security]"
+    labels: ["security", "P1-high"]
+    max: 3
+    close-older-issues: true
+    skip-if-match: "\\[security\\].*CVE-.*open"
+  add-labels:
+    max: 2
+imports:
+  - shared/mood.md
+  - shared/go-security.md
+engine: copilot
+strict: true
+timeout-minutes: 20
+network:
+  allowed: [defaults, vuln.go.dev]
+---
+
+# Security Scanner
+
+Run a focused Go security scan for this repository.
+
+## Objectives
+
+- Run `govulncheck ./...` to detect known vulnerabilities in dependencies.
+- Run `gosec ./...` for static security analysis of Go code.
+- Audit `go.mod` and `go.sum` for dependency health signals.
+
+## Severity classification
+
+- **Critical**: Known exploitable CVE in a direct dependency.
+- **High**: CVE in a direct dependency that is not yet exploitable in this codebase.
+- **Medium**: CVE in a transitive dependency.
+- **Low / Informational**: `gosec` style findings and best-practice warnings.
+
+## Issue creation rules
+
+- Create issues only for **Critical** and **High** findings.
+- Deduplicate by CVE; do not create duplicate issues for the same vulnerability.
+- Include the **CVE ID in the issue title** for deduplication via `skip-if-match`.
+- Create at most **3 issues per run**, prioritized by severity.
+- Add the `security` label to all findings.
+- Add the `dependency` label when the finding is dependency-related.
+- Clearly separate actionable findings from informational ones in the issue body.
+
+## Required issue content
+
+For each created issue, include:
+
+- CVE ID in the title.
+- Affected dependency and version.
+- Whether the dependency is direct or transitive.
+- Recommended remediation: upgrade, replace, or mitigate.
+
+## Repository context
+
+If the repository already has `gosec` coverage through its lint configuration (as patron does), treat this workflow as complementary rather than duplicative.

--- a/.github/workflows/stale-issue-cleanup.md
+++ b/.github/workflows/stale-issue-cleanup.md
@@ -1,0 +1,63 @@
+---
+on:
+  schedule:
+    - cron: "0 5 * * 0"
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: read
+safe-outputs:
+  add-comment:
+    title-prefix: "[stale]"
+    max: 10
+  add-labels:
+    max: 10
+  close-issue:
+    max: 5
+tools:
+  - github[issues, labels]
+  - bash
+imports:
+  - shared/mood.md
+  - shared/issue-triage-go.md
+engine: copilot
+strict: true
+timeout-minutes: 15
+---
+
+You are performing stale issue cleanup for this repository.
+
+Goals:
+- Scan open issues for staleness signals.
+- Process warnings first, then closures.
+- Limit actions to a maximum of 10 warnings and 5 closures per run.
+- Be transparent: every action must include a comment explaining why.
+
+Use GitHub issues and labels tools for issue inspection, comments, labels, and closures. Use bash only for date arithmetic and inactivity window calculations.
+
+Staleness rules:
+- No activity for 60+ days (including comments, label changes, and assignee changes) -> warning candidate.
+- No activity for 90+ days after warning -> close candidate.
+
+Warning phase:
+- Add the `stale` label.
+- Post a `[stale]` comment explaining that the issue has been inactive and will be closed in 30 days if there is still no activity.
+- Invite the author or maintainers to respond if the issue is still relevant.
+
+Close phase:
+- Only close issues that were warned 30+ days ago and still have no activity.
+- Post a `[stale]` closing comment explaining why the issue is being closed.
+- Close no more than 5 issues in a single run.
+
+Never close issues with any of the following:
+- `P1-high`
+- `security`
+- `keep-open`
+- Active assignees who have committed recently.
+- Recent linked PR activity in the last 30 days.
+
+Additional requirements:
+- Do not surprise users with closures; warning must happen before closure.
+- Warnings and closures must both include clear explanatory comments.
+- Prioritize safety over throughput.
+- If an issue has recent activity or any exemption applies, leave it open.


### PR DESCRIPTION
## Summary

Phase 3 of the gh-aw rollout — security and housekeeping workflows for patron.

### New Workflows
- **`security-scanner`** — Weekly + on go.mod/go.sum push: runs govulncheck + gosec, creates issues for findings with severity/CVE details
- **`stale-issue-cleanup`** — Weekly (Sun 5am UTC): warns on issues inactive >60 days, closes after 14-day grace period

### QA
- Verify `gh aw compile` succeeds for both workflows
- Verify `security-scanner` triggers on schedule, push (go.mod/go.sum), and workflow_dispatch
- Verify `stale-issue-cleanup` triggers on schedule and workflow_dispatch
- Verify security-scanner imports `shared/go-security.md` from aw-common