### PR TITLE
fix: wrap sql client errors

### DIFF
--- a/client/sql/integration_test.go
+++ b/client/sql/integration_test.go
@@ -39,7 +39,9 @@ func TestOpen(t *testing.T) {
 			got, err := Open(tt.args.driverName, dsn)
 
 			if tt.expectedErr != "" {
-				require.EqualError(t, err, tt.expectedErr)
+				require.Error(t, err)
+				require.ErrorContains(t, err, "db.Open")
+				require.ErrorContains(t, err, tt.expectedErr)
 				assert.Nil(t, got)
 			} else {
 				require.NoError(t, err)

--- a/client/sql/sql.go
+++ b/client/sql/sql.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"fmt"
 	"regexp"
 	"time"
 
@@ -68,7 +69,7 @@ func (c *Conn) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
 	observeDuration(ctx, start, op, err)
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
 	return &Tx{tx: tx, connInfo: c.connInfo}, nil
@@ -85,7 +86,7 @@ func (c *Conn) Close(ctx context.Context) error {
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
 	}
-	return err
+	return wrapError(op, err)
 }
 
 // Exec executes a query without returning any rows.
@@ -99,7 +100,7 @@ func (c *Conn) Exec(ctx context.Context, query string, args ...any) (sql.Result,
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
 	}
-	return res, err
+	return res, wrapError(op, err)
 }
 
 // Ping verifies the connection to the database is still alive.
@@ -113,7 +114,7 @@ func (c *Conn) Ping(ctx context.Context) error {
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
 	}
-	return err
+	return wrapError(op, err)
 }
 
 // Prepare creates a prepared statement for later queries or executions.
@@ -126,7 +127,7 @@ func (c *Conn) Prepare(ctx context.Context, query string) (*Stmt, error) {
 	observeDuration(ctx, start, op, err)
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 	return &Stmt{stmt: stmt, connInfo: c.connInfo, query: query}, nil
 }
@@ -141,7 +142,7 @@ func (c *Conn) Query(ctx context.Context, query string, args ...any) (*sql.Rows,
 	observeDuration(ctx, start, op, err)
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
 	return rows, nil
@@ -168,7 +169,7 @@ type DB struct {
 func Open(driverName, dataSourceName string) (*DB, error) {
 	db, err := sql.Open(driverName, dataSourceName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("db.Open: %w", err)
 	}
 	info := parseDSN(dataSourceName)
 	connInfo := connInfo{
@@ -208,7 +209,7 @@ func (db *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, error) {
 	observeDuration(ctx, start, op, err)
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 	return &Tx{tx: tx, connInfo: db.connInfo}, nil
 }
@@ -224,7 +225,7 @@ func (db *DB) Close(ctx context.Context) error {
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
 	}
-	return err
+	return wrapError(op, err)
 }
 
 // Conn returns a connection.
@@ -237,7 +238,7 @@ func (db *DB) Conn(ctx context.Context) (*Conn, error) {
 	observeDuration(ctx, start, op, err)
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
 	return &Conn{conn: conn, connInfo: db.connInfo}, nil
@@ -264,7 +265,7 @@ func (db *DB) Exec(ctx context.Context, query string, args ...any) (sql.Result, 
 	observeDuration(ctx, start, op, err)
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
 	return res, nil
@@ -281,7 +282,7 @@ func (db *DB) Ping(ctx context.Context) error {
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
 	}
-	return err
+	return wrapError(op, err)
 }
 
 // Prepare creates a prepared statement for later queries or executions.
@@ -294,7 +295,7 @@ func (db *DB) Prepare(ctx context.Context, query string) (*Stmt, error) {
 	observeDuration(ctx, start, op, err)
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
 	return &Stmt{stmt: stmt, connInfo: db.connInfo, query: query}, nil
@@ -310,7 +311,7 @@ func (db *DB) Query(ctx context.Context, query string, args ...any) (*sql.Rows, 
 	observeDuration(ctx, start, op, err)
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
 	return rows, err
@@ -371,7 +372,7 @@ func (s *Stmt) Close(ctx context.Context) error {
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
 	}
-	return err
+	return wrapError(op, err)
 }
 
 // Exec executes a prepared statement.
@@ -384,7 +385,7 @@ func (s *Stmt) Exec(ctx context.Context, args ...any) (sql.Result, error) {
 	observeDuration(ctx, start, op, err)
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
 	return res, nil
@@ -400,7 +401,7 @@ func (s *Stmt) Query(ctx context.Context, args ...any) (*sql.Rows, error) {
 	observeDuration(ctx, start, op, err)
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", op, err)
 	}
 
 	return rows, nil
@@ -434,7 +435,7 @@ func (tx *Tx) Commit(ctx context.Context) error {
 	if err != nil {
 		patrontrace.SetSpanError(sp, op, err)
 	}
-	return err
+	return wrapError(op, err)
 }
 
 // Exec executes a query that doesn't return rows.
@@ -552,4 +553,12 @@ func observeDuration(ctx context.Context, start time.Time, op string, err error)
 
 func operationAttr(op string) attribute.KeyValue {
 	return attribute.String("op", op)
+}
+
+func wrapError(op string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("%s: %w", op, err)
 }

--- a/client/sql/sql_test.go
+++ b/client/sql/sql_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
-	"io"
 	"testing"
 	"time"
 
@@ -241,26 +240,6 @@ func (s *failingStmt) QueryContext(_ context.Context, _ []driver.NamedValue) (dr
 	}
 
 	return &mockRows{}, nil
-}
-
-type failingRows struct {
-	err error
-}
-
-func (r *failingRows) Columns() []string {
-	return []string{"id"}
-}
-
-func (r *failingRows) Close() error {
-	return nil
-}
-
-func (r *failingRows) Next(_ []driver.Value) error {
-	if r.err != nil {
-		return r.err
-	}
-
-	return io.EOF
 }
 
 type failingTx struct {
@@ -535,8 +514,8 @@ func TestWrapError(t *testing.T) {
 	wrapped := wrapError("db.Exec", err)
 
 	require.Error(t, wrapped)
-	assert.ErrorContains(t, wrapped, "db.Exec")
-	assert.ErrorIs(t, wrapped, err)
+	require.ErrorContains(t, wrapped, "db.Exec")
+	require.ErrorIs(t, wrapped, err)
 	assert.NoError(t, wrapError("db.Exec", nil))
 }
 
@@ -555,8 +534,8 @@ func TestDBExec_WrapsError(t *testing.T) {
 
 	assert.Nil(t, res)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "db.Exec")
-	assert.ErrorIs(t, err, baseErr)
+	require.ErrorContains(t, err, "db.Exec")
+	require.ErrorIs(t, err, baseErr)
 }
 
 func TestConnPrepare_WrapsError(t *testing.T) {
@@ -580,8 +559,8 @@ func TestConnPrepare_WrapsError(t *testing.T) {
 
 	assert.Nil(t, stmt)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "conn.Prepare")
-	assert.ErrorIs(t, err, baseErr)
+	require.ErrorContains(t, err, "conn.Prepare")
+	require.ErrorIs(t, err, baseErr)
 }
 
 func TestStmtExec_WrapsError(t *testing.T) {
@@ -605,8 +584,8 @@ func TestStmtExec_WrapsError(t *testing.T) {
 
 	assert.Nil(t, res)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "stmt.Exec")
-	assert.ErrorIs(t, err, baseErr)
+	require.ErrorContains(t, err, "stmt.Exec")
+	require.ErrorIs(t, err, baseErr)
 }
 
 func TestTxCommit_WrapsError(t *testing.T) {
@@ -626,8 +605,8 @@ func TestTxCommit_WrapsError(t *testing.T) {
 	err = tx.Commit(context.Background())
 
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "tx.Commit")
-	assert.ErrorIs(t, err, baseErr)
+	require.ErrorContains(t, err, "tx.Commit")
+	require.ErrorIs(t, err, baseErr)
 }
 
 func TestDBQueryRow_PreservesErrNoRows(t *testing.T) {

--- a/client/sql/sql_test.go
+++ b/client/sql/sql_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -123,6 +124,188 @@ func (m *mockTx) Commit() error {
 
 func (m *mockTx) Rollback() error {
 	return nil
+}
+
+type failingDriver struct {
+	conn *failingConn
+}
+
+func (d *failingDriver) Open(_ string) (driver.Conn, error) {
+	return d.conn, nil
+}
+
+type failingConn struct {
+	beginTxErr error
+	closeErr   error
+	execErr    error
+	pingErr    error
+	prepareErr error
+	queryErr   error
+	tx         *failingTx
+	stmt       *failingStmt
+}
+
+func (c *failingConn) Prepare(_ string) (driver.Stmt, error) {
+	if c.prepareErr != nil {
+		return nil, c.prepareErr
+	}
+
+	if c.stmt != nil {
+		return c.stmt, nil
+	}
+
+	return &failingStmt{}, nil
+}
+
+func (c *failingConn) Close() error {
+	return c.closeErr
+}
+
+func (c *failingConn) Begin() (driver.Tx, error) {
+	if c.beginTxErr != nil {
+		return nil, c.beginTxErr
+	}
+
+	if c.tx != nil {
+		return c.tx, nil
+	}
+
+	return &failingTx{}, nil
+}
+
+func (c *failingConn) BeginTx(_ context.Context, _ driver.TxOptions) (driver.Tx, error) {
+	return c.Begin()
+}
+
+func (c *failingConn) Ping(_ context.Context) error {
+	return c.pingErr
+}
+
+func (c *failingConn) ExecContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Result, error) {
+	if c.execErr != nil {
+		return nil, c.execErr
+	}
+
+	return &mockResult{}, nil
+}
+
+func (c *failingConn) QueryContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+	if c.queryErr != nil {
+		return nil, c.queryErr
+	}
+
+	return &mockRows{}, nil
+}
+
+type failingStmt struct {
+	closeErr error
+	execErr  error
+	queryErr error
+}
+
+func (s *failingStmt) Close() error {
+	return s.closeErr
+}
+
+func (s *failingStmt) NumInput() int {
+	return -1
+}
+
+func (s *failingStmt) Exec(_ []driver.Value) (driver.Result, error) {
+	if s.execErr != nil {
+		return nil, s.execErr
+	}
+
+	return &mockResult{}, nil
+}
+
+func (s *failingStmt) Query(_ []driver.Value) (driver.Rows, error) {
+	if s.queryErr != nil {
+		return nil, s.queryErr
+	}
+
+	return &mockRows{}, nil
+}
+
+func (s *failingStmt) ExecContext(_ context.Context, _ []driver.NamedValue) (driver.Result, error) {
+	if s.execErr != nil {
+		return nil, s.execErr
+	}
+
+	return &mockResult{}, nil
+}
+
+func (s *failingStmt) QueryContext(_ context.Context, _ []driver.NamedValue) (driver.Rows, error) {
+	if s.queryErr != nil {
+		return nil, s.queryErr
+	}
+
+	return &mockRows{}, nil
+}
+
+type failingRows struct {
+	err error
+}
+
+func (r *failingRows) Columns() []string {
+	return []string{"id"}
+}
+
+func (r *failingRows) Close() error {
+	return nil
+}
+
+func (r *failingRows) Next(_ []driver.Value) error {
+	if r.err != nil {
+		return r.err
+	}
+
+	return io.EOF
+}
+
+type failingTx struct {
+	commitErr   error
+	rollbackErr error
+	execErr     error
+	prepareErr  error
+	queryErr    error
+	stmt        *failingStmt
+}
+
+func (tx *failingTx) Commit() error {
+	return tx.commitErr
+}
+
+func (tx *failingTx) Rollback() error {
+	return tx.rollbackErr
+}
+
+func (tx *failingTx) ExecContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Result, error) {
+	if tx.execErr != nil {
+		return nil, tx.execErr
+	}
+
+	return &mockResult{}, nil
+}
+
+func (tx *failingTx) QueryContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+	if tx.queryErr != nil {
+		return nil, tx.queryErr
+	}
+
+	return &mockRows{}, nil
+}
+
+func (tx *failingTx) PrepareContext(_ context.Context, _ string) (driver.Stmt, error) {
+	if tx.prepareErr != nil {
+		return nil, tx.prepareErr
+	}
+
+	if tx.stmt != nil {
+		return tx.stmt, nil
+	}
+
+	return &failingStmt{}, nil
 }
 
 func TestDSNInfo(t *testing.T) {
@@ -313,6 +496,7 @@ func TestOpen_InvalidDriver(t *testing.T) {
 	// Should return error for unknown driver
 	require.Error(t, err)
 	assert.Nil(t, db)
+	assert.ErrorContains(t, err, "db.Open")
 }
 
 func TestOpen_Success(t *testing.T) {
@@ -343,4 +527,123 @@ func TestPackageNameConstant(t *testing.T) {
 
 func TestDurationHistogramInitialized(t *testing.T) {
 	assert.NotNil(t, durationHistogram)
+}
+
+func TestWrapError(t *testing.T) {
+	err := errors.New("boom")
+
+	wrapped := wrapError("db.Exec", err)
+
+	require.Error(t, wrapped)
+	assert.ErrorContains(t, wrapped, "db.Exec")
+	assert.ErrorIs(t, wrapped, err)
+	assert.NoError(t, wrapError("db.Exec", nil))
+}
+
+func TestDBExec_WrapsError(t *testing.T) {
+	t.Parallel()
+
+	baseErr := errors.New("exec failed")
+	driverName := "failing-driver-db-exec"
+	sql.Register(driverName, &failingDriver{conn: &failingConn{execErr: baseErr}})
+	stdDB, err := sql.Open(driverName, "")
+	require.NoError(t, err)
+	defer stdDB.Close()
+
+	db := FromDB(stdDB)
+	res, err := db.Exec(context.Background(), "INSERT INTO test VALUES (?)", 1)
+
+	assert.Nil(t, res)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "db.Exec")
+	assert.ErrorIs(t, err, baseErr)
+}
+
+func TestConnPrepare_WrapsError(t *testing.T) {
+	t.Parallel()
+
+	baseErr := errors.New("prepare failed")
+	driverName := "failing-driver-conn-prepare"
+	sql.Register(driverName, &failingDriver{conn: &failingConn{prepareErr: baseErr}})
+	stdDB, err := sql.Open(driverName, "")
+	require.NoError(t, err)
+	defer stdDB.Close()
+
+	db := FromDB(stdDB)
+	conn, err := db.Conn(context.Background())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, conn.Close(context.Background()))
+	}()
+
+	stmt, err := conn.Prepare(context.Background(), "SELECT 1")
+
+	assert.Nil(t, stmt)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "conn.Prepare")
+	assert.ErrorIs(t, err, baseErr)
+}
+
+func TestStmtExec_WrapsError(t *testing.T) {
+	t.Parallel()
+
+	baseErr := errors.New("stmt exec failed")
+	driverName := "failing-driver-stmt-exec"
+	sql.Register(driverName, &failingDriver{conn: &failingConn{stmt: &failingStmt{execErr: baseErr}}})
+	stdDB, err := sql.Open(driverName, "")
+	require.NoError(t, err)
+	defer stdDB.Close()
+
+	db := FromDB(stdDB)
+	stmt, err := db.Prepare(context.Background(), "UPDATE test SET value = 1")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, stmt.Close(context.Background()))
+	}()
+
+	res, err := stmt.Exec(context.Background())
+
+	assert.Nil(t, res)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "stmt.Exec")
+	assert.ErrorIs(t, err, baseErr)
+}
+
+func TestTxCommit_WrapsError(t *testing.T) {
+	t.Parallel()
+
+	baseErr := errors.New("commit failed")
+	driverName := "failing-driver-tx-commit"
+	sql.Register(driverName, &failingDriver{conn: &failingConn{tx: &failingTx{commitErr: baseErr}}})
+	stdDB, err := sql.Open(driverName, "")
+	require.NoError(t, err)
+	defer stdDB.Close()
+
+	db := FromDB(stdDB)
+	tx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+
+	err = tx.Commit(context.Background())
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "tx.Commit")
+	assert.ErrorIs(t, err, baseErr)
+}
+
+func TestDBQueryRow_PreservesErrNoRows(t *testing.T) {
+	t.Parallel()
+
+	driverName := "failing-driver-query-row"
+	sql.Register(driverName, &failingDriver{conn: &failingConn{queryErr: sql.ErrNoRows}})
+	stdDB, err := sql.Open(driverName, "")
+	require.NoError(t, err)
+	defer stdDB.Close()
+
+	db := FromDB(stdDB)
+	row := db.QueryRow(context.Background(), "SELECT 1")
+
+	err = row.Scan(new(int))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sql.ErrNoRows)
 }


### PR DESCRIPTION
## Summary
- wrap SQL client operation errors with the operation name across DB, Conn, Stmt, and Tx methods
- preserve underlying error identity with percent-w wrapping so errors.Is remains usable
- add focused unit coverage for wrapped failures and sql.ErrNoRows compatibility

## Testing
- go test ./client/sql/...
- go test ./...

Closes #1051