### PR TITLE
fix(kafka): count consumer errors only on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Task
         uses: arduino/setup-task@v2
         with:
-          version: 3.x
+          version: 3.50.0
 
       - name: Validate Taskfile
         run: task validate
@@ -96,7 +96,7 @@ jobs:
       - name: Install Task
         uses: arduino/setup-task@v2
         with:
-          version: 3.x
+          version: 3.50.0
 
       - name: Validate Taskfile
         run: task validate

--- a/component/kafka/component.go
+++ b/component/kafka/component.go
@@ -189,7 +189,9 @@ func (c *Component) processing(ctx context.Context) error {
 			cl.Close()
 		}
 
-		consumerErrorsInc(ctx, c.name)
+		if componentError != nil {
+			consumerErrorsInc(ctx, c.name)
+		}
 
 		if c.retries > 0 {
 			if handler.processedMessages {

--- a/component/kafka/integration_test.go
+++ b/component/kafka/integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -165,6 +166,17 @@ func TestKafkaComponent_Success(t *testing.T) {
 	test.AssertMetric(t, allMetrics, "kafka.consumer.offset.diff")
 	test.AssertMetric(t, allMetrics, "kafka.publish.count")
 	test.AssertMetric(t, allMetrics, "kafka.message.status")
+	assertMetricAbsent(t, allMetrics, "kafka.consumer.errors")
+}
+
+func assertMetricAbsent(t *testing.T, metrics []metricdata.Metrics, expectedName string) {
+	t.Helper()
+	for _, metric := range metrics {
+		if metric.Name == expectedName {
+			assert.Fail(t, "unexpected metric found", "metric %s should not be present", expectedName)
+			return
+		}
+	}
 }
 
 func TestKafkaComponent_FailAllRetries(t *testing.T) {


### PR DESCRIPTION
## Summary
- guard `consumerErrorsInc` so the Kafka consumer error counter increments only when a loop iteration actually ends with a component error
- add an integration assertion on the successful Kafka path to prove `kafka.consumer.errors` is absent after clean processing and shutdown
- keep retry behavior unchanged while fixing the metric semantics for clean shutdown and successful iterations

Closes #1561.

## Testing
- go test ./component/kafka -run 'TestConsumerErrorsInc|TestNew|TestConsumerHandler_Flush' -v
- go test -tags=integration ./component/kafka -run 'TestKafkaComponent_Success|TestKafkaComponent_FailAllRetries' -v
- task test