### PR TITLE
fix: harden service startup and observability shutdown

### DIFF
--- a/observability/observability.go
+++ b/observability/observability.go
@@ -93,16 +93,26 @@ func Setup(ctx context.Context, cfg Config) (*Provider, error) {
 // It forces a flush of metrics and traces, logs any errors encountered during flushing,
 // and shuts down the metric and trace providers.
 func (p *Provider) Shutdown(ctx context.Context) error {
-	err := p.mp.ForceFlush(ctx)
-	if err != nil {
-		slog.Error("failed to flush metrics", log.ErrorAttr(err))
-	}
-	err = p.mp.Shutdown(ctx)
-	if err != nil {
-		return err
+	if p == nil {
+		return nil
 	}
 
-	err = p.tp.ForceFlush(ctx)
+	if p.mp != nil {
+		err := p.mp.ForceFlush(ctx)
+		if err != nil {
+			slog.Error("failed to flush metrics", log.ErrorAttr(err))
+		}
+		err = p.mp.Shutdown(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	if p.tp == nil {
+		return nil
+	}
+
+	err := p.tp.ForceFlush(ctx)
 	if err != nil {
 		slog.Error("failed to flush traces", log.ErrorAttr(err))
 	}

--- a/observability/observability_test.go
+++ b/observability/observability_test.go
@@ -217,24 +217,19 @@ func TestProvider_Structure(t *testing.T) {
 }
 
 func TestProvider_Shutdown_WithNilProviders(t *testing.T) {
-	provider := &Provider{
-		mp: nil,
-		tp: nil,
-	}
+	provider := &Provider{}
 
-	ctx := context.Background()
+	assert.NotPanics(t, func() {
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+}
 
-	// This should handle nil providers gracefully or panic - let's see
-	// In actual implementation, this would likely panic or error
-	// We're documenting the behavior
-	defer func() {
-		if r := recover(); r != nil {
-			// Expected to panic with nil providers
-			assert.NotNil(t, r)
-		}
-	}()
+func TestProvider_Shutdown_WithNilReceiver(t *testing.T) {
+	var provider *Provider
 
-	_ = provider.Shutdown(ctx)
+	assert.NotPanics(t, func() {
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
 }
 
 func TestSetup_ValidConfig(t *testing.T) {

--- a/observability/observability_test.go
+++ b/observability/observability_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
@@ -226,6 +228,22 @@ func TestProvider_Shutdown_WithNilProviders(t *testing.T) {
 
 func TestProvider_Shutdown_WithNilReceiver(t *testing.T) {
 	var provider *Provider
+
+	assert.NotPanics(t, func() {
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+}
+
+func TestProvider_Shutdown_WithOnlyMeterProvider(t *testing.T) {
+	provider := &Provider{mp: &sdkmetric.MeterProvider{}}
+
+	assert.NotPanics(t, func() {
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+}
+
+func TestProvider_Shutdown_WithOnlyTraceProvider(t *testing.T) {
+	provider := &Provider{tp: sdktrace.NewTracerProvider()}
 
 	assert.NotPanics(t, func() {
 		require.NoError(t, provider.Shutdown(context.Background()))

--- a/service.go
+++ b/service.go
@@ -87,8 +87,14 @@ func New(name, version string, options ...OptionFunc) (*Service, error) {
 
 // Run starts the provided components and blocks until termination or a component error.
 func (s *Service) Run(ctx context.Context, components ...Component) error {
-	if len(components) == 0 || components[0] == nil {
+	if len(components) == 0 {
 		return errors.New("components are empty or nil")
+	}
+
+	for _, component := range components {
+		if component == nil {
+			return errors.New("components are empty or nil")
+		}
 	}
 
 	defer func() {

--- a/service_test.go
+++ b/service_test.go
@@ -1,13 +1,27 @@
 package patron
 
 import (
+	"context"
 	"log/slog"
+	"os"
+	"sync/atomic"
 	"testing"
 
+	"github.com/beatlabs/patron/observability"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
+
+type testRunComponent struct {
+	ran atomic.Bool
+	err error
+}
+
+func (c *testRunComponent) Run(_ context.Context) error {
+	c.ran.Store(true)
+	return c.err
+}
 
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
@@ -67,4 +81,20 @@ func TestNew(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRunRejectsNilComponentBeforeStartingAny(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{
+		name:                  "test-service",
+		termSig:               make(chan os.Signal, 1),
+		observabilityProvider: &observability.Provider{},
+	}
+	component := &testRunComponent{}
+
+	err := service.Run(context.Background(), component, nil)
+
+	require.EqualError(t, err, "components are empty or nil")
+	assert.False(t, component.ran.Load())
 }

--- a/service_test.go
+++ b/service_test.go
@@ -98,3 +98,17 @@ func TestRunRejectsNilComponentBeforeStartingAny(t *testing.T) {
 	require.EqualError(t, err, "components are empty or nil")
 	assert.False(t, component.ran.Load())
 }
+
+func TestRunRejectsEmptyComponents(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{
+		name:                  "test-service",
+		termSig:               make(chan os.Signal, 1),
+		observabilityProvider: &observability.Provider{},
+	}
+
+	err := service.Run(context.Background())
+
+	require.EqualError(t, err, "components are empty or nil")
+}


### PR DESCRIPTION
## Summary
- reject nil components before service startup so the service never partially starts and then panics on a later nil component
- make observability provider shutdown nil-safe for deferred cleanup paths and update tests to assert no-panic behavior
- keep the change set small and bugs-first: two focused commits, no broader trace/metric refactor yet

Closes #1054.

## Testing
- go test ./... -run 'TestRunRejectsNilComponentBeforeStartingAny|TestProvider_Shutdown_WithNilProviders|TestProvider_Shutdown_WithNilReceiver' -v
- go test -race ./... -run 'TestRunRejectsNilComponentBeforeStartingAny|TestProvider_Shutdown_WithNilProviders|TestProvider_Shutdown_WithNilReceiver' -v
- task test