### PR TITLE
fix(amqp): correct stats log message

### DIFF
--- a/component/amqp/component.go
+++ b/component/amqp/component.go
@@ -188,7 +188,7 @@ func (c *Component) processLoop(ctx context.Context, sub subscription) error {
 		case <-tickerStats.C:
 			err := c.stats(ctx, sub)
 			if err != nil {
-				slog.Error("failed to report sqsAPI stats: %v", log.ErrorAttr(err))
+				slog.Error("failed to report amqp stats", log.ErrorAttr(err))
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which an issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/patron/blob/master/README.md#how-to-contribute
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/patron/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Resolves #1052.

`component/amqp/component.go:191` had a copy-paste error from the SQS component:
- It logs the message `failed to report sqsAPI stats` from inside the AMQP component.
- It uses a printf-style `%v` placeholder in the slog message string. `slog` does not interpret printf verbs, so `%v` ends up in the output verbatim, and the error itself is also attached as a structured attribute.

## Short description of the changes

Replace `"failed to report sqsAPI stats: %v"` with `"failed to report amqp stats"`, matching the slog-style usage already adopted in `component/sqs/component.go:165` (`"failed to report sqsAPI stats", log.ErrorAttr(err)`). One-line fix in `component/amqp/component.go`.