### PR TITLE
fix(observability): fix data races and Shutdown error leak

### DIFF
--- a/observability/log/log.go
+++ b/observability/log/log.go
@@ -3,8 +3,10 @@ package log
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
+	"sync"
 )
 
 // Config represents the configuration for setting up the logger.
@@ -16,16 +18,26 @@ type Config struct {
 
 type ctxKey struct{}
 
-var logCfg *Config
+var (
+	logCfg   *Config
+	logCfgMu sync.Mutex
+)
 
 // Setup sets up the logger with the given configuration.
 func Setup(cfg *Config) error {
+	logCfgMu.Lock()
 	logCfg = cfg
+	logCfgMu.Unlock()
 	return setDefaultLogger(cfg)
 }
 
 // SetLevel sets the logger level.
 func SetLevel(lvl string) error {
+	logCfgMu.Lock()
+	defer logCfgMu.Unlock()
+	if logCfg == nil {
+		return errors.New("logger not configured, call Setup first")
+	}
 	logCfg.Level = lvl
 	return setDefaultLogger(logCfg)
 }

--- a/observability/observability.go
+++ b/observability/observability.go
@@ -4,14 +4,13 @@ package observability
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/beatlabs/patron/observability/log"
 	patronmetric "github.com/beatlabs/patron/observability/metric"
 	patrontrace "github.com/beatlabs/patron/observability/trace"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -72,14 +71,13 @@ func Setup(ctx context.Context, cfg Config) (*Provider, error) {
 		return nil, err
 	}
 
-	otel.SetTextMapPropagator(propagation.TraceContext{})
-
 	metricProvider, err := patronmetric.Setup(ctx, res)
 	if err != nil {
 		return nil, err
 	}
 	traceProvider, err := patrontrace.SetupGRPC(ctx, cfg.Name, res)
 	if err != nil {
+		_ = metricProvider.Shutdown(ctx)
 		return nil, err
 	}
 
@@ -97,27 +95,27 @@ func (p *Provider) Shutdown(ctx context.Context) error {
 		return nil
 	}
 
+	var errs []error
+
 	if p.mp != nil {
-		err := p.mp.ForceFlush(ctx)
-		if err != nil {
+		if err := p.mp.ForceFlush(ctx); err != nil {
 			slog.Error("failed to flush metrics", log.ErrorAttr(err))
 		}
-		err = p.mp.Shutdown(ctx)
-		if err != nil {
-			return err
+		if err := p.mp.Shutdown(ctx); err != nil {
+			errs = append(errs, err)
 		}
 	}
 
-	if p.tp == nil {
-		return nil
+	if p.tp != nil {
+		if err := p.tp.ForceFlush(ctx); err != nil {
+			slog.Error("failed to flush traces", log.ErrorAttr(err))
+		}
+		if err := p.tp.Shutdown(ctx); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
-	err := p.tp.ForceFlush(ctx)
-	if err != nil {
-		slog.Error("failed to flush traces", log.ErrorAttr(err))
-	}
-
-	return p.tp.Shutdown(ctx)
+	return errors.Join(errs...)
 }
 
 func createResource(name, version string) (*resource.Resource, error) {

--- a/observability/trace/tracing.go
+++ b/observability/trace/tracing.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"context"
+	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
@@ -12,11 +13,20 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-var tracer trace.Tracer
+var (
+	globalTracer   trace.Tracer
+	globalTracerMu sync.RWMutex
+)
 
 // StartSpan starts a span with the given name and context.
 func StartSpan(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-	return tracer.Start(ctx, name, opts...) //nolint:spancheck
+	globalTracerMu.RLock()
+	t := globalTracer
+	globalTracerMu.RUnlock()
+	if t == nil {
+		return ctx, trace.SpanFromContext(ctx)
+	}
+	return t.Start(ctx, name, opts...) //nolint:spancheck
 }
 
 // SetupGRPC configures the global tracer with the OTLP gRPC exporter.
@@ -40,7 +50,9 @@ func Setup(name string, res *resource.Resource, exp sdktrace.SpanExporter) *sdkt
 	)
 	otel.SetTextMapPropagator(prop)
 
-	tracer = tp.Tracer(name)
+	globalTracerMu.Lock()
+	globalTracer = tp.Tracer(name)
+	globalTracerMu.Unlock()
 
 	return tp
 }


### PR DESCRIPTION
## Summary

- **`observability/log/log.go`**: protect `logCfg` with a `sync.Mutex`; add nil guard in `SetLevel` so calling it before `Setup` returns an error instead of panicking
- **`observability/trace/tracing.go`**: protect the package-level tracer with `sync.RWMutex` to eliminate data races between `Setup` and `StartSpan`
- **`observability/observability.go`**: remove dead `otel.SetTextMapPropagator` call (trace.Setup already sets the composite propagator); always attempt both metric and trace provider shutdown and accumulate errors with `errors.Join`; clean up the metric provider on trace-setup failure

## Test plan

- [x] `go test -race ./observability/...` passes

Closes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)