### PR TITLE
fix: wrap underlying errors with %w in sqs and http cache

### DIFF
--- a/component/http/cache/cache.go
+++ b/component/http/cache/cache.go
@@ -166,7 +166,7 @@ func get(ctx context.Context, key string, rc *RouteCache) *response {
 		r := &response{}
 		err := r.decode(b)
 		if err != nil {
-			return &response{Err: fmt.Errorf("could not decode cached bytes as response %v for key %s", resp, key)}
+			return &response{Err: fmt.Errorf("could not decode cached bytes as response %v for key %s: %w", resp, key, err)}
 		}
 		r.FromCache = true
 		return r
@@ -176,7 +176,7 @@ func get(ctx context.Context, key string, rc *RouteCache) *response {
 		r := &response{}
 		err := r.decode([]byte(b))
 		if err != nil {
-			return &response{Err: fmt.Errorf("could not decode cached string as response %v for key %s", resp, key)}
+			return &response{Err: fmt.Errorf("could not decode cached string as response %v for key %s: %w", resp, key, err)}
 		}
 		r.FromCache = true
 		return r

--- a/component/sqs/component.go
+++ b/component/sqs/component.go
@@ -296,7 +296,7 @@ func getAttributeFloat64(attr map[string]string, key string) (float64, error) {
 	}
 	value, err := strconv.ParseFloat(valueString, 64)
 	if err != nil {
-		return 0.0, fmt.Errorf("could not convert %s to float64", valueString)
+		return 0.0, fmt.Errorf("could not convert %s to float64: %w", valueString, err)
 	}
 	return value, nil
 }

--- a/component/sqs/component_test.go
+++ b/component/sqs/component_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -258,6 +259,13 @@ func TestComponent_Run_Error(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	cnl()
 	wg.Wait()
+}
+
+func TestGetAttributeFloat64_WrapsParseError(t *testing.T) {
+	_, err := getAttributeFloat64(map[string]string{"k": "not-a-number"}, "k")
+	require.Error(t, err)
+	var numErr *strconv.NumError
+	require.True(t, errors.As(err, &numErr), "underlying *strconv.NumError must be reachable via errors.As")
 }
 
 type stubProcessor struct {


### PR DESCRIPTION
Closes #1046 (partial).

Wraps three lost underlying errors with `%w` so callers can use `errors.Is`/`errors.As`:

- `component/sqs/component.go:299` wraps `strconv.ParseFloat` error
- `component/http/cache/cache.go:169` wraps decode error (bytes path)
- `component/http/cache/cache.go:179` wraps decode error (string path)

Line 185 ("could not parse cached response") has no underlying `error` value in scope, so I left it as-is rather than fabricate one.

Added a regression test in `component/sqs/component_test.go` (`TestGetAttributeFloat64_WrapsParseError`) that uses `errors.As` on a `*strconv.NumError`; it fails before the change and passes after.

`go test ./component/sqs/ ./component/http/cache/` and `go vet` clean.