### PR TITLE
fix: path traversal in file server + HTTP decompression bugs

### DIFF
--- a/client/http/http.go
+++ b/client/http/http.go
@@ -89,6 +89,11 @@ func opName(method, scheme, host string) string {
 	return method + " " + scheme + "://" + host
 }
 
+const (
+	encodingGzip    = "gzip"
+	encodingDeflate = "deflate"
+)
+
 // joinedReadCloser closes both the decompressor and the underlying body so the
 // TCP connection is returned to the pool when the caller closes the response body.
 type joinedReadCloser struct {
@@ -103,14 +108,14 @@ func (j *joinedReadCloser) Close() error {
 
 func decompress(hdr string, body io.ReadCloser) (io.ReadCloser, error) {
 	switch hdr {
-	case "gzip":
+	case encodingGzip:
 		gr, err := gzip.NewReader(body)
 		if err != nil {
 			_ = body.Close()
 			return nil, err
 		}
 		return &joinedReadCloser{Reader: gr, decompressor: gr, body: body}, nil
-	case "deflate":
+	case encodingDeflate:
 		fr := flate.NewReader(body)
 		return &joinedReadCloser{Reader: fr, decompressor: fr, body: body}, nil
 	default:

--- a/client/http/http.go
+++ b/client/http/http.go
@@ -55,14 +55,14 @@ func (tc *TracedClient) Do(req *http.Request) (*http.Response, error) {
 		return rsp, err
 	}
 
-	if hdr := req.Header.Get(encoding.AcceptEncodingHeader); hdr != "" {
-		rsp.Body, err = decompress(hdr, rsp)
+	if hdr := rsp.Header.Get(encoding.ContentEncodingHeader); hdr != "" {
+		rsp.Body, err = decompress(hdr, rsp.Body)
 		if err != nil {
-			return rsp, err
+			return nil, err
 		}
 	}
 
-	return rsp, err
+	return rsp, nil
 }
 
 func (tc *TracedClient) do(req *http.Request) (*http.Response, error) {
@@ -89,13 +89,31 @@ func opName(method, scheme, host string) string {
 	return method + " " + scheme + "://" + host
 }
 
-func decompress(hdr string, rsp *http.Response) (io.ReadCloser, error) {
+// joinedReadCloser closes both the decompressor and the underlying body so the
+// TCP connection is returned to the pool when the caller closes the response body.
+type joinedReadCloser struct {
+	io.Reader
+	decompressor io.Closer
+	body         io.Closer
+}
+
+func (j *joinedReadCloser) Close() error {
+	return errors.Join(j.decompressor.Close(), j.body.Close())
+}
+
+func decompress(hdr string, body io.ReadCloser) (io.ReadCloser, error) {
 	switch hdr {
 	case "gzip":
-		return gzip.NewReader(rsp.Body)
+		gr, err := gzip.NewReader(body)
+		if err != nil {
+			_ = body.Close()
+			return nil, err
+		}
+		return &joinedReadCloser{Reader: gr, decompressor: gr, body: body}, nil
 	case "deflate":
-		return flate.NewReader(rsp.Body), nil
+		fr := flate.NewReader(body)
+		return &joinedReadCloser{Reader: fr, decompressor: fr, body: body}, nil
 	default:
-		return rsp.Body, nil
+		return body, nil
 	}
 }

--- a/client/http/http_test.go
+++ b/client/http/http_test.go
@@ -144,6 +144,7 @@ func TestDecompress(t *testing.T) {
 		if err != nil {
 			return
 		}
+		w.Header().Set("Content-Encoding", "gzip")
 		_, err = fmt.Fprint(w, b.String())
 		if err != nil {
 			return
@@ -162,6 +163,7 @@ func TestDecompress(t *testing.T) {
 		if err != nil {
 			return
 		}
+		w.Header().Set("Content-Encoding", "deflate")
 		_, err = fmt.Fprint(w, b.String())
 		if err != nil {
 			return
@@ -186,14 +188,12 @@ func TestDecompress(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, tt.url, nil)
 			require.NoError(t, err)
-			req.Header.Add(encoding.AcceptEncodingHeader, tt.hdr)
 			rsp, err := c.Do(req)
 			require.NoError(t, err)
 
 			b, err := io.ReadAll(rsp.Body)
 			require.NoError(t, err)
-			body := string(b)
-			require.Equal(t, msg, body)
+			require.Equal(t, msg, string(b))
 			require.NoError(t, rsp.Body.Close())
 		})
 	}

--- a/client/http/http_test.go
+++ b/client/http/http_test.go
@@ -177,12 +177,11 @@ func TestDecompress(t *testing.T) {
 
 	tests := []struct {
 		name string
-		hdr  string
 		url  string
 	}{
-		{"no compression", "", ts1.URL},
-		{"gzip", "gzip", ts2.URL},
-		{"deflate", "deflate", ts3.URL},
+		{"no compression", ts1.URL},
+		{encodingGzip, ts2.URL},
+		{encodingDeflate, ts3.URL},
 	}
 
 	for _, tt := range tests {
@@ -217,6 +216,9 @@ func TestTracedClient_Do_DecompressError(t *testing.T) {
 
 	rsp, err := c.Do(req)
 	require.Error(t, err)
+	if rsp != nil {
+		_ = rsp.Body.Close()
+	}
 	assert.Nil(t, rsp)
 }
 

--- a/client/http/http_test.go
+++ b/client/http/http_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -197,4 +198,57 @@ func TestDecompress(t *testing.T) {
 			require.NoError(t, rsp.Body.Close())
 		})
 	}
+}
+
+func TestTracedClient_Do_DecompressError(t *testing.T) {
+	// Server claims gzip but sends garbage — transport auto-decompression is
+	// disabled so our decompress() call in Do() sees the invalid body.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		_, _ = w.Write([]byte("not valid gzip"))
+	}))
+	defer ts.Close()
+
+	c, err := New(WithTransport(&http.Transport{DisableCompression: true}))
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL, nil)
+	require.NoError(t, err)
+
+	rsp, err := c.Do(req)
+	require.Error(t, err)
+	assert.Nil(t, rsp)
+}
+
+func TestDecompressUnit(t *testing.T) {
+	const msg = "hello, patron!"
+
+	t.Run("gzip success", func(t *testing.T) {
+		var b bytes.Buffer
+		w := gzip.NewWriter(&b)
+		_, err := w.Write([]byte(msg))
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+
+		rc, err := decompress("gzip", io.NopCloser(&b))
+		require.NoError(t, err)
+		data, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		assert.Equal(t, msg, string(data))
+		require.NoError(t, rc.Close())
+	})
+
+	t.Run("gzip invalid data", func(t *testing.T) {
+		rc, err := decompress("gzip", io.NopCloser(strings.NewReader("not gzip")))
+		require.Error(t, err)
+		assert.Nil(t, rc)
+	})
+
+	t.Run("unknown encoding passthrough", func(t *testing.T) {
+		rc, err := decompress("br", io.NopCloser(strings.NewReader(msg)))
+		require.NoError(t, err)
+		data, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		assert.Equal(t, msg, string(data))
+	})
 }

--- a/component/http/router/route.go
+++ b/component/http/router/route.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 
 	patronhttp "github.com/beatlabs/patron/component/http"
 )
@@ -37,25 +39,39 @@ func NewFileServerRoute(path string, assetsDir string, fallbackPath string) (*pa
 		return nil, fmt.Errorf("error while checking fallback file: %w", err)
 	}
 
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		// get the absolute path to prevent directory traversal
-		path := assetsDir + r.PathValue("path")
+	absAssetsDir, err := filepath.Abs(assetsDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve assets dir: %w", err)
+	}
 
-		// check whether a file exists at the given path
-		info, err := os.Stat(path)
-		if os.IsNotExist(err) || info.IsDir() {
-			// file does not exist, serve index.html
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		filePath := filepath.Join(absAssetsDir, r.PathValue("path"))
+
+		// Prevent directory traversal: filepath.Join resolves ".." so a path
+		// escaping absAssetsDir will no longer share its prefix. Adding a
+		// separator to filePath before the check handles the edge case where
+		// filePath equals absAssetsDir exactly (empty path value).
+		if !strings.HasPrefix(filePath+string(filepath.Separator), absAssetsDir+string(filepath.Separator)) {
 			http.ServeFile(w, r, fallbackPath)
 			return
-		} else if err != nil {
-			// if we got an error (that wasn't that the file doesn't exist) stating the
-			// file, return a 500 internal server error and stop
+		}
+
+		info, err := os.Stat(filePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				http.ServeFile(w, r, fallbackPath)
+				return
+			}
 			http.Error(w, "", http.StatusInternalServerError)
 			return
 		}
 
-		// otherwise, use server the specific file directly from the filesystem.
-		http.ServeFile(w, r, path)
+		if info.IsDir() {
+			http.ServeFile(w, r, fallbackPath)
+			return
+		}
+
+		http.ServeFile(w, r, filePath)
 	}
 
 	return patronhttp.NewRoute(path, handler)

--- a/component/http/router/route.go
+++ b/component/http/router/route.go
@@ -56,7 +56,7 @@ func NewFileServerRoute(path string, assetsDir string, fallbackPath string) (*pa
 			return
 		}
 
-		info, err := os.Stat(filePath)
+		info, err := os.Stat(filePath) //nolint:gosec // filePath is validated by the HasPrefix check above
 		if err != nil {
 			if os.IsNotExist(err) {
 				http.ServeFile(w, r, fallbackPath)
@@ -71,7 +71,7 @@ func NewFileServerRoute(path string, assetsDir string, fallbackPath string) (*pa
 			return
 		}
 
-		http.ServeFile(w, r, filePath)
+		http.ServeFile(w, r, filePath) //nolint:gosec // filePath is validated by the HasPrefix check above
 	}
 
 	return patronhttp.NewRoute(path, handler)

--- a/component/http/router/route_test.go
+++ b/component/http/router/route_test.go
@@ -39,6 +39,16 @@ func TestNewFileServerRoute(t *testing.T) {
 			assetsDir:    "123",
 			fallbackPath: "",
 		}, expectedErr: "fallback path is empty"},
+		"nonexistent assets dir": {args: args{
+			path:         "GET /frontend/*path",
+			assetsDir:    "nonexistent_dir",
+			fallbackPath: "testdata/index.html",
+		}, expectedErr: "assets directory [GET /frontend/*path] doesn't exist"},
+		"nonexistent fallback file": {args: args{
+			path:         "GET /frontend/*path",
+			assetsDir:    "testdata/",
+			fallbackPath: "nonexistent.html",
+		}, expectedErr: "fallback file [nonexistent.html] doesn't exist"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -69,6 +79,7 @@ func TestFileServerRouteHandler(t *testing.T) {
 		"fallback": {urlPath: "/frontend/", pathValue: "", expectedCode: 200},
 		// urlPath must not end in /index.html — http.ServeFile redirects that to ./
 		"index":             {urlPath: "/frontend/app", pathValue: "index.html", expectedCode: 200},
+		"file not found":    {urlPath: "/frontend/x", pathValue: "nonexistent.html", expectedCode: 200},
 		"traversal attempt": {urlPath: "/frontend/x", pathValue: "../../etc/passwd", expectedCode: 200},
 		"traversal nested":  {urlPath: "/frontend/x", pathValue: "sub/../../etc/passwd", expectedCode: 200},
 	}

--- a/component/http/router/route_test.go
+++ b/component/http/router/route_test.go
@@ -1,7 +1,6 @@
 package router
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -62,21 +61,21 @@ func TestFileServerRouteHandler(t *testing.T) {
 	handler, err := NewFileServerRoute("GET /frontend/*path", "testdata/", "testdata/index.html")
 	require.NoError(t, err)
 
-	type args struct {
-		path string
-	}
 	tests := map[string]struct {
-		args         args
+		urlPath      string // request URL (must be clean so http.ServeFile accepts it)
+		pathValue    string // value PathValue("path") returns, as set by the router
 		expectedCode int
-		expectedErr  string
 	}{
-		"fallback": {args: args{path: "frontend"}, expectedCode: 200},
-		"index":    {args: args{path: "frontend/index"}, expectedCode: 200},
+		"fallback":          {urlPath: "/frontend/", pathValue: "", expectedCode: 200},
+		// urlPath must not end in /index.html — http.ServeFile redirects that to ./
+		"index": {urlPath: "/frontend/app", pathValue: "index.html", expectedCode: 200},
+		"traversal attempt": {urlPath: "/frontend/x", pathValue: "../../etc/passwd", expectedCode: 200},
+		"traversal nested":  {urlPath: "/frontend/x", pathValue: "sub/../../etc/passwd", expectedCode: 200},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, tt.args.path, nil)
-			require.NoError(t, err)
+			req := httptest.NewRequest(http.MethodGet, tt.urlPath, nil)
+			req.SetPathValue("path", tt.pathValue)
 			rc := httptest.NewRecorder()
 			handler.Handler().ServeHTTP(rc, req)
 			assert.Equal(t, tt.expectedCode, rc.Code)

--- a/component/http/router/route_test.go
+++ b/component/http/router/route_test.go
@@ -66,9 +66,9 @@ func TestFileServerRouteHandler(t *testing.T) {
 		pathValue    string // value PathValue("path") returns, as set by the router
 		expectedCode int
 	}{
-		"fallback":          {urlPath: "/frontend/", pathValue: "", expectedCode: 200},
+		"fallback": {urlPath: "/frontend/", pathValue: "", expectedCode: 200},
 		// urlPath must not end in /index.html — http.ServeFile redirects that to ./
-		"index": {urlPath: "/frontend/app", pathValue: "index.html", expectedCode: 200},
+		"index":             {urlPath: "/frontend/app", pathValue: "index.html", expectedCode: 200},
 		"traversal attempt": {urlPath: "/frontend/x", pathValue: "../../etc/passwd", expectedCode: 200},
 		"traversal nested":  {urlPath: "/frontend/x", pathValue: "sub/../../etc/passwd", expectedCode: 200},
 	}

--- a/component/http/router/route_test.go
+++ b/component/http/router/route_test.go
@@ -1,12 +1,20 @@
 package router
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	testRoutePath    = "GET /frontend/*path"
+	testAssetsDir    = "testdata/"
+	testFallbackPath = "testdata/index.html"
+	testURLPath      = "/frontend/x"
 )
 
 func TestNewFileServerRoute(t *testing.T) {
@@ -20,9 +28,9 @@ func TestNewFileServerRoute(t *testing.T) {
 		expectedErr string
 	}{
 		"success": {args: args{
-			path:         "GET /frontend/*path",
-			assetsDir:    "testdata/",
-			fallbackPath: "testdata/index.html",
+			path:         testRoutePath,
+			assetsDir:    testAssetsDir,
+			fallbackPath: testFallbackPath,
 		}},
 		"missing path": {args: args{
 			path:         "",
@@ -40,13 +48,13 @@ func TestNewFileServerRoute(t *testing.T) {
 			fallbackPath: "",
 		}, expectedErr: "fallback path is empty"},
 		"nonexistent assets dir": {args: args{
-			path:         "GET /frontend/*path",
+			path:         testRoutePath,
 			assetsDir:    "nonexistent_dir",
-			fallbackPath: "testdata/index.html",
+			fallbackPath: testFallbackPath,
 		}, expectedErr: "assets directory [GET /frontend/*path] doesn't exist"},
 		"nonexistent fallback file": {args: args{
-			path:         "GET /frontend/*path",
-			assetsDir:    "testdata/",
+			path:         testRoutePath,
+			assetsDir:    testAssetsDir,
 			fallbackPath: "nonexistent.html",
 		}, expectedErr: "fallback file [nonexistent.html] doesn't exist"},
 	}
@@ -59,7 +67,7 @@ func TestNewFileServerRoute(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.NotNil(t, got)
-				assert.Equal(t, "GET /frontend/*path", got.Path())
+				assert.Equal(t, testRoutePath, got.Path())
 				assert.NotNil(t, got.Handler())
 				assert.Empty(t, got.Middlewares())
 			}
@@ -68,7 +76,7 @@ func TestNewFileServerRoute(t *testing.T) {
 }
 
 func TestFileServerRouteHandler(t *testing.T) {
-	handler, err := NewFileServerRoute("GET /frontend/*path", "testdata/", "testdata/index.html")
+	handler, err := NewFileServerRoute(testRoutePath, testAssetsDir, testFallbackPath)
 	require.NoError(t, err)
 
 	tests := map[string]struct {
@@ -79,13 +87,13 @@ func TestFileServerRouteHandler(t *testing.T) {
 		"fallback": {urlPath: "/frontend/", pathValue: "", expectedCode: 200},
 		// urlPath must not end in /index.html — http.ServeFile redirects that to ./
 		"index":             {urlPath: "/frontend/app", pathValue: "index.html", expectedCode: 200},
-		"file not found":    {urlPath: "/frontend/x", pathValue: "nonexistent.html", expectedCode: 200},
-		"traversal attempt": {urlPath: "/frontend/x", pathValue: "../../etc/passwd", expectedCode: 200},
-		"traversal nested":  {urlPath: "/frontend/x", pathValue: "sub/../../etc/passwd", expectedCode: 200},
+		"file not found":    {urlPath: testURLPath, pathValue: "nonexistent.html", expectedCode: 200},
+		"traversal attempt": {urlPath: testURLPath, pathValue: "../../etc/passwd", expectedCode: 200},
+		"traversal nested":  {urlPath: testURLPath, pathValue: "sub/../../etc/passwd", expectedCode: 200},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, tt.urlPath, nil)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tt.urlPath, nil)
 			req.SetPathValue("path", tt.pathValue)
 			rc := httptest.NewRecorder()
 			handler.Handler().ServeHTTP(rc, req)


### PR DESCRIPTION
Closes #1037

## Summary

- **Path traversal prevention** (`component/http/router/route.go`): resolve `assetsDir` to an absolute path once at construction time, then use `filepath.Join` + a `strings.HasPrefix` check in the handler to ensure every requested path still lives under that directory. `../../etc/passwd` resolves to `/etc/passwd` after `filepath.Join`, which fails the prefix check and falls back to the configured fallback page.
- **Nil-deref fix** (same file): `os.IsNotExist(err) || info.IsDir()` would panic when `os.Stat` returned a non-NotExist error (e.g. permission denied) because `info` is nil in that case. Split into two separate `if` blocks.
- **Wrong decompression header** (`client/http/http.go`): decompression was keyed off `Accept-Encoding` from the *request* instead of `Content-Encoding` from the *response*. A server can respond with a different or no encoding.
- **TCP connection leak** (same file): `gzip`/`flate` reader `Close` does not close the underlying response body, so the connection was never returned to the pool. Introduced `joinedReadCloser` that closes both the decompressor and the original body.
- **Body leak on gzip init failure** (same file): when `gzip.NewReader` fails, the original body is now closed before returning the error.

## Test plan

- [ ] `go test ./component/http/router/...` — all pass, two new traversal test cases added using `req.SetPathValue` to simulate what the router would inject
- [ ] `go test ./client/http/...` — all pass, test servers now set `Content-Encoding` on responses to match the corrected decompression logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)