### PR TITLE
fix(circuitbreaker): respect context cancellation before executing action

### DIFF
--- a/reliability/circuitbreaker/breaker.go
+++ b/reliability/circuitbreaker/breaker.go
@@ -127,6 +127,9 @@ func (cb *CircuitBreaker) isClose() bool {
 
 // Execute the provided action.
 func (cb *CircuitBreaker) Execute(ctx context.Context, act Action) (any, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if cb.isOpen() {
 		breakerCounterInc(ctx, cb.name, opened)
 		return nil, errOpen


### PR DESCRIPTION
## Summary

- `Execute` now checks `ctx.Err()` at the top before invoking the action
- Callers with already-cancelled or timed-out contexts receive an immediate error instead of a spurious action invocation

## Test plan

- [x] `go test ./reliability/...` passes

Closes #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)