### PR TITLE
Secure HTTP profiling routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,23 @@ task --list           # List all available tasks
 - goleak in `TestMain` for goroutine leak detection; testify `assert`/`require` for assertions.
 - CI: `.github/workflows/ci.yml` — validates Taskfile, lint, format check, integration tests (excludes `examples` and `encoding/protobuf/test`), e2e example tests. Codecov enabled.
 - Prerequisites: golangci-lint v2.6.1. Install: `go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.6.1`.
-- Git worktrees: `wt <branch-name>` for parallel development.
+- Before pushing: run `task test`, `task lint`, and `task fmtcheck`. If the change touches integration-backed packages, infrastructure clients/components, examples/e2e behavior, Docker/dependency setup, or public runtime behavior, also run `task deps-start && task testint && task deps-stop`.
+- If `task deps-start` or integration tests fail because Docker or external services are unavailable, report the exact failure and do not claim the push is fully verified.
+
+## Documentation and public API changes
+
+- Update `docs/api/...` whenever exported APIs, defaults, environment variables, route behavior, middleware behavior, observability behavior, or client/component setup changes.
+- Update examples when the recommended usage changes, especially for constructor options, router setup, auth/middleware, observability, or lifecycle handling.
+- Update `BREAKING.md` for breaking behavior or API changes, including security fixes that intentionally change defaults. Include the old behavior, new behavior, and migration path.
+- Keep exported Go doc comments accurate when exported names, options, or route helpers are added or changed.
+
+## GitHub and Worktrunk workflow
+
+- Use GitHub CLI for issue and PR work: `gh issue view <number>`, `gh issue list`, `gh pr view`, `gh pr create`, and `gh pr checks` as appropriate.
+- When fixing a GitHub issue, read the issue body before editing, reference the issue in the PR/commit text, and call out verification performed.
+- Use Worktrunk (`wt`) for parallel development. Create or switch worktrees with `wt switch --create <branch>` for new work and `wt switch <branch>` for existing work; inspect with `wt list`; merge with `wt merge`; remove completed worktrees with `wt remove`.
+- Do not create a new worktree if the user explicitly wants changes in the current worktree, or if the current worktree already contains the relevant uncommitted work.
+- Before committing or pushing, run `git status --short` and make sure only intended files are staged. Never discard unrelated user changes.
 
 ## Lint configuration
 

--- a/component/http/observability.go
+++ b/component/http/observability.go
@@ -6,14 +6,16 @@ import (
 	"net/http"
 	"net/http/pprof"
 
+	patronhttp "github.com/beatlabs/patron/component/http/middleware"
 	"github.com/beatlabs/patron/observability/log"
 )
 
-func ProfilingRoutes(enableExpVar bool) []*Route {
+func ProfilingRoutes(enableExpVar bool, middlewares ...patronhttp.Func) []*Route {
 	var routes []*Route
 
 	routeFunc := func(path string, handler http.HandlerFunc) *Route {
 		route, _ := NewRoute(path, handler)
+		route.middlewares = append(route.middlewares, middlewares...)
 		return route
 	}
 
@@ -51,7 +53,7 @@ func expVars(w http.ResponseWriter, _ *http.Request) {
 }
 
 // LoggingRoutes returns a routes relates to logs.
-func LoggingRoutes() []*Route {
+func LoggingRoutes(middlewares ...patronhttp.Func) []*Route {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		lvl := r.PathValue("level")
 		if lvl == "" {
@@ -68,5 +70,6 @@ func LoggingRoutes() []*Route {
 	}
 
 	route, _ := NewRoute("POST /debug/log/{level}", handler)
+	route.middlewares = append(route.middlewares, middlewares...)
 	return []*Route{route}
 }

--- a/component/http/observability_test.go
+++ b/component/http/observability_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	patronhttp "github.com/beatlabs/patron/component/http/middleware"
 	"github.com/beatlabs/patron/observability/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,10 +55,10 @@ func TestProfilingRoutes(t *testing.T) {
 func createServer(enableExpVar bool) *httptest.Server {
 	mux := http.NewServeMux()
 	for _, route := range ProfilingRoutes(enableExpVar) {
-		mux.HandleFunc(route.path, route.handler)
+		mux.Handle(route.path, patronhttp.Chain(route.handler, route.middlewares...))
 	}
 	for _, route := range LoggingRoutes() {
-		mux.HandleFunc(route.path, route.handler)
+		mux.Handle(route.path, patronhttp.Chain(route.handler, route.middlewares...))
 	}
 
 	return httptest.NewServer(mux)
@@ -119,4 +120,48 @@ func TestLoggingRoutes(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 		require.NoError(t, resp.Body.Close())
 	})
+}
+
+func TestProfilingRoutesWithMiddleware(t *testing.T) {
+	middleware := func(_ http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+	}
+
+	mux := http.NewServeMux()
+	for _, route := range ProfilingRoutes(false, middleware) {
+		mux.Handle(route.path, patronhttp.Chain(route.handler, route.middlewares...))
+	}
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/debug/pprof/", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestLoggingRoutesWithMiddleware(t *testing.T) {
+	middleware := func(_ http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+	}
+
+	mux := http.NewServeMux()
+	for _, route := range LoggingRoutes(middleware) {
+		mux.Handle(route.path, patronhttp.Chain(route.handler, route.middlewares...))
+	}
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL+"/debug/log/debug", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
 }

--- a/component/http/router/router.go
+++ b/component/http/router/router.go
@@ -22,7 +22,9 @@ type Config struct {
 	deflateLevel             int
 	middlewares              []middleware.Func
 	routes                   []*patronhttp.Route
+	enableProfiling          bool
 	enableProfilingExpVar    bool
+	profilingMiddlewares     []middleware.Func
 	appNameVersionMiddleware middleware.Func
 }
 
@@ -44,7 +46,9 @@ func New(oo ...OptionFunc) (*http.ServeMux, error) {
 	var stdRoutes []*patronhttp.Route
 
 	mux := http.NewServeMux()
-	stdRoutes = append(stdRoutes, patronhttp.ProfilingRoutes(cfg.enableProfilingExpVar)...)
+	if cfg.enableProfiling {
+		stdRoutes = append(stdRoutes, patronhttp.ProfilingRoutes(cfg.enableProfilingExpVar, cfg.profilingMiddlewares...)...)
+	}
 
 	route, err := patronhttp.LivenessCheckRoute(cfg.aliveCheckFunc)
 	if err != nil {
@@ -64,7 +68,10 @@ func New(oo ...OptionFunc) (*http.ServeMux, error) {
 	}
 
 	for _, route := range stdRoutes {
-		handler := middleware.Chain(route.Handler(), stdMiddlewares...)
+		var middlewares []middleware.Func
+		middlewares = append(middlewares, stdMiddlewares...)
+		middlewares = append(middlewares, route.Middlewares()...)
+		handler := middleware.Chain(route.Handler(), middlewares...)
 		mux.Handle(route.Path(), handler)
 		slog.Debug("added route", slog.Any("route", route))
 	}

--- a/component/http/router/router_option.go
+++ b/component/http/router/router_option.go
@@ -63,9 +63,31 @@ func WithMiddlewares(mm ...middleware.Func) OptionFunc {
 	}
 }
 
+// WithProfiling enables the profiling routes.
+func WithProfiling(mm ...middleware.Func) OptionFunc {
+	return func(cfg *Config) error {
+		cfg.enableProfiling = true
+		cfg.profilingMiddlewares = append(cfg.profilingMiddlewares, mm...)
+		return nil
+	}
+}
+
+// WithProfilingMiddlewares applies middlewares to the profiling routes.
+func WithProfilingMiddlewares(mm ...middleware.Func) OptionFunc {
+	return func(cfg *Config) error {
+		if len(mm) == 0 {
+			return errors.New("middlewares are empty")
+		}
+		cfg.enableProfiling = true
+		cfg.profilingMiddlewares = mm
+		return nil
+	}
+}
+
 // WithExpVarProfiling option for enabling expVar in profiling endpoints.
 func WithExpVarProfiling() OptionFunc {
 	return func(cfg *Config) error {
+		cfg.enableProfiling = true
 		cfg.enableProfilingExpVar = true
 		return nil
 	}

--- a/component/http/router/router_option_test.go
+++ b/component/http/router/router_option_test.go
@@ -144,11 +144,22 @@ func TestMiddlewares(t *testing.T) {
 	}
 }
 
+func TestWithProfiling(t *testing.T) {
+	t.Parallel()
+	mw := func(next http.Handler) http.Handler { return next }
+	cfg := &Config{}
+	err := WithProfiling(mw)(cfg)
+	require.NoError(t, err)
+	assert.True(t, cfg.enableProfiling)
+	assert.Len(t, cfg.profilingMiddlewares, 1)
+}
+
 func TestDisableProfiling(t *testing.T) {
 	t.Parallel()
 	cfg := &Config{}
 	err := WithExpVarProfiling()(cfg)
 	require.NoError(t, err)
+	assert.True(t, cfg.enableProfiling)
 	assert.True(t, cfg.enableProfilingExpVar)
 }
 

--- a/component/http/router/router_test.go
+++ b/component/http/router/router_test.go
@@ -91,7 +91,7 @@ func TestVerifyRouter(t *testing.T) {
 		require.NoError(t, err)
 		rsp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
-		assertResponse(t, rsp)
+		assert.Equal(t, http.StatusNotFound, rsp.StatusCode)
 		require.NoError(t, rsp.Body.Close())
 	})
 
@@ -103,4 +103,62 @@ func TestVerifyRouter(t *testing.T) {
 		assertResponse(t, rsp)
 		require.NoError(t, rsp.Body.Close())
 	})
+}
+
+func TestProfiling(t *testing.T) {
+	router, err := New(WithProfiling())
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/debug/pprof", nil)
+	require.NoError(t, err)
+	rsp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rsp.StatusCode)
+	require.NoError(t, rsp.Body.Close())
+}
+
+func TestProfilingMiddlewares(t *testing.T) {
+	deny := func(_ http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+	}
+
+	router, err := New(WithProfilingMiddlewares(deny))
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	t.Run("protects pprof endpoint", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/debug/pprof", nil)
+		require.NoError(t, err)
+		rsp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, rsp.StatusCode)
+		require.NoError(t, rsp.Body.Close())
+	})
+
+	t.Run("does not protect alive endpoint", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/alive", nil)
+		require.NoError(t, err)
+		rsp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rsp.StatusCode)
+		require.NoError(t, rsp.Body.Close())
+	})
+}
+
+func TestProfilingMiddlewaresOption(t *testing.T) {
+	cfg := &Config{}
+	err := WithProfilingMiddlewares(func(next http.Handler) http.Handler { return next })(cfg)
+	require.NoError(t, err)
+	assert.True(t, cfg.enableProfiling)
+	assert.Len(t, cfg.profilingMiddlewares, 1)
+
+	err = WithProfilingMiddlewares()(cfg)
+	assert.EqualError(t, err, "middlewares are empty")
 }

--- a/docs/api/components/http.md
+++ b/docs/api/components/http.md
@@ -1,6 +1,6 @@
 # HTTP component (server)
 
-Serve HTTP endpoints with built-in profiling, health checks, middleware, and tracing/logging.
+Serve HTTP endpoints with health checks, optional profiling, middleware, and tracing/logging.
 
 - Component: `github.com/beatlabs/patron/component/http`
 - Router: `github.com/beatlabs/patron/component/http/router`
@@ -49,10 +49,13 @@ Env overrides: `PATRON_HTTP_DEFAULT_PORT`, `PATRON_HTTP_READ_TIMEOUT`, `PATRON_H
 - `WithReadyCheck(func() ReadyStatus)` (defaults to Ready)
 - `WithDeflateLevel(level int)` (compression)
 - `WithMiddlewares(mm ...)`
-- `WithExpVarProfiling()` (adds `/debug/vars`)
+- `WithProfiling(mm ...)` (adds `/debug/pprof/*`)
+- `WithProfilingMiddlewares(mm ...)` (adds `/debug/pprof/*` and applies middleware)
+- `WithExpVarProfiling()` (adds `/debug/pprof/*` and `/debug/vars`)
 - `WithAppNameHeaders(name, version)` (adds X-App-Name/X-App-Version)
 
-Management routes: `/debug/pprof/*`, `/alive`, `/ready`.
+Management routes: `/alive`, `/ready`; `/debug/pprof/*` is opt-in.
+Protect profiling routes with `WithProfiling` or `WithProfilingMiddlewares`, for example by passing an auth middleware.
 
 ## Route helpers
 
@@ -66,4 +69,4 @@ Management routes: `/debug/pprof/*`, `/alive`, `/ready`.
 
 - Logging/tracing middleware is applied to user routes.
 - Configure error-status logging via `PATRON_HTTP_STATUS_ERROR_LOGGING` (comma-separated status codes).
-- Change log level at runtime: `POST /debug/log/{level}`.
+- Change log level at runtime: `POST /debug/log/{level}`. If registering `LoggingRoutes` directly, pass auth or equivalent middleware.


### PR DESCRIPTION
## Summary
- make router pprof profiling routes opt-in instead of registered by default
- allow profiling and logging route helpers to receive middleware for auth protection
- document profiling setup and update AGENTS workflow guidance

Closes #1565

## Verification
- task fmtcheck
- task test
- task deps-start && task testint && task deps-stop
- git diff --check

## Notes
- task lint was attempted with Homebrew golangci-lint 2.12.2 and failed before analysis with: context loading failed: no go files to analyze. The repo instructions pin golangci-lint 2.6.1.