### PR TITLE
fix: prevent goroutine leaks and nil dereference in SQS, HTTP, Kafka, gRPC

### DIFF
--- a/component/grpc/component.go
+++ b/component/grpc/component.go
@@ -67,9 +67,15 @@ func (c *Component) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to listen: %w", err)
 	}
 
+	stopCtx, stopCancel := context.WithCancel(context.Background())
+	defer stopCancel()
+
 	go func() {
-		<-ctx.Done()
-		c.srv.GracefulStop()
+		select {
+		case <-ctx.Done():
+			c.srv.GracefulStop()
+		case <-stopCtx.Done():
+		}
 	}()
 
 	slog.Debug("gRPC component listening", slog.Int("port", c.port))

--- a/component/http/component.go
+++ b/component/http/component.go
@@ -123,7 +123,7 @@ func New(handler http.Handler, oo ...OptionFunc) (*Component, error) {
 // Run starts the HTTP server and blocks until the context is canceled or the server fails.
 func (c *Component) Run(ctx context.Context) error {
 	c.mu.Lock()
-	chFail := make(chan error)
+	chFail := make(chan error, 1)
 	srv := c.createHTTPServer()
 	go c.listenAndServe(srv, chFail)
 	c.mu.Unlock()

--- a/component/kafka/component.go
+++ b/component/kafka/component.go
@@ -201,7 +201,11 @@ func (c *Component) processing(ctx context.Context) error {
 		if shouldRetry {
 			slog.Error("failed run", slog.Uint64("current", uint64(i)), slog.Uint64("retries", uint64(c.retries)),
 				slog.Duration("wait", c.retryWait), log.ErrorAttr(componentError))
-			time.Sleep(c.retryWait)
+			select {
+			case <-time.After(c.retryWait):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 			continue
 		}
 
@@ -291,10 +295,7 @@ func (c *consumerHandler) consume(ctx context.Context, cl *kgo.Client) error {
 				slog.Info("closing consumer", log.ErrorAttr(ctx.Err()))
 			}
 
-			c.mu.Lock()
-			err := c.flush(cl)
-			c.mu.Unlock()
-			if err != nil {
+			if err := c.flush(cl); err != nil {
 				return err
 			}
 
@@ -325,17 +326,16 @@ func (c *consumerHandler) consume(ctx context.Context, cl *kgo.Client) error {
 					c.mu.Unlock()
 					return
 				}
-
 				c.recBuf = append(c.recBuf, rec)
-				if uint(len(c.recBuf)) >= c.batchSize {
-					err := c.flush(cl)
-					if err != nil {
-						c.err = err
-						c.mu.Unlock()
+				shouldFlush := uint(len(c.recBuf)) >= c.batchSize
+				c.mu.Unlock()
+
+				if shouldFlush {
+					if err := c.flush(cl); err != nil {
+						c.setErr(err)
 						return
 					}
 				}
-				c.mu.Unlock()
 			}
 		})
 
@@ -345,10 +345,7 @@ func (c *consumerHandler) consume(ctx context.Context, cl *kgo.Client) error {
 
 		select {
 		case <-c.ticker.C:
-			c.mu.Lock()
-			err := c.flush(cl)
-			c.mu.Unlock()
-			if err != nil {
+			if err := c.flush(cl); err != nil {
 				return err
 			}
 		default:
@@ -357,19 +354,25 @@ func (c *consumerHandler) consume(ctx context.Context, cl *kgo.Client) error {
 }
 
 func (c *consumerHandler) flush(cl *kgo.Client) error {
+	// Snapshot and clear recBuf under the lock so proc and commit run outside it,
+	// preventing a deadlock when OnPartitionsAssigned fires during proc execution.
+	c.mu.Lock()
 	if len(c.recBuf) == 0 {
+		c.mu.Unlock()
 		return nil
 	}
+	records := c.recBuf
+	c.recBuf = make([]*kgo.Record, 0, cap(c.recBuf))
+	c.mu.Unlock()
 
-	recordSpans := make([]recordSpan, 0, len(c.recBuf))
-	for _, rec := range c.recBuf {
+	recordSpans := make([]recordSpan, 0, len(records))
+	for _, rec := range records {
 		ctx, sp := c.getContextWithCorrelation(rec)
 		messageStatusCountInc(ctx, messageProcessed, c.group, rec.Topic)
 		rec.Context = ctx
 		recordSpans = append(recordSpans, recordSpan{record: rec, span: sp})
 	}
 
-	records := c.recBuf
 	if c.batchMessageDeduplication {
 		records = deduplicateRecords(records)
 	}
@@ -408,8 +411,6 @@ func (c *consumerHandler) flush(cl *kgo.Client) error {
 		}
 	}
 
-	c.recBuf = c.recBuf[:0]
-
 	return nil
 }
 
@@ -422,7 +423,7 @@ func (c *consumerHandler) executeFailureStrategy(recordSpans []recordSpan, err e
 			messageStatusCountInc(rs.record.Context, messageErrored, c.group, rs.record.Topic)
 		}
 		slog.Error("could not process message(s)")
-		c.err = err
+		c.setErr(err)
 		return err
 	case SkipStrategy:
 		for _, rs := range recordSpans {

--- a/component/kafka/component_test.go
+++ b/component/kafka/component_test.go
@@ -311,9 +311,7 @@ func TestConsumerHandler_BatchTimeoutFlush(t *testing.T) {
 
 	select {
 	case <-handler.ticker.C:
-		handler.mu.Lock()
 		err := handler.flush(nil)
-		handler.mu.Unlock()
 		require.NoError(t, err)
 	case <-time.After(50 * time.Millisecond):
 		t.Fatal("ticker did not fire within expected time")

--- a/component/sqs/component.go
+++ b/component/sqs/component.go
@@ -146,7 +146,7 @@ func New(name, queueName string, sqsAPI API, proc ProcessorFunc, oo ...OptionFun
 
 // Run starts the consumer processing loop messages.
 func (c *Component) Run(ctx context.Context) error {
-	chErr := make(chan error)
+	chErr := make(chan error, 1)
 	consumeDone := make(chan struct{})
 
 	go func() {

--- a/component/sqs/message.go
+++ b/component/sqs/message.go
@@ -63,7 +63,7 @@ func (m message) ID() string {
 }
 
 func (m message) Body() []byte {
-	return []byte(*m.msg.Body)
+	return []byte(aws.ToString(m.msg.Body))
 }
 
 func (m message) Span() trace.Span {


### PR DESCRIPTION
## Summary

- **`component/http`**: buffer `chFail` channel (cap 1) to prevent a goroutine leak when the sender fires after the `select` has already taken the `ctx.Done()` arm
- **`component/sqs/message`**: replace `[]byte(*m.msg.Body)` with `[]byte(aws.ToString(m.msg.Body))` to avoid a nil-pointer dereference when `Body` is absent
- **`component/sqs/component`**: buffer `chErr` channel (cap 1) for the same reason as HTTP above
- **`component/kafka`**: make the retry `time.Sleep` a context-aware `select` so cancellation exits immediately; snapshot `recBuf` under lock then release before calling `proc`/`CommitRecords`/`AllowRebalance` to prevent a deadlock when `AllowRebalance` synchronously calls `OnPartitionsAssigned`
- **`component/grpc`**: cancel an internal stop context in a `defer` after `Serve` returns so the graceful-stop goroutine always exits even if `Serve` fails early

## Test plan

- [x] `go test -race ./component/http/...` passes
- [x] `go test -race ./component/sqs/...` passes
- [x] `go test -race ./component/kafka/...` passes
- [x] `go test -race ./component/grpc/...` passes

Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)