### PR TITLE
fix(sql): propagate connInfo in Conn.BeginTx, Conn.Prepare, and Tx.Prepare

### DIFF
--- a/client/sql/sql.go
+++ b/client/sql/sql.go
@@ -70,7 +70,7 @@ func (c *Conn) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
 		return nil, err
 	}
 
-	return &Tx{tx: tx}, nil
+	return &Tx{tx: tx, connInfo: c.connInfo}, nil
 }
 
 // Close returns the connection to the connection pool.
@@ -117,7 +117,7 @@ func (c *Conn) Prepare(ctx context.Context, query string) (*Stmt, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Stmt{stmt: stmt}, nil
+	return &Stmt{stmt: stmt, connInfo: c.connInfo, query: query}, nil
 }
 
 // Query executes a query that returns rows.
@@ -433,7 +433,7 @@ func (tx *Tx) Prepare(ctx context.Context, query string) (*Stmt, error) {
 		return nil, err
 	}
 
-	return &Stmt{stmt: stmt}, nil
+	return &Stmt{stmt: stmt, connInfo: tx.connInfo, query: query}, nil
 }
 
 // Query executes a query that returns rows.


### PR DESCRIPTION
## Summary

Fixes #1225 (also closes the duplicate agentic-workflow issues #1291 and #1556).

Three one-line fixes in `client/sql/sql.go`:

| Method | Before | After |
|---|---|---|
| `Conn.BeginTx` | `&Tx{tx: tx}` | `&Tx{tx: tx, connInfo: c.connInfo}` |
| `Conn.Prepare` | `&Stmt{stmt: stmt}` | `&Stmt{stmt: stmt, connInfo: c.connInfo, query: query}` |
| `Tx.Prepare` | `&Stmt{stmt: stmt}` | `&Stmt{stmt: stmt, connInfo: tx.connInfo, query: query}` |

Without these, spans produced by `Tx.Commit`, `Tx.Exec`, `Tx.Query`, `Tx.Rollback`, and all `Stmt.*` methods obtained via `Conn.Prepare`/`Tx.Prepare` were missing `db.user`, `db.instance`, `db.name`, and `db.statement` attributes.

The fixes mirror the already-correct sibling implementations (`DB.BeginTx`, `DB.Prepare`, `Tx.Stmt`).

## Test plan

- [x] `go test ./client/sql/...` passes
- [x] 1 file changed, 3 lines — no exported API changes, no new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)