### PR TITLE
fix(sqs): restore trace propagation from message attributes

### DIFF
--- a/component/sqs/component.go
+++ b/component/sqs/component.go
@@ -345,18 +345,30 @@ type consumerMessageCarrier struct {
 
 // Get retrieves a single value for a given key.
 func (c consumerMessageCarrier) Get(key string) string {
-	return c.msg.Attributes[key]
+	attribute, ok := c.msg.MessageAttributes[key]
+	if !ok || attribute.StringValue == nil {
+		return ""
+	}
+
+	return *attribute.StringValue
 }
 
 // Set sets a header.
 func (c consumerMessageCarrier) Set(key, val string) {
-	c.msg.Attributes[key] = val
+	if c.msg.MessageAttributes == nil {
+		c.msg.MessageAttributes = make(map[string]types.MessageAttributeValue)
+	}
+
+	c.msg.MessageAttributes[key] = types.MessageAttributeValue{
+		DataType:    aws.String("String"),
+		StringValue: aws.String(val),
+	}
 }
 
 // Keys returns a slice of all key identifiers in the carrier.
 func (c consumerMessageCarrier) Keys() []string {
-	keys := make([]string, 0, len(c.msg.Attributes))
-	for key := range c.msg.Attributes {
+	keys := make([]string, 0, len(c.msg.MessageAttributes))
+	for key := range c.msg.MessageAttributes {
 		keys = append(keys, key)
 	}
 	return keys

--- a/component/sqs/component_carrier_test.go
+++ b/component/sqs/component_carrier_test.go
@@ -1,0 +1,77 @@
+package sqs
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const traceparentKey = "traceparent"
+
+func TestConsumerMessageCarrierGet(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		message  types.Message
+		key      string
+		expected string
+	}{
+		"returns value from message attributes": {
+			message: types.Message{MessageAttributes: map[string]types.MessageAttributeValue{
+				traceparentKey: {StringValue: aws.String("00-abc-123-01")},
+			}},
+			key:      traceparentKey,
+			expected: "00-abc-123-01",
+		},
+		"missing attribute returns empty string": {
+			message:  types.Message{},
+			key:      traceparentKey,
+			expected: "",
+		},
+		"non string attribute returns empty string": {
+			message: types.Message{MessageAttributes: map[string]types.MessageAttributeValue{
+				traceparentKey: {DataType: aws.String("String")},
+			}},
+			key:      traceparentKey,
+			expected: "",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			carrier := consumerMessageCarrier{msg: &tt.message}
+
+			assert.Equal(t, tt.expected, carrier.Get(tt.key))
+		})
+	}
+}
+
+func TestConsumerMessageCarrierSet(t *testing.T) {
+	t.Parallel()
+
+	message := types.Message{}
+	carrier := consumerMessageCarrier{msg: &message}
+
+	carrier.Set(traceparentKey, "00-abc-123-01")
+
+	require.Contains(t, message.MessageAttributes, traceparentKey)
+	assert.Equal(t, "String", aws.ToString(message.MessageAttributes[traceparentKey].DataType))
+	assert.Equal(t, "00-abc-123-01", aws.ToString(message.MessageAttributes[traceparentKey].StringValue))
+}
+
+func TestConsumerMessageCarrierKeys(t *testing.T) {
+	t.Parallel()
+
+	message := types.Message{MessageAttributes: map[string]types.MessageAttributeValue{
+		traceparentKey: {StringValue: aws.String("00-abc-123-01")},
+		"baggage":      {StringValue: aws.String("k=v")},
+	}}
+	carrier := consumerMessageCarrier{msg: &message}
+
+	assert.ElementsMatch(t, []string{traceparentKey, "baggage"}, carrier.Keys())
+}


### PR DESCRIPTION
## Summary
- switch the SQS consumer text-map carrier from system attributes to message attributes so trace headers can be extracted correctly
- initialize `MessageAttributes` with string-typed values when the carrier sets headers
- add focused carrier tests for get/set/keys behavior and verify with unit and integration tests

Closes #1562