### PR TITLE
fix(sqs): resolve goroutine leak in consumer retry sleep

### DIFF
--- a/component/sqs/component.go
+++ b/component/sqs/component.go
@@ -192,7 +192,11 @@ func (c *Component) consume(ctx context.Context, chErr chan error) {
 		})
 		if err != nil {
 			logger.Error("failed to receive messages, sleeping", log.ErrorAttr(err), slog.Duration("wait", c.retry.wait))
-			time.Sleep(c.retry.wait)
+			select {
+			case <-time.After(c.retry.wait):
+			case <-ctx.Done():
+				return
+			}
 			retries--
 			if retries > 0 {
 				continue

--- a/component/sqs/integration_test.go
+++ b/component/sqs/integration_test.go
@@ -74,7 +74,10 @@ func Test_SQS_Consume(t *testing.T) {
 		WithPollWaitSeconds(20), WithVisibilityTimeout(30), WithQueueStatsInterval(10*time.Millisecond))
 	require.NoError(t, err)
 
-	go func() { assert.NoError(t, cmp.Run(context.Background())) }()
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+
+	go func() { assert.NoError(t, cmp.Run(runCtx)) }()
 
 	got := <-chReceived
 
@@ -98,6 +101,8 @@ func Test_SQS_Consume(t *testing.T) {
 	collectedMetrics := collectMetrics(2)
 	test.AssertMetric(t, collectedMetrics.ScopeMetrics[0].Metrics, "sqs.message.counter")
 	test.AssertMetric(t, collectedMetrics.ScopeMetrics[0].Metrics, "sqs.queue.size")
+
+	runCancel()
 }
 
 func sendMessage(t *testing.T, client *sqs.Client, correlationID, queue string, ids ...string) []*testMessage {


### PR DESCRIPTION
## Summary

- Replace `time.Sleep` with context-aware `select` in the SQS consumer retry loop (`component.go`), so the goroutine exits promptly on context cancellation instead of blocking for the full retry wait duration.
- Use a cancellable context in the integration test and cancel it after assertions, preventing `goleak.VerifyTestMain` from detecting leaked goroutines.

## Root Cause

The `consume` goroutine used `time.Sleep(c.retry.wait)` which doesn't respect context cancellation. After `Run` returns on `ctx.Done()`, the `consume` goroutine could be stuck sleeping for up to 1 second (default retry wait), causing `goleak` to flag it as a leak.

The integration test compounded this by passing `context.Background()` (never cancels) to `cmp.Run()`.