### PR TITLE
fix: wrap errors with %w in SQS and HTTP cache components

### DIFF
--- a/component/http/cache/cache.go
+++ b/component/http/cache/cache.go
@@ -166,7 +166,7 @@ func get(ctx context.Context, key string, rc *RouteCache) *response {
 		r := &response{}
 		err := r.decode(b)
 		if err != nil {
-			return &response{Err: fmt.Errorf("could not decode cached bytes as response %v for key %s", resp, key)}
+			return &response{Err: fmt.Errorf("could not decode cached bytes as response for key %s: %w", key, err)}
 		}
 		r.FromCache = true
 		return r
@@ -176,7 +176,7 @@ func get(ctx context.Context, key string, rc *RouteCache) *response {
 		r := &response{}
 		err := r.decode([]byte(b))
 		if err != nil {
-			return &response{Err: fmt.Errorf("could not decode cached string as response %v for key %s", resp, key)}
+			return &response{Err: fmt.Errorf("could not decode cached string as response for key %s: %w", key, err)}
 		}
 		r.FromCache = true
 		return r

--- a/component/sqs/component.go
+++ b/component/sqs/component.go
@@ -310,7 +310,7 @@ func getAttributeFloat64(attr map[string]string, key string) (float64, error) {
 	}
 	value, err := strconv.ParseFloat(valueString, 64)
 	if err != nil {
-		return 0.0, fmt.Errorf("could not convert %s to float64", valueString)
+		return 0.0, fmt.Errorf("could not convert %s to float64: %w", valueString, err)
 	}
 	return value, nil
 }
@@ -322,7 +322,7 @@ func getOptionalAttributeFloat64(attr map[string]string, key string) (float64, e
 	}
 	value, err := strconv.ParseFloat(valueString, 64)
 	if err != nil {
-		return 0.0, fmt.Errorf("could not convert %s to float64", valueString)
+		return 0.0, fmt.Errorf("could not convert %s to float64: %w", valueString, err)
 	}
 	return value, nil
 }

--- a/component/sqs/component_test.go
+++ b/component/sqs/component_test.go
@@ -205,7 +205,7 @@ func TestGetAttributeFloat64(t *testing.T) {
 			got, err := getAttributeFloat64(tt.attrs, tt.key)
 
 			if tt.expectedErr != "" {
-				require.EqualError(t, err, tt.expectedErr)
+				require.ErrorContains(t, err, tt.expectedErr)
 				return
 			}
 


### PR DESCRIPTION
## Summary

- `component/sqs/component.go`: `getAttributeFloat64` and `getOptionalAttributeFloat64` now wrap the `strconv.ParseFloat` error with `%w`, making `errors.Is`/`errors.As` work for callers
- `component/http/cache/cache.go`: two `gob.Decode` error paths now wrap the underlying error with `%w`
- `component/sqs/component_test.go`: updated assertion from `EqualError` to `ErrorContains` to match the new wrapped error message

## Test plan

- [x] `go test ./component/sqs/...` passes
- [x] `go test ./component/http/...` passes

Closes #1046

🤖 Generated with [Claude Code](https://claude.com/claude-code)