### PR TITLE
fix(kafka): cap retry attempts after partial progress

### DIFF
--- a/component/kafka/component.go
+++ b/component/kafka/component.go
@@ -191,30 +191,39 @@ func (c *Component) processing(ctx context.Context) error {
 
 		consumerErrorsInc(ctx, c.name)
 
-		if c.retries > 0 {
-			if handler.processedMessages {
-				i = 0
-			}
+		componentError, shouldRetry := shouldRetryProcessingAttempt(componentError, handler.getErr(), i, retries)
+		if componentError == nil {
+			return nil
+		}
 
-			if componentError == nil {
-				componentError = handler.getErr()
-			}
-
+		if shouldRetry {
 			slog.Error("failed run", slog.Uint64("current", uint64(i)), slog.Uint64("retries", uint64(c.retries)),
 				slog.Duration("wait", c.retryWait), log.ErrorAttr(componentError))
 			time.Sleep(c.retryWait)
-
-			if i < retries {
-				componentError = nil
-			}
+			continue
 		}
 
-		if i == retries && componentError == nil && handler.getErr() != nil {
-			componentError = fmt.Errorf("message processing failure exhausted %d retries: %w", i, handler.getErr())
-		}
+		return componentError
 	}
 
-	return componentError
+	return nil
+}
+
+func resolveRetryError(componentError, handlerError error) error {
+	if componentError != nil {
+		return componentError
+	}
+
+	return handlerError
+}
+
+func shouldRetryProcessingAttempt(componentError, handlerError error, current, retries uint32) (error, bool) {
+	err := resolveRetryError(componentError, handlerError)
+	if err == nil {
+		return nil, false
+	}
+
+	return err, current < retries
 }
 
 type consumerHandler struct {

--- a/component/kafka/component.go
+++ b/component/kafka/component.go
@@ -191,7 +191,7 @@ func (c *Component) processing(ctx context.Context) error {
 
 		consumerErrorsInc(ctx, c.name)
 
-		componentError, shouldRetry := shouldRetryProcessingAttempt(componentError, handler.getErr(), i, retries)
+		shouldRetry, componentError := shouldRetryProcessingAttempt(componentError, handler.getErr(), i, retries)
 		if componentError == nil {
 			return nil
 		}
@@ -217,13 +217,13 @@ func resolveRetryError(componentError, handlerError error) error {
 	return handlerError
 }
 
-func shouldRetryProcessingAttempt(componentError, handlerError error, current, retries uint32) (error, bool) {
+func shouldRetryProcessingAttempt(componentError, handlerError error, current, retries uint32) (bool, error) {
 	err := resolveRetryError(componentError, handlerError)
 	if err == nil {
-		return nil, false
+		return false, nil
 	}
 
-	return err, current < retries
+	return current < retries, err
 }
 
 type consumerHandler struct {

--- a/component/kafka/component_test.go
+++ b/component/kafka/component_test.go
@@ -326,6 +326,87 @@ func TestConsumerHandler_BatchTimeoutFlush(t *testing.T) {
 	handler.ticker.Stop()
 }
 
+func TestResolveRetryError(t *testing.T) {
+	t.Parallel()
+
+	componentErr := errors.New("component error")
+	handlerErr := errors.New("handler error")
+
+	tests := map[string]struct {
+		componentError error
+		handlerError   error
+		expected       error
+	}{
+		"prefers component error": {
+			componentError: componentErr,
+			handlerError:   handlerErr,
+			expected:       componentErr,
+		},
+		"falls back to handler error": {
+			handlerError: handlerErr,
+			expected:     handlerErr,
+		},
+		"returns nil on success": {},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.ErrorIs(t, resolveRetryError(tt.componentError, tt.handlerError), tt.expected)
+		})
+	}
+}
+
+func TestShouldRetryProcessingAttempt(t *testing.T) {
+	t.Parallel()
+
+	componentErr := errors.New("component error")
+	handlerErr := errors.New("handler error")
+
+	tests := map[string]struct {
+		componentError error
+		handlerError   error
+		current        uint32
+		retries        uint32
+		expectedErr    error
+		expectedRetry  bool
+	}{
+		"success does not retry": {},
+		"retries on component error before budget exhausted": {
+			componentError: componentErr,
+			current:        0,
+			retries:        1,
+			expectedErr:    componentErr,
+			expectedRetry:  true,
+		},
+		"retries on handler error before budget exhausted": {
+			handlerError:  handlerErr,
+			current:       0,
+			retries:       1,
+			expectedErr:   handlerErr,
+			expectedRetry: true,
+		},
+		"stops retrying when budget exhausted": {
+			handlerError:  handlerErr,
+			current:       1,
+			retries:       1,
+			expectedErr:   handlerErr,
+			expectedRetry: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err, retry := shouldRetryProcessingAttempt(tt.componentError, tt.handlerError, tt.current, tt.retries)
+
+			assert.ErrorIs(t, err, tt.expectedErr)
+			assert.Equal(t, tt.expectedRetry, retry)
+		})
+	}
+}
+
 func TestExecuteFailureStrategy_Unknown(t *testing.T) {
 	ctx := context.Background()
 	tracer := kotel.NewTracer()

--- a/component/kafka/component_test.go
+++ b/component/kafka/component_test.go
@@ -399,7 +399,7 @@ func TestShouldRetryProcessingAttempt(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			err, retry := shouldRetryProcessingAttempt(tt.componentError, tt.handlerError, tt.current, tt.retries)
+			retry, err := shouldRetryProcessingAttempt(tt.componentError, tt.handlerError, tt.current, tt.retries)
 
 			assert.ErrorIs(t, err, tt.expectedErr)
 			assert.Equal(t, tt.expectedRetry, retry)

--- a/component/kafka/option_test.go
+++ b/component/kafka/option_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const optionSuccessCase = "success"
+
 func TestFailureStrategy(t *testing.T) {
 	t.Parallel()
 	type args struct {
@@ -59,7 +61,7 @@ func TestRetryWait(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {
+		optionSuccessCase: {
 			args: args{retryWait: 5 * time.Second},
 		},
 		"negative retry wait": {
@@ -91,7 +93,7 @@ func TestBatchSize(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {
+		optionSuccessCase: {
 			args: args{batchSize: 1},
 		},
 		"zero batch size": {
@@ -123,7 +125,7 @@ func TestBatchTimeout(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {
+		optionSuccessCase: {
 			args: args{batchTimeout: 5 * time.Second},
 		},
 		"negative batch timeout": {
@@ -155,7 +157,7 @@ func TestNewSessionCallback(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {
+		optionSuccessCase: {
 			args: args{sessionCallback: func() error {
 				return nil
 			}},


### PR DESCRIPTION
## Summary
- remove processed-message-based retry counter resets so Kafka retries stay bounded
- make retry decisions explicit with small helper functions and focused unit coverage
- verify the fix with Kafka unit tests and the retry integration scenarios

Closes #1564