### PR TITLE
Replace Moto with Floci for local AWS emulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ docker-compose/tempo-data/
 # Local GitHub Actions runner (act) artifacts
 .github/aw/
 .gitnexus
+.claude-flow/

--- a/client/sqs/sqs_test.go
+++ b/client/sqs/sqs_test.go
@@ -157,13 +157,13 @@ func TestNewFromConfig_WithRetryConfig(t *testing.T) {
 	})
 }
 
-func TestNewFromConfig_LocalStack(t *testing.T) {
+func TestNewFromConfig_LocalEmulator(t *testing.T) {
 	t.Parallel()
 
-	t.Run("creates client for LocalStack", func(t *testing.T) {
+	t.Run("creates client for local AWS emulator", func(t *testing.T) {
 		t.Parallel()
 
-		localStackEndpoint := "http://localhost:4566"
+		localEndpoint := "http://localhost:4566"
 		cfg := aws.Config{
 			Region: "us-east-1",
 			Credentials: aws.CredentialsProviderFunc(func(_ context.Context) (aws.Credentials, error) {
@@ -175,11 +175,11 @@ func TestNewFromConfig_LocalStack(t *testing.T) {
 		}
 
 		client := NewFromConfig(cfg, func(o *sqs.Options) {
-			o.BaseEndpoint = &localStackEndpoint
+			o.BaseEndpoint = &localEndpoint
 		})
 
 		require.NotNil(t, client)
 		assert.NotNil(t, client.Options().BaseEndpoint)
-		assert.Equal(t, localStackEndpoint, *client.Options().BaseEndpoint)
+		assert.Equal(t, localEndpoint, *client.Options().BaseEndpoint)
 	})
 }

--- a/component/sqs/component.go
+++ b/component/sqs/component.go
@@ -147,17 +147,23 @@ func New(name, queueName string, sqsAPI API, proc ProcessorFunc, oo ...OptionFun
 // Run starts the consumer processing loop messages.
 func (c *Component) Run(ctx context.Context) error {
 	chErr := make(chan error)
+	consumeDone := make(chan struct{})
 
-	go c.consume(ctx, chErr)
+	go func() {
+		defer close(consumeDone)
+		c.consume(ctx, chErr)
+	}()
 
 	tickerStats := time.NewTicker(c.stats.interval)
 	defer tickerStats.Stop()
 	for {
 		select {
 		case err := <-chErr:
+			<-consumeDone
 			return err
 		case <-ctx.Done():
 			log.FromContext(ctx).Info("context cancellation received. exiting...")
+			<-consumeDone
 			return nil
 		case <-tickerStats.C:
 			err := c.report(ctx, c.api, c.queue.url)
@@ -277,22 +283,42 @@ func (c *Component) report(ctx context.Context, sqsAPI API, queueURL string) err
 
 	size, err = getAttributeFloat64(rsp.Attributes, sqsAttributeApproximateNumberOfMessagesDelayed)
 	if err != nil {
-		return err
+		size, err = getOptionalAttributeFloat64(rsp.Attributes, sqsAttributeApproximateNumberOfMessagesDelayed)
+		if err != nil {
+			return err
+		}
 	}
 	observeQueueSize(ctx, c.queue.name, "delayed", size)
 
 	size, err = getAttributeFloat64(rsp.Attributes, sqsAttributeApproximateNumberOfMessagesNotVisible)
 	if err != nil {
-		return err
+		size, err = getOptionalAttributeFloat64(rsp.Attributes, sqsAttributeApproximateNumberOfMessagesNotVisible)
+		if err != nil {
+			return err
+		}
 	}
 	observeQueueSize(ctx, c.queue.name, "invisible", size)
 	return nil
 }
 
 func getAttributeFloat64(attr map[string]string, key string) (float64, error) {
+	valueString := strings.TrimSpace(attr[key])
+	if valueString == "" {
+		// Some local AWS emulators omit queue attribute values when the count is zero.
+		// Stats reporting is best effort, so treat missing values as zero instead of failing the entire report tick.
+		return 0.0, nil
+	}
+	value, err := strconv.ParseFloat(valueString, 64)
+	if err != nil {
+		return 0.0, fmt.Errorf("could not convert %s to float64", valueString)
+	}
+	return value, nil
+}
+
+func getOptionalAttributeFloat64(attr map[string]string, key string) (float64, error) {
 	valueString := attr[key]
 	if len(strings.TrimSpace(valueString)) == 0 {
-		return 0.0, fmt.Errorf("value of %s is empty", key)
+		return 0.0, nil
 	}
 	value, err := strconv.ParseFloat(valueString, 64)
 	if err != nil {

--- a/component/sqs/component_test.go
+++ b/component/sqs/component_test.go
@@ -161,6 +161,60 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestGetAttributeFloat64(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		attrs       map[string]string
+		key         string
+		expected    float64
+		expectedErr string
+	}{
+		"success": {
+			attrs: map[string]string{
+				sqsAttributeApproximateNumberOfMessages: "12",
+			},
+			key:      sqsAttributeApproximateNumberOfMessages,
+			expected: 12,
+		},
+		"missing key defaults to zero": {
+			attrs:    map[string]string{},
+			key:      sqsAttributeApproximateNumberOfMessagesDelayed,
+			expected: 0,
+		},
+		"empty value defaults to zero": {
+			attrs: map[string]string{
+				sqsAttributeApproximateNumberOfMessagesDelayed: "   ",
+			},
+			key:      sqsAttributeApproximateNumberOfMessagesDelayed,
+			expected: 0,
+		},
+		"invalid value returns error": {
+			attrs: map[string]string{
+				sqsAttributeApproximateNumberOfMessagesNotVisible: "oops",
+			},
+			key:         sqsAttributeApproximateNumberOfMessagesNotVisible,
+			expectedErr: "could not convert oops to float64",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := getAttributeFloat64(tt.attrs, tt.key)
+
+			if tt.expectedErr != "" {
+				require.EqualError(t, err, tt.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
 func TestComponent_Run_Success(t *testing.T) {
 	t.Cleanup(func() { traceExporter.Reset() })
 

--- a/component/sqs/component_test.go
+++ b/component/sqs/component_test.go
@@ -210,7 +210,7 @@ func TestGetAttributeFloat64(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, got)
+			assert.InDelta(t, tt.expected, got, 0)
 		})
 	}
 }

--- a/component/sqs/integration_test.go
+++ b/component/sqs/integration_test.go
@@ -161,7 +161,12 @@ type SQSAPI interface {
 }
 
 func createSQSAPI(region, endpoint string) (*sqs.Client, func(), error) {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, nil, fmt.Errorf("default transport is %T, expected *http.Transport", http.DefaultTransport)
+	}
+
+	transport = transport.Clone()
 	transport.DisableKeepAlives = true
 	transport.ForceAttemptHTTP2 = false
 	closeIdleConnections := transport.CloseIdleConnections

--- a/component/sqs/integration_test.go
+++ b/component/sqs/integration_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,8 +42,9 @@ func Test_SQS_Consume(t *testing.T) {
 	const queueName = "test-sqs-consume"
 	const correlationID = "123"
 
-	api, err := createSQSAPI(region, endpoint)
+	api, closeAPI, err := createSQSAPI(region, endpoint)
 	require.NoError(t, err)
+	t.Cleanup(closeAPI)
 	queue, err := createSQSQueue(api, queueName)
 	require.NoError(t, err)
 
@@ -77,7 +80,13 @@ func Test_SQS_Consume(t *testing.T) {
 	runCtx, runCancel := context.WithCancel(context.Background())
 	defer runCancel()
 
-	go func() { assert.NoError(t, cmp.Run(runCtx)) }()
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		assert.NoError(t, cmp.Run(runCtx))
+	}()
 
 	got := <-chReceived
 
@@ -103,6 +112,8 @@ func Test_SQS_Consume(t *testing.T) {
 	test.AssertMetric(t, collectedMetrics.ScopeMetrics[0].Metrics, "sqs.queue.size")
 
 	runCancel()
+	wg.Wait()
+	closeAPI()
 }
 
 func sendMessage(t *testing.T, client *sqs.Client, correlationID, queue string, ids ...string) []*testMessage {
@@ -149,13 +160,20 @@ type SQSAPI interface {
 	ReceiveMessage(ctx context.Context, params *sqs.ReceiveMessageInput, optFns ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error)
 }
 
-func createSQSAPI(region, endpoint string) (*sqs.Client, error) {
+func createSQSAPI(region, endpoint string) (*sqs.Client, func(), error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DisableKeepAlives = true
+	transport.ForceAttemptHTTP2 = false
+	closeIdleConnections := transport.CloseIdleConnections
+	httpClient := &http.Client{Transport: transport}
+
 	cfg, err := awsConfig.LoadDefaultConfig(context.Background(),
 		awsConfig.WithRegion(region),
+		awsConfig.WithHTTPClient(httpClient),
 		awsConfig.WithCredentialsProvider(aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider("test", "test", ""))),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create AWS config: %w", err)
+		return nil, nil, fmt.Errorf("failed to create AWS config: %w", err)
 	}
 
 	api := sqs.NewFromConfig(cfg, func(o *sqs.Options) {
@@ -163,5 +181,5 @@ func createSQSAPI(region, endpoint string) (*sqs.Client, error) {
 		o.Region = region
 	})
 
-	return api, nil
+	return api, closeIdleConnections, nil
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,19 +98,11 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
-  moto:
-    image: motoserver/moto:5.1.22
+  floci:
+    image: floci/floci:1.5.16
     restart: always
     ports:
-      - "127.0.0.1:4566:5000"
-    environment:
-      - MOTO_PORT=5000
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/moto-api/"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
+      - "127.0.0.1:4566:4566"
   hivemq:
     image: hivemq/hivemq4:4.51.0
     restart: always


### PR DESCRIPTION
## Summary
- replace the local AWS emulator container from Moto to Floci while keeping the existing `http://localhost:4566` contract
- make SQS queue stats and shutdown behavior tolerate Floci's response shape and long-poll cancellation timing
- stabilize the SQS integration test by using a test-owned HTTP transport and rename the remaining LocalStack-specific test wording

## Testing
- `go test ./client/sqs -tags=integration -run '^TestNewFromConfig$' -count=1`
- `go test ./client/sns -tags=integration -run '^TestNewFromConfig$' -count=1`
- `go test ./component/sqs -tags=integration -run '^Test_SQS_Consume$' -count=1`
- `docker compose up -d --wait && task testint && docker compose down`

Resolves #1571 