### PR TITLE
[codex] Improve integration test coverage

### DIFF
--- a/cache/metric_test.go
+++ b/cache/metric_test.go
@@ -45,4 +45,11 @@ func TestSetupAndUseMetrics(t *testing.T) {
 	require.NoError(t, read.Collect(context.Background(), collectedMetrics))
 
 	assert.Len(t, collectedMetrics.ScopeMetrics, 1)
+
+	ObserveEviction(context.Background(), attribute.String("test", "test"))
+
+	collectedMetrics = &metricdata.ResourceMetrics{}
+	require.NoError(t, read.Collect(context.Background(), collectedMetrics))
+
+	assert.Len(t, collectedMetrics.ScopeMetrics, 1)
 }

--- a/client/http/encoding/json/json_test.go
+++ b/client/http/encoding/json/json_test.go
@@ -3,8 +3,11 @@ package json
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/beatlabs/patron/encoding"
@@ -73,6 +76,47 @@ func TestFromResponse(t *testing.T) {
 	}
 }
 
+func TestFromResponseErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing content type header", func(t *testing.T) {
+		t.Parallel()
+
+		err := FromResponse(context.Background(), &http.Response{Header: http.Header{}, Body: io.NopCloser(strings.NewReader("{}"))}, &customer{})
+		require.EqualError(t, err, "response content type header key is missing")
+	})
+
+	t.Run("empty content type header", func(t *testing.T) {
+		t.Parallel()
+
+		err := FromResponse(context.Background(), &http.Response{
+			Header: http.Header{encoding.ContentTypeHeader: []string{}},
+			Body:   io.NopCloser(strings.NewReader("{}")),
+		}, &customer{})
+		require.EqualError(t, err, "response content type header value is missing")
+	})
+
+	t.Run("read body error", func(t *testing.T) {
+		t.Parallel()
+
+		err := FromResponse(context.Background(), &http.Response{
+			Header: http.Header{encoding.ContentTypeHeader: []string{json.Type}},
+			Body:   failingReadCloser{},
+		}, &customer{})
+		require.EqualError(t, err, "read failed")
+	})
+}
+
 func stringPointer(val string) *string {
 	return &val
+}
+
+type failingReadCloser struct{}
+
+func (failingReadCloser) Read(_ []byte) (int, error) {
+	return 0, errors.New("read failed")
+}
+
+func (failingReadCloser) Close() error {
+	return nil
 }

--- a/component/amqp/helpers_integration_test.go
+++ b/component/amqp/helpers_integration_test.go
@@ -1,0 +1,147 @@
+//go:build integration
+
+package amqp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/beatlabs/patron/correlation"
+	patrontrace "github.com/beatlabs/patron/observability/trace"
+	"github.com/google/uuid"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const helperQueueName = "queueName"
+
+func TestMessageAccessorsAndAckIntegration(t *testing.T) {
+	t.Cleanup(func() { traceExporter.Reset() })
+
+	ctx, sp := patrontrace.StartSpan(context.Background(), patrontrace.ComponentOpName(consumerComponent, helperQueueName),
+		trace.WithSpanKind(trace.SpanKindConsumer))
+	msg := message{
+		ctx:   ctx,
+		span:  sp,
+		queue: helperQueueName,
+		msg: amqp.Delivery{
+			MessageId:    "id",
+			Body:         []byte("body"),
+			Acknowledger: integrationAcknowledger{},
+		},
+	}
+
+	assert.Equal(t, ctx, msg.Context())
+	assert.Equal(t, "id", msg.ID())
+	assert.Equal(t, []byte("body"), msg.Body())
+	assert.Equal(t, sp, msg.Span())
+	assert.Equal(t, amqp.Delivery{MessageId: "id", Body: []byte("body"), Acknowledger: integrationAcknowledger{}}, msg.Message())
+	require.NoError(t, msg.ACK())
+}
+
+func TestMessageNackIntegration(t *testing.T) {
+	t.Cleanup(func() { traceExporter.Reset() })
+
+	_, sp := patrontrace.StartSpan(context.Background(), patrontrace.ComponentOpName(consumerComponent, helperQueueName),
+		trace.WithSpanKind(trace.SpanKindConsumer))
+	msg := message{
+		ctx:     context.Background(),
+		span:    sp,
+		queue:   helperQueueName,
+		requeue: true,
+		msg: amqp.Delivery{
+			Acknowledger: integrationAcknowledger{},
+		},
+	}
+
+	require.NoError(t, msg.NACK())
+}
+
+func TestMessageAckAndNackErrorsIntegration(t *testing.T) {
+	t.Cleanup(func() { traceExporter.Reset() })
+
+	tests := map[string]struct {
+		msgFn func(trace.Span) message
+		call  func(message) error
+	}{
+		"ack": {
+			msgFn: func(sp trace.Span) message {
+				return message{ctx: context.Background(), span: sp, queue: helperQueueName, msg: amqp.Delivery{Acknowledger: integrationAcknowledger{ackErr: true}}}
+			},
+			call: message.ACK,
+		},
+		"nack": {
+			msgFn: func(sp trace.Span) message {
+				return message{ctx: context.Background(), span: sp, queue: helperQueueName, msg: amqp.Delivery{Acknowledger: integrationAcknowledger{nackErr: true}}}
+			},
+			call: message.NACK,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, sp := patrontrace.StartSpan(context.Background(), patrontrace.ComponentOpName(consumerComponent, helperQueueName),
+				trace.WithSpanKind(trace.SpanKindConsumer))
+
+			require.EqualError(t, tt.call(tt.msgFn(sp)), "ERROR")
+		})
+	}
+}
+
+func TestAMQPHelpersIntegration(t *testing.T) {
+	t.Run("sanitize url removes credentials", func(t *testing.T) {
+		assert.Equal(t, "amqp://example.com:5672/vhost", sanitizeURL("amqp://user:pass@example.com:5672/vhost"))
+		assert.Equal(t, "[unparseable url]", sanitizeURL("%"))
+	})
+
+	t.Run("correlation id", func(t *testing.T) {
+		assert.Equal(t, "known", getCorrelationID(amqp.Table{correlation.HeaderID: "known"}))
+
+		got := getCorrelationID(amqp.Table{correlation.HeaderID: ""})
+		_, err := uuid.Parse(got)
+		require.NoError(t, err)
+	})
+
+	t.Run("carrier", func(t *testing.T) {
+		delivery := amqp.Delivery{Headers: amqp.Table{"string": "value", "number": 1}}
+		carrier := consumerMessageCarrier{msg: &delivery}
+
+		assert.Equal(t, "value", carrier.Get("string"))
+		assert.Empty(t, carrier.Get("missing"))
+		assert.Empty(t, carrier.Get("number"))
+
+		carrier.Set("new", "header")
+		assert.Equal(t, "header", delivery.Headers["new"])
+		assert.ElementsMatch(t, []string{"string", "number", "new"}, carrier.Keys())
+	})
+
+	assert.NotPanics(t, func() {
+		observeQueueSize(context.Background(), helperQueueName, 3)
+	})
+}
+
+type integrationAcknowledger struct {
+	ackErr  bool
+	nackErr bool
+}
+
+func (a integrationAcknowledger) Ack(_ uint64, _ bool) error {
+	if a.ackErr {
+		return errors.New("ERROR")
+	}
+	return nil
+}
+
+func (a integrationAcknowledger) Nack(_ uint64, _ bool, _ bool) error {
+	if a.nackErr {
+		return errors.New("ERROR")
+	}
+	return nil
+}
+
+func (a integrationAcknowledger) Reject(_ uint64, _ bool) error {
+	return nil
+}

--- a/component/http/cache/cache_test.go
+++ b/component/http/cache/cache_test.go
@@ -116,6 +116,57 @@ func TestExtractCacheHeaders(t *testing.T) {
 	}
 }
 
+func TestGet(t *testing.T) {
+	tc := newTestingCache()
+	tc.instant = func() int64 { return 1 }
+	rc := &RouteCache{cache: tc}
+
+	assert.Nil(t, get(context.Background(), "missing", rc))
+
+	rsp := &response{Response: handlerResponse{Bytes: []byte("payload"), Header: http.Header{"X-Test": []string{"value"}}}}
+	encoded, err := rsp.encode()
+	require.NoError(t, err)
+
+	require.NoError(t, tc.SetTTL(context.Background(), "bytes", encoded, time.Second))
+	got := get(context.Background(), "bytes", rc)
+	require.NoError(t, got.Err)
+	assert.True(t, got.FromCache)
+	assert.Equal(t, []byte("payload"), got.Response.Bytes)
+
+	require.NoError(t, tc.SetTTL(context.Background(), "string", string(encoded), time.Second))
+	got = get(context.Background(), "string", rc)
+	require.NoError(t, got.Err)
+	assert.True(t, got.FromCache)
+
+	require.NoError(t, tc.SetTTL(context.Background(), "invalid-type", 123, time.Second))
+	got = get(context.Background(), "invalid-type", rc)
+	require.ErrorContains(t, got.Err, "could not parse cached response")
+
+	require.NoError(t, tc.SetTTL(context.Background(), "invalid-bytes", []byte("{"), time.Second))
+	got = get(context.Background(), "invalid-bytes", rc)
+	require.ErrorContains(t, got.Err, "could not decode cached bytes")
+}
+
+func TestSave(t *testing.T) {
+	tc := newTestingCache()
+	tc.instant = func() int64 { return 1 }
+	ctx := context.Background()
+
+	save(ctx, "/path", "key", &response{Response: handlerResponse{Bytes: []byte("payload")}}, tc, time.Second)
+	assert.Equal(t, 1, tc.setCount)
+	assert.NotNil(t, get(ctx, "key", &RouteCache{cache: tc}))
+
+	save(ctx, "/path", "from-cache", &response{FromCache: true}, tc, time.Second)
+	assert.Equal(t, 1, tc.setCount)
+
+	save(ctx, "/path", "with-error", &response{Err: errors.New("response error")}, tc, time.Second)
+	assert.Equal(t, 1, tc.setCount)
+
+	tc.setErr = errors.New("set error")
+	save(ctx, "/path", "set-error", &response{Response: handlerResponse{Bytes: []byte("payload")}}, tc, time.Second)
+	assert.Equal(t, 2, tc.setCount)
+}
+
 type routeConfig struct {
 	path string
 	hnd  executor

--- a/component/http/cache/route_test.go
+++ b/component/http/cache/route_test.go
@@ -2,7 +2,9 @@ package cache
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,4 +57,41 @@ func TestResponseReadWriter_ReadAllEmpty(t *testing.T) {
 
 	assert.Empty(t, b)
 	assert.Empty(t, string(b))
+}
+
+func TestHandler(t *testing.T) {
+	tc := newTestingCache()
+	tc.instant = func() int64 { return 1 }
+	rc, errs := NewRouteCache(tc, Age{Min: time.Second, Max: 10 * time.Second})
+	require.Empty(t, errs)
+
+	req := httptest.NewRequest(http.MethodGet, "/cached?key=value", nil)
+	rec := httptest.NewRecorder()
+
+	err := Handler(rec, req, rc, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Test", "value")
+		_, writeErr := w.Write([]byte("payload"))
+		assert.NoError(t, writeErr)
+	}))
+
+	require.NoError(t, err)
+	assert.Equal(t, "payload", rec.Body.String())
+	assert.Equal(t, "value", rec.Header().Get("X-Test"))
+}
+
+func TestHTTPExecutor(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/cached", nil)
+	exec := httpExecutor(httptest.NewRecorder(), req, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Test", "value")
+		_, err := w.Write([]byte("payload"))
+		assert.NoError(t, err)
+	})
+
+	got := exec(10, "key")
+
+	require.NoError(t, got.Err)
+	assert.Equal(t, []byte("payload"), got.Response.Bytes)
+	assert.Equal(t, "value", got.Response.Header.Get("X-Test"))
+	assert.Equal(t, int64(10), got.LastValid)
+	assert.NotEmpty(t, got.Etag)
 }

--- a/component/kafka/helpers_integration_test.go
+++ b/component/kafka/helpers_integration_test.go
@@ -1,0 +1,41 @@
+//go:build integration
+
+package kafka
+
+import (
+	"testing"
+
+	"github.com/beatlabs/patron/correlation"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func TestKafkaHelpersIntegration(t *testing.T) {
+	t.Run("correlation id", func(t *testing.T) {
+		assert.Equal(t, "known", getCorrelationID([]kgo.RecordHeader{{Key: correlation.HeaderID, Value: []byte("known")}}))
+
+		got := getCorrelationID([]kgo.RecordHeader{{Key: correlation.HeaderID}})
+		_, err := uuid.Parse(got)
+		require.NoError(t, err)
+
+		got = getCorrelationID(nil)
+		_, err = uuid.Parse(got)
+		require.NoError(t, err)
+	})
+
+	t.Run("deduplicate records keeps latest in original order", func(t *testing.T) {
+		records := []*kgo.Record{
+			{Key: []byte("a"), Value: []byte("a1")},
+			{Key: []byte("b"), Value: []byte("b1")},
+			{Key: []byte("a"), Value: []byte("a2")},
+		}
+
+		got := deduplicateRecords(records)
+
+		require.Len(t, got, 2)
+		assert.Equal(t, []byte("b1"), got[0].Value)
+		assert.Equal(t, []byte("a2"), got[1].Value)
+	})
+}

--- a/component/sqs/helpers_integration_test.go
+++ b/component/sqs/helpers_integration_test.go
@@ -1,0 +1,41 @@
+//go:build integration
+
+package sqs
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/beatlabs/patron/correlation"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQSHelpersIntegration(t *testing.T) {
+	t.Run("optional float attribute", func(t *testing.T) {
+		got, err := getOptionalAttributeFloat64(map[string]string{"key": "  "}, "key")
+		require.NoError(t, err)
+		assert.InDelta(t, 0, got, 0)
+
+		got, err = getOptionalAttributeFloat64(map[string]string{"key": "12.5"}, "key")
+		require.NoError(t, err)
+		assert.InDelta(t, 12.5, got, 0)
+
+		_, err = getOptionalAttributeFloat64(map[string]string{"key": "nope"}, "key")
+		require.ErrorContains(t, err, "could not convert nope to float64")
+	})
+
+	t.Run("correlation id", func(t *testing.T) {
+		known := "known"
+		assert.Equal(t, known, getCorrelationID(map[string]types.MessageAttributeValue{
+			correlation.HeaderID: {StringValue: &known},
+		}))
+
+		got := getCorrelationID(map[string]types.MessageAttributeValue{
+			correlation.HeaderID: {},
+		})
+		_, err := uuid.Parse(got)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Improves CI integration test coverage above 90% by adding focused tests for existing uncovered helper and error branches.

## Short description of the changes

- Add integration-tagged helper tests for AMQP, Kafka, and SQS coverage gaps.
- Cover HTTP cache get/save/route executor branches and JSON response error handling.
- Cover cache eviction metric recording.

Validation:
- `task fmt`
- `task lint`
- `go test ./cache ./component/amqp ./component/kafka ./component/sqs -tags=integration -run 'Test(SetupAndUseMetrics|Message|AMQPHelpers|KafkaHelpers|SQSHelpers)' -race -cover -timeout 120s`
- `go test ./component/http/cache ./client/http/encoding/json ./component/amqp ./component/kafka ./component/sqs -tags=integration -run 'Test(Handler|HTTPExecutor|Get|Save|FromResponse|Message|AMQPHelpers|KafkaHelpers|SQSHelpers)' -race -cover -timeout 120s`
- CI-style integration coverage: `90.2%` total statements with `-tags=integration -race -coverprofile`
