### PR TITLE
fix(retry): skip terminal sleep after last failure

### DIFF
--- a/reliability/retry/retry.go
+++ b/reliability/retry/retry.go
@@ -29,13 +29,13 @@ func (r Retry) Execute(act Action) (any, error) {
 	var err error
 	var res any
 
-	for range r.attempts {
+	for attempt := 0; attempt < r.attempts; attempt++ {
 		res, err = act()
 		if err == nil {
 			return res, nil
 		}
 
-		if r.delay > 0 {
+		if attempt < r.attempts-1 && r.delay > 0 {
 			time.Sleep(r.delay)
 		}
 	}

--- a/reliability/retry/retry_test.go
+++ b/reliability/retry/retry_test.go
@@ -113,6 +113,27 @@ func Test_Retry_Execute(t *testing.T) {
 	}
 }
 
+func Test_Retry_Execute_DoesNotSleepAfterLastFailure(t *testing.T) {
+	t.Parallel()
+
+	r, err := New(2, 300*time.Millisecond)
+	require.NoError(t, err)
+
+	action := &mockAction{errors: 2}
+
+	start := time.Now()
+	res, err := r.Execute(func() (any, error) {
+		return action.Execute()
+	})
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, errTest)
+	assert.Nil(t, res)
+	assert.Equal(t, 2, action.executions)
+	assert.GreaterOrEqual(t, elapsed, 300*time.Millisecond)
+	assert.Less(t, elapsed, 500*time.Millisecond)
+}
+
 type mockAction struct {
 	errors     int
 	executions int


### PR DESCRIPTION
## Summary
- stop `Retry.Execute` from sleeping after the final failed attempt so failure paths do not incur an extra delay
- add a regression test that proves the last failed attempt returns without an additional sleep
- keep scope limited to `reliability/retry` as the next bugs-first reliability fix

Part of #1039.

## Testing
- go test ./reliability/retry -run Test_Retry_Execute -race -v
- go test ./reliability/... -race
- go test ./client/http -run TestTracedClient_Do -race