### PR TITLE
fix(circuitbreaker): emit status metric on open rejection

### DIFF
--- a/reliability/circuitbreaker/breaker.go
+++ b/reliability/circuitbreaker/breaker.go
@@ -128,6 +128,7 @@ func (cb *CircuitBreaker) isClose() bool {
 // Execute the provided action.
 func (cb *CircuitBreaker) Execute(ctx context.Context, act Action) (any, error) {
 	if cb.isOpen() {
+		breakerCounterInc(ctx, cb.name, opened)
 		return nil, errOpen
 	}
 

--- a/reliability/circuitbreaker/breaker_test.go
+++ b/reliability/circuitbreaker/breaker_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	internaltest "github.com/beatlabs/patron/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -271,6 +272,38 @@ func TestCircuitBreaker_ConcurrentHalfOpenSuccessesIgnoreStaleCallers(t *testing
 		assert.Equal(t, uint(0), cb.retries)
 		assert.Equal(t, tsFuture, cb.nextRetry)
 	}
+}
+
+func TestCircuitBreaker_Execute_OpenCircuitEmitsMetric(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	shutdownMetrics, collectMetrics := internaltest.SetupMetrics(ctx, t)
+	t.Cleanup(shutdownMetrics)
+
+	cb, err := New("test", Setting{
+		FailureThreshold:           1,
+		RetryTimeout:               time.Second,
+		RetrySuccessThreshold:      1,
+		MaxRetryExecutionThreshold: 1,
+	})
+	require.NoError(t, err)
+
+	cb.status = opened
+	cb.nextRetry = time.Now().Add(time.Second).UnixNano()
+
+	actionCalled := false
+	_, err = cb.Execute(ctx, func() (any, error) {
+		actionCalled = true
+		return "unexpected", nil
+	})
+
+	require.ErrorIs(t, err, errOpen)
+	assert.False(t, actionCalled)
+
+	collectedMetrics := collectMetrics(1)
+	allMetrics := internaltest.AllMetrics(collectedMetrics)
+	internaltest.AssertMetric(t, allMetrics, "circuit-breaker.status")
 }
 
 func BenchmarkCircuitBreaker_Execute(b *testing.B) {


### PR DESCRIPTION
## Summary
- emit the existing `circuit-breaker.status` metric when `Execute` rejects immediately because the breaker is already open
- add a direct regression test that proves the callback is skipped, `errOpen` is returned, and the status metric is emitted on that early-return path
- keep the patch limited to the already-open observability gap left in the broader reliability issue

Part of #1039.

## Testing
- go test ./reliability/circuitbreaker -run 'TestCircuitBreaker_Execute_OpenCircuitEmitsMetric|TestCircuitBreaker_Close_Open_HalfOpen_Open_HalfOpen_Close|TestCircuitBreaker_isOpen' -v
- go test ./reliability/... -v
- task test