### PR TITLE
fix: address maintenance cleanups

### DIFF
--- a/client/http/http.go
+++ b/client/http/http.go
@@ -85,10 +85,6 @@ func (tc *TracedClient) do(req *http.Request) (*http.Response, error) {
 	return rsp, nil
 }
 
-func opName(method, scheme, host string) string {
-	return method + " " + scheme + "://" + host
-}
-
 const (
 	encodingGzip    = "gzip"
 	encodingDeflate = "deflate"

--- a/client/http/http_test.go
+++ b/client/http/http_test.go
@@ -38,7 +38,7 @@ func TestTracedClient_Do(t *testing.T) {
 	reqErr.Header.Set(encoding.AcceptEncodingHeader, "gzip")
 	u, err := req.URL.Parse(ts.URL)
 	require.NoError(t, err)
-	opName := opName(http.MethodGet, u.Scheme, u.Host)
+	opName := http.MethodGet + " " + u.Scheme + "://" + u.Host
 	opNameError := "HTTP GET"
 
 	type args struct {

--- a/component/http/component.go
+++ b/component/http/component.go
@@ -64,7 +64,6 @@ func writeTimeout() (time.Duration, error) {
 	return timeout, nil
 }
 
-// Component implementation of an HTTP router.
 // Component implements an HTTP server with sane defaults and graceful shutdown.
 type Component struct {
 	port                int
@@ -78,7 +77,6 @@ type Component struct {
 	keyFile             string
 }
 
-// New creates an HTTP component configurable by functional options.
 // New creates an HTTP Component configurable by functional options.
 func New(handler http.Handler, oo ...OptionFunc) (*Component, error) {
 	if handler == nil {
@@ -119,7 +117,6 @@ func New(handler http.Handler, oo ...OptionFunc) (*Component, error) {
 	return cmp, nil
 }
 
-// Run starts the HTTP server and returns only if listening and/or serving failed, or if the context was canceled.
 // Run starts the HTTP server and blocks until the context is canceled or the server fails.
 func (c *Component) Run(ctx context.Context) error {
 	c.mu.Lock()

--- a/component/http/route.go
+++ b/component/http/route.go
@@ -7,11 +7,9 @@ import (
 	patronhttp "github.com/beatlabs/patron/component/http/middleware"
 )
 
-// RouteOptionFunc definition for configuring the route in a functional way.
 // RouteOptionFunc configures a Route in a functional way.
 type RouteOptionFunc func(route *Route) error
 
-// Route definition of an HTTP route.
 // Route describes an HTTP route with optional middleware.
 type Route struct {
 	path        string
@@ -35,7 +33,6 @@ func (r Route) String() string {
 	return r.path
 }
 
-// NewRoute creates a new raw route with functional configuration.
 // NewRoute creates a new route with functional configuration.
 func NewRoute(path string, handler http.HandlerFunc, oo ...RouteOptionFunc) (*Route, error) {
 	if path == "" {
@@ -61,14 +58,12 @@ func NewRoute(path string, handler http.HandlerFunc, oo ...RouteOptionFunc) (*Ro
 	return route, nil
 }
 
-// Routes definition.
 // Routes aggregates route creation results and errors.
 type Routes struct {
 	routes []*Route
 	ee     []error
 }
 
-// Append route.
 // Append adds a route or records an error.
 func (r *Routes) Append(route *Route, err error) {
 	if err != nil {
@@ -82,7 +77,6 @@ func (r *Routes) Append(route *Route, err error) {
 	r.routes = append(r.routes, route)
 }
 
-// Result of the route aggregation.
 // Result returns the accumulated routes and a joined error, if any.
 func (r *Routes) Result() ([]*Route, error) {
 	return r.routes, errors.Join(r.ee...)

--- a/component/http/route_option.go
+++ b/component/http/route_option.go
@@ -66,7 +66,7 @@ func WithCache(cache cache.TTLCache, ageBounds httpcache.Age) RouteOptionFunc {
 		}
 		m, err := patronhttp.NewCaching(rc)
 		if err != nil {
-			return errors.Join(err)
+			return err
 		}
 		r.middlewares = append(r.middlewares, m)
 		return nil

--- a/options.go
+++ b/options.go
@@ -31,7 +31,7 @@ func WithLogFields(attrs ...slog.Attr) OptionFunc {
 
 		for _, attr := range attrs {
 			if attr.Key == srv || attr.Key == ver || attr.Key == host {
-				// don't override
+				slog.Warn("ignoring reserved log field", slog.String("key", attr.Key))
 				continue
 			}
 

--- a/options_test.go
+++ b/options_test.go
@@ -1,6 +1,7 @@
 package patron
 
 import (
+	"bytes"
 	"errors"
 	"log/slog"
 	"testing"
@@ -50,6 +51,24 @@ func TestLogFields(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLogFields_ReservedKeysWarnAndIgnore(t *testing.T) {
+	var buf bytes.Buffer
+	originalLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(originalLogger)
+
+	svc := &Service{
+		observabilityCfg: observability.Config{},
+	}
+
+	err := WithLogFields(slog.String("srv", "override"), slog.String("env", "dev"))(svc)
+	require.NoError(t, err)
+
+	assert.Contains(t, buf.String(), "ignoring reserved log field")
+	assert.Contains(t, buf.String(), "key=srv")
+	assert.Equal(t, []slog.Attr{slog.String("env", "dev")}, svc.observabilityCfg.LogConfig.Attributes)
 }
 
 func TestSIGHUP(t *testing.T) {

--- a/reliability/circuitbreaker/breaker.go
+++ b/reliability/circuitbreaker/breaker.go
@@ -91,13 +91,10 @@ func New(name string, s Setting) (*CircuitBreaker, error) {
 	}
 
 	return &CircuitBreaker{
-		name:       name,
-		set:        s,
-		status:     closed,
-		executions: 0,
-		failures:   0,
-		retries:    0,
-		nextRetry:  tsFuture,
+		name:      name,
+		set:       s,
+		status:    closed,
+		nextRetry: tsFuture,
 	}, nil
 }
 
@@ -119,7 +116,7 @@ func (cb *CircuitBreaker) isOpen() bool {
 	return false
 }
 
-func (cb *CircuitBreaker) isClose() bool {
+func (cb *CircuitBreaker) isClosed() bool {
 	cb.RLock()
 	defer cb.RUnlock()
 	return cb.status == closed

--- a/reliability/circuitbreaker/breaker_test.go
+++ b/reliability/circuitbreaker/breaker_test.go
@@ -101,7 +101,7 @@ func TestCircuitBreaker_isOpen(t *testing.T) {
 	}
 }
 
-func TestCircuitBreaker_isClose(t *testing.T) {
+func TestCircuitBreaker_isClosed(t *testing.T) {
 	t.Parallel()
 
 	type fields struct {
@@ -124,7 +124,7 @@ func TestCircuitBreaker_isClose(t *testing.T) {
 				status:    tt.fields.status,
 				nextRetry: tt.fields.nextRetry,
 			}
-			assert.Equal(t, tt.want, cb.isClose())
+			assert.Equal(t, tt.want, cb.isClosed())
 		})
 	}
 }
@@ -141,7 +141,7 @@ func TestCircuitBreaker_Close_Open_HalfOpen_Open_HalfOpen_Close(t *testing.T) {
 	assert.Equal(t, uint(0), cb.failures)
 	assert.Equal(t, uint(0), cb.executions)
 	assert.Equal(t, uint(0), cb.retries)
-	assert.True(t, cb.isClose())
+	assert.True(t, cb.isClosed())
 	assert.Equal(t, tsFuture, cb.nextRetry)
 	// will transition to open
 	_, err = cb.Execute(context.Background(), testFailureAction)
@@ -190,7 +190,7 @@ func TestCircuitBreaker_Close_Open_HalfOpen_Open_HalfOpen_Close(t *testing.T) {
 	assert.Equal(t, uint(0), cb.failures)
 	assert.Equal(t, uint(0), cb.executions)
 	assert.Equal(t, uint(0), cb.retries)
-	assert.True(t, cb.isClose())
+	assert.True(t, cb.isClosed())
 	assert.Equal(t, tsFuture, cb.nextRetry)
 }
 


### PR DESCRIPTION
## Summary
- rename the circuit breaker closed-state helper and drop redundant zero-value initialization
- remove dead code and redundant error wrapping, and clean duplicate HTTP godoc comments
- warn when reserved log fields are ignored and cover that behavior in tests

## Testing
- go test ./...

Closes #1567