### PR TITLE
fix(circuitbreaker): prevent stale half-open state transitions

### DIFF
--- a/reliability/circuitbreaker/breaker.go
+++ b/reliability/circuitbreaker/breaker.go
@@ -142,12 +142,14 @@ func (cb *CircuitBreaker) Execute(ctx context.Context, act Action) (any, error) 
 }
 
 func (cb *CircuitBreaker) incFailure(ctx context.Context) {
-	// allow closed and half open to transition to open
-	if cb.isOpen() {
-		return
-	}
 	cb.Lock()
 	defer cb.Unlock()
+	now := time.Now().UnixNano()
+
+	// allow only closed and half open to transition to open
+	if cb.status == opened && cb.nextRetry > now {
+		return
+	}
 
 	cb.failures++
 
@@ -166,12 +168,14 @@ func (cb *CircuitBreaker) incFailure(ctx context.Context) {
 }
 
 func (cb *CircuitBreaker) incSuccess(ctx context.Context) {
-	// allow only half open in order to transition to closed
-	if !cb.isHalfOpen() {
-		return
-	}
 	cb.Lock()
 	defer cb.Unlock()
+	now := time.Now().UnixNano()
+
+	// allow only half open in order to transition to closed
+	if cb.status != opened || cb.nextRetry > now {
+		return
+	}
 
 	cb.retries++
 	cb.executions++

--- a/reliability/circuitbreaker/breaker_test.go
+++ b/reliability/circuitbreaker/breaker_test.go
@@ -3,6 +3,7 @@ package circuitbreaker
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -190,6 +191,86 @@ func TestCircuitBreaker_Close_Open_HalfOpen_Open_HalfOpen_Close(t *testing.T) {
 	assert.Equal(t, uint(0), cb.retries)
 	assert.True(t, cb.isClose())
 	assert.Equal(t, tsFuture, cb.nextRetry)
+}
+
+func TestCircuitBreaker_ConcurrentHalfOpenFailuresIgnoreStaleCallers(t *testing.T) {
+	t.Parallel()
+
+	cb, err := New("test", Setting{
+		FailureThreshold:           10,
+		RetryTimeout:               time.Second,
+		RetrySuccessThreshold:      2,
+		MaxRetryExecutionThreshold: 2,
+	})
+	require.NoError(t, err)
+
+	for range 50 {
+		cb.status = opened
+		cb.failures = 0
+		cb.executions = 0
+		cb.retries = 0
+		cb.nextRetry = time.Now().Add(-time.Second).UnixNano()
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for range 3 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				cb.incFailure(context.Background())
+			}()
+		}
+
+		close(start)
+		wg.Wait()
+
+		assert.Equal(t, opened, cb.status)
+		assert.Equal(t, uint(0), cb.failures)
+		assert.Equal(t, uint(0), cb.executions)
+		assert.Equal(t, uint(0), cb.retries)
+		assert.Greater(t, cb.nextRetry, time.Now().UnixNano())
+	}
+}
+
+func TestCircuitBreaker_ConcurrentHalfOpenSuccessesIgnoreStaleCallers(t *testing.T) {
+	t.Parallel()
+
+	cb, err := New("test", Setting{
+		FailureThreshold:           1,
+		RetryTimeout:               time.Second,
+		RetrySuccessThreshold:      2,
+		MaxRetryExecutionThreshold: 3,
+	})
+	require.NoError(t, err)
+
+	for range 50 {
+		cb.status = opened
+		cb.failures = 0
+		cb.executions = 0
+		cb.retries = 0
+		cb.nextRetry = time.Now().Add(-time.Second).UnixNano()
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for range 3 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				cb.incSuccess(context.Background())
+			}()
+		}
+
+		close(start)
+		wg.Wait()
+
+		assert.Equal(t, closed, cb.status)
+		assert.Equal(t, uint(0), cb.failures)
+		assert.Equal(t, uint(0), cb.executions)
+		assert.Equal(t, uint(0), cb.retries)
+		assert.Equal(t, tsFuture, cb.nextRetry)
+	}
 }
 
 func BenchmarkCircuitBreaker_Execute(b *testing.B) {


### PR DESCRIPTION
## Summary
- move half-open/open gating fully inside `incFailure` and `incSuccess` write locks so stale callers cannot classify state outside the critical section
- keep `Execute` behavior unchanged around the user action and limit the fix to circuit-breaker bookkeeping
- add concurrent regression tests that exercise stale half-open callers on both failure and success paths

Part of #1039.

## Testing
- go test ./reliability/circuitbreaker -run TestCircuitBreaker_ -race -v
- go test ./reliability/... -race
- go test ./client/http -run TestTracedClient_Do -race
- task test