### PR TITLE
fix(amqp): remove printf formatting from stats error log

### DIFF
--- a/client/es/elasticsearch_test.go
+++ b/client/es/elasticsearch_test.go
@@ -16,6 +16,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
+const indexMappingsBody = `{"mappings": {"_doc": {"properties": {"field1": {"type": "integer"}}}}}`
+
 func TestNew(t *testing.T) {
 	exp := tracetest.NewInMemoryExporter()
 	tracePublisher := trace.Setup("test", nil, exp)
@@ -52,11 +54,9 @@ func TestNew(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, client)
 
-	queryBody := `{"mappings": {"_doc": {"properties": {"field1": {"type": "integer"}}}}}` //nolint: goconst
-
 	rsp, err := client.Indices.Create(
 		indexName,
-		client.Indices.Create.WithBody(strings.NewReader(queryBody)),
+		client.Indices.Create.WithBody(strings.NewReader(indexMappingsBody)),
 		client.Indices.Create.WithContext(ctx),
 	)
 	require.NoError(t, err)
@@ -104,10 +104,9 @@ func TestNew_FailureMetrics(t *testing.T) {
 	require.NoError(t, err)
 
 	// Make a typed API request (uses instrumentation Start/Close) that will return 500
-	queryBody := `{"mappings": {"_doc": {"properties": {"field1": {"type": "integer"}}}}}`
 	rsp, err := client.Indices.Create(
 		"failed_index",
-		client.Indices.Create.WithBody(strings.NewReader(queryBody)),
+		client.Indices.Create.WithBody(strings.NewReader(indexMappingsBody)),
 		client.Indices.Create.WithContext(ctx),
 	)
 	require.NoError(t, err)

--- a/component/amqp/component.go
+++ b/component/amqp/component.go
@@ -189,7 +189,7 @@ func (c *Component) processLoop(ctx context.Context, sub subscription) error {
 		case <-tickerStats.C:
 			err := c.stats(ctx, sub)
 			if err != nil {
-				slog.Error("failed to report sqsAPI stats: %v", log.ErrorAttr(err))
+				slog.Error("failed to report sqsAPI stats", log.ErrorAttr(err))
 			}
 		}
 	}

--- a/component/amqp/component.go
+++ b/component/amqp/component.go
@@ -189,10 +189,14 @@ func (c *Component) processLoop(ctx context.Context, sub subscription) error {
 		case <-tickerStats.C:
 			err := c.stats(ctx, sub)
 			if err != nil {
-				slog.Error("failed to report sqsAPI stats", log.ErrorAttr(err))
+				logStatsError(err)
 			}
 		}
 	}
+}
+
+func logStatsError(err error) {
+	slog.Error("failed to report sqsAPI stats", log.ErrorAttr(err))
 }
 
 type subscription struct {

--- a/component/amqp/component_test.go
+++ b/component/amqp/component_test.go
@@ -1,7 +1,10 @@
 package amqp
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -84,4 +87,31 @@ func TestNew(t *testing.T) {
 			}
 		})
 	}
+}
+
+
+func TestLogStatsError(t *testing.T) {
+	errOutput := captureAMQPLogOutput(t, func() {
+		logStatsError(errors.New("stats failed"))
+	})
+
+	assert.Contains(t, errOutput, "failed to report sqsAPI stats")
+	assert.NotContains(t, errOutput, "%v")
+	assert.Contains(t, errOutput, "stats failed")
+}
+
+func captureAMQPLogOutput(t *testing.T, fn func()) string {
+	t.Helper()
+
+	originalLogger := slog.Default()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	defer func() {
+		slog.SetDefault(originalLogger)
+	}()
+
+	slog.SetDefault(logger)
+	fn()
+
+	return buf.String()
 }

--- a/component/amqp/component_test.go
+++ b/component/amqp/component_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testURL   = "url"
+	testQueue = "queue"
+)
+
 func TestNew(t *testing.T) {
 	t.Parallel()
 	proc := func(_ context.Context, b Batch) {
@@ -30,8 +35,8 @@ func TestNew(t *testing.T) {
 	}{
 		"success": {
 			args: args{
-				url:   "url",
-				queue: "queue",
+				url:   testURL,
+				queue: testQueue,
 				proc:  proc,
 				oo:    []OptionFunc{WithBatching(5, 5*time.Millisecond)},
 			},
@@ -39,7 +44,7 @@ func TestNew(t *testing.T) {
 		"missing url": {
 			args: args{
 				url:   "",
-				queue: "queue",
+				queue: testQueue,
 				proc:  proc,
 				oo:    []OptionFunc{WithBatching(5, 5*time.Millisecond)},
 			},
@@ -47,7 +52,7 @@ func TestNew(t *testing.T) {
 		},
 		"missing queue": {
 			args: args{
-				url:   "url",
+				url:   testURL,
 				queue: "",
 				proc:  proc,
 				oo:    []OptionFunc{WithBatching(5, 5*time.Millisecond)},
@@ -56,8 +61,8 @@ func TestNew(t *testing.T) {
 		},
 		"missing process function": {
 			args: args{
-				url:   "url",
-				queue: "queue",
+				url:   testURL,
+				queue: testQueue,
 				proc:  nil,
 				oo:    []OptionFunc{WithBatching(5, 5*time.Millisecond)},
 			},
@@ -65,8 +70,8 @@ func TestNew(t *testing.T) {
 		},
 		"batching option fails": {
 			args: args{
-				url:   "url",
-				queue: "queue",
+				url:   testURL,
+				queue: testQueue,
 				proc:  proc,
 				oo:    []OptionFunc{WithBatching(0, 5*time.Millisecond)},
 			},
@@ -88,7 +93,6 @@ func TestNew(t *testing.T) {
 		})
 	}
 }
-
 
 func TestLogStatsError(t *testing.T) {
 	errOutput := captureAMQPLogOutput(t, func() {

--- a/component/amqp/integration_test.go
+++ b/component/amqp/integration_test.go
@@ -3,7 +3,9 @@
 package amqp
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"os"
 	"testing"
 	"time"
@@ -46,6 +48,7 @@ func init() {
 const (
 	endpoint      = "amqp://bitnami:bitnami@localhost:5672/" //nolint:gosec
 	rabbitMQQueue = "rmq-test-queue"
+	missingQueue  = "rmq-missing-queue"
 )
 
 func TestRun(t *testing.T) {
@@ -137,6 +140,51 @@ func TestRun(t *testing.T) {
 	test.AssertMetric(t, collectedMetrics.ScopeMetrics[0].Metrics, "amqp.publish.duration")
 	test.AssertMetric(t, collectedMetrics.ScopeMetrics[0].Metrics, "amqp.message.age")
 	test.AssertMetric(t, collectedMetrics.ScopeMetrics[0].Metrics, "amqp.message.counter")
+}
+
+func TestProcessLoop_LogsStatsError(t *testing.T) {
+	require.NoError(t, createQueue())
+
+	cmp, err := New(endpoint, rabbitMQQueue, func(_ context.Context, _ Batch) {},
+		WithStatsInterval(10*time.Millisecond),
+		WithRetry(1, time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	sub, err := cmp.subscribe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = sub.close()
+	})
+
+	cmp.queueCfg.queue = missingQueue
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	errOutput := captureAMQPIntegrationLogOutput(t, func() {
+		err = cmp.processLoop(ctx, sub)
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, errOutput, "failed to report sqsAPI stats")
+	assert.NotContains(t, errOutput, "%v")
+}
+
+func captureAMQPIntegrationLogOutput(t *testing.T, fn func()) string {
+	t.Helper()
+
+	originalLogger := slog.Default()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	defer func() {
+		slog.SetDefault(originalLogger)
+	}()
+
+	slog.SetDefault(logger)
+	fn()
+
+	return buf.String()
 }
 
 func createQueue() error {

--- a/component/amqp/option_test.go
+++ b/component/amqp/option_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const successCase = "success"
+
 func TestAMQPConfig(t *testing.T) {
 	cfg := amqp.Config{Locale: "123"}
 	c := &Component{}
@@ -26,7 +28,7 @@ func TestBatching(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success":         {args: args{count: 2, timeout: 2 * time.Millisecond}},
+		successCase:       {args: args{count: 2, timeout: 2 * time.Millisecond}},
 		"invalid count":   {args: args{count: 1, timeout: 2 * time.Millisecond}, expectedErr: "count should be larger than 1 message"},
 		"invalid timeout": {args: args{count: 2, timeout: -3}, expectedErr: "timeout should be a positive number"},
 	}
@@ -70,7 +72,7 @@ func TestStatsInterval(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success":          {args: args{interval: 2 * time.Millisecond}},
+		successCase:        {args: args{interval: 2 * time.Millisecond}},
 		"invalid interval": {args: args{interval: -3}, expectedErr: "stats interval should be a positive number"},
 	}
 	for name, tt := range tests {


### PR DESCRIPTION
## Summary
- remove the printf-style `%v` placeholder from the AMQP stats error log so slog emits the message correctly
- keep the existing `sqsAPI` wording unchanged so issue #1052 remains a separate fix
- verify the change with AMQP package tests

Closes #1566