### PR TITLE
fix: correct LRU metric labels, AMQP carrier Get, HTTP JSON body close

### DIFF
--- a/cache/lru/lru.go
+++ b/cache/lru/lru.go
@@ -9,11 +9,11 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-const cacheTypeAttrbute = "cache.type"
+const cacheTypeAttribute = "cache.type"
 
 var (
-	lruAttribute      = attribute.String(cacheTypeAttrbute, "lru")
-	lruEvictAttribute = attribute.String(cacheTypeAttrbute, "lru-evict")
+	lruAttribute      = attribute.String(cacheTypeAttribute, "lru")
+	lruEvictAttribute = attribute.String(cacheTypeAttribute, "lru-evict")
 )
 
 // Cache encapsulates a thread-safe fixed size LRU cache.
@@ -63,10 +63,10 @@ func newFunction[k comparable, v any](chc *lru.Cache[k, v], typeAttr attribute.K
 func (c *Cache[k, v]) Get(ctx context.Context, key k) (any, bool, error) {
 	value, ok := c.cache.Get(key)
 	if !ok {
-		cache.ObserveMiss(ctx, lruAttribute, c.useCaseAttribute, c.typeAttribute)
+		cache.ObserveMiss(ctx, c.typeAttribute, c.useCaseAttribute)
 		return nil, false, nil
 	}
-	cache.ObserveHit(ctx, lruAttribute, c.useCaseAttribute, c.typeAttribute)
+	cache.ObserveHit(ctx, c.typeAttribute, c.useCaseAttribute)
 	return value, true, nil
 }
 

--- a/client/amqp/amqp.go
+++ b/client/amqp/amqp.go
@@ -123,8 +123,13 @@ type producerMessageCarrier struct {
 }
 
 // Get retrieves a single value for a given key.
-func (c producerMessageCarrier) Get(_ string) string {
-	return ""
+func (c producerMessageCarrier) Get(key string) string {
+	val, ok := c.msg.Headers[key]
+	if !ok {
+		return ""
+	}
+	s, _ := val.(string)
+	return s
 }
 
 // Set sets a header.

--- a/client/http/encoding/json/json.go
+++ b/client/http/encoding/json/json.go
@@ -40,16 +40,16 @@ func FromResponse(ctx context.Context, rsp *http.Response, payload any) error {
 		return err
 	}
 
+	defer func() {
+		if err := rsp.Body.Close(); err != nil {
+			log.FromContext(ctx).Error("failed to close response body", log.ErrorAttr(err))
+		}
+	}()
+
 	buf, err := io.ReadAll(rsp.Body)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		err := rsp.Body.Close()
-		if err != nil {
-			log.FromContext(ctx).Error("failed to close response body", log.ErrorAttr(err))
-		}
-	}()
 
 	return json.DecodeRaw(buf, payload)
 }


### PR DESCRIPTION
## Summary

- **`cache/lru/lru.go`**: Fix typo `cacheTypeAttrbute` → `cacheTypeAttribute`. Remove the hardcoded `lruAttribute` from `ObserveHit`/`ObserveMiss` calls and use only `c.typeAttribute` — caches created via `NewWithEvict` were reporting hits/misses under `cache.type=lru` while evictions appeared under `cache.type=lru-evict`, splitting one logical cache across two metric series.

- **`client/amqp/amqp.go`**: Implement `producerMessageCarrier.Get` to read from `msg.Headers` with a type assertion instead of always returning `""`. The stub silently broke outbound trace-context propagation: `otel.GetTextMapPropagator().Inject` calls `Get` to check existing header values before setting, causing trace headers to be overwritten rather than merged.

- **`client/http/encoding/json/json.go`**: Move `defer rsp.Body.Close()` to before `io.ReadAll` so the response body is always closed even when the read fails. Previously an `io.ReadAll` error caused an early return before the defer was registered, leaking the underlying connection.

## Test plan

- [x] `go test -race ./cache/lru/...` passes
- [x] `go test -race ./client/amqp/...` passes
- [x] `go test -race ./client/http/encoding/json/...` passes

Closes #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)