### PR TITLE
fix: check all components for nil in Service.Run

### DIFF
--- a/service.go
+++ b/service.go
@@ -3,6 +3,7 @@ package patron
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -87,8 +88,13 @@ func New(name, version string, options ...OptionFunc) (*Service, error) {
 
 // Run starts the provided components and blocks until termination or a component error.
 func (s *Service) Run(ctx context.Context, components ...Component) error {
-	if len(components) == 0 || components[0] == nil {
+	if len(components) == 0 {
 		return errors.New("components are empty or nil")
+	}
+	for i, c := range components {
+		if c == nil {
+			return fmt.Errorf("component at index %d is nil", i)
+		}
 	}
 
 	defer func() {

--- a/service_test.go
+++ b/service_test.go
@@ -1,6 +1,7 @@
 package patron
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 
@@ -8,6 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
+
+type stubComponent struct{}
+
+func (stubComponent) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
@@ -65,6 +73,29 @@ func TestNew(t *testing.T) {
 				assert.NotNil(t, gotService.termSig)
 				assert.NotNil(t, gotService.sighupHandler)
 			}
+		})
+	}
+}
+
+func TestService_Run_RejectsNilComponentAtAnyIndex(t *testing.T) {
+	svc, err := New("test", "1.0", WithJSONLogger())
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		components []Component
+		wantErr    string
+	}{
+		"empty":           {components: nil, wantErr: "components are empty or nil"},
+		"nil at index 0":  {components: []Component{nil}, wantErr: "component at index 0 is nil"},
+		"nil at index 1":  {components: []Component{stubComponent{}, nil}, wantErr: "component at index 1 is nil"},
+		"nil at index 2":  {components: []Component{stubComponent{}, stubComponent{}, nil}, wantErr: "component at index 2 is nil"},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := svc.Run(context.Background(), tt.components...)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #1054. `Service.Run` only checks `components[0]` for nil before launching goroutines. A nil at any later index reaches `c.Run(ctx)` inside the goroutine and panics with `runtime error: invalid memory address or nil pointer dereference`.

## Short description of the changes

- `service.go`: iterate over all components and return `fmt.Errorf("component at index %d is nil", i)` for the first nil entry. Keeps the existing `components are empty or nil` error for the zero-length case.
- `service_test.go`: add `TestService_Run_RejectsNilComponentAtAnyIndex` with subtests for empty, nil at index 0, 1, and 2. All pass under `-race`.