### PR TITLE
chore: upgrade to Go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.6.1
+          version: v2.13.1
           args: --build-tags=integration -v
         env:
           GOFLAGS: -mod=vendor

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ patron/
 make                  # Run tests (default)
 make test             # go test ./... -cover -race -timeout 60s
 make testint          # Integration tests (-tags=integration), needs `make deps-start`
-make lint             # golangci-lint (requires v2.6.1 installed)
+make lint             # golangci-lint (requires v2.13.1 installed)
 make fmt              # go fmt
 make fmtcheck         # Check formatting (CI uses this)
 make deps-start       # Docker Compose up (Kafka, RabbitMQ, MySQL, etc.)
@@ -82,7 +82,7 @@ make help             # List all available targets
 - Test files: `*_test.go` (unit), `*_integration_test.go` (integration with `//go:build integration`).
 - goleak in `TestMain` for goroutine leak detection; testify `assert`/`require` for assertions.
 - CI: `.github/workflows/ci.yml` — lint, format check, integration tests (excludes `examples` and `encoding/protobuf/test`), e2e example tests. Codecov enabled.
-- Prerequisites: golangci-lint v2.6.1. Install: `go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.6.1`.
+- Prerequisites: golangci-lint v2.13.1. Install: `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1`.
 - Before pushing: run `make test`, `make lint`, and `make fmtcheck`. If the change touches integration-backed packages, infrastructure clients/components, examples/e2e behavior, Docker/dependency setup, or public runtime behavior, also run `make deps-start && make testint && make deps-stop`.
 - If `make deps-start` or integration tests fail because Docker or external services are unavailable, report the exact failure and do not claim the push is fully verified.
 

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,5 +1,13 @@
 # Breaking Changes Migration Guide
 
+## Next release
+
+### Go 1.27 is now required
+
+Patron now requires Go 1.27 or newer. Upgrade your Go toolchain before updating Patron.
+
+Go 1.27 uses the `encoding/json` v2 implementation behind the existing API, so exact JSON error text may differ. It may also produce different, interoperable gzip and DEFLATE bytes.
+
 ## v0.78.0
 
 ### Kafka client constructor uses functional options

--- a/cache/lru/lru_test.go
+++ b/cache/lru/lru_test.go
@@ -8,14 +8,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	invalidSizeMessage = "must provide a positive size"
+)
+
 func TestNew(t *testing.T) {
 	tests := map[string]struct {
 		err     string
 		size    int
 		wantErr bool
 	}{
-		"negative size": {size: -1, wantErr: true, err: "must provide a positive size"},
-		"zero size":     {size: 0, wantErr: true, err: "must provide a positive size"},
+		"negative size": {size: -1, wantErr: true, err: invalidSizeMessage},
+		"zero size":     {size: 0, wantErr: true, err: invalidSizeMessage},
 		"positive size": {size: 1024, wantErr: false},
 	}
 
@@ -39,8 +43,8 @@ func TestNewWithEvict(t *testing.T) {
 		size    int
 		wantErr bool
 	}{
-		"negative size": {size: -1, wantErr: true, err: "must provide a positive size"},
-		"zero size":     {size: 0, wantErr: true, err: "must provide a positive size"},
+		"negative size": {size: -1, wantErr: true, err: invalidSizeMessage},
+		"zero size":     {size: 0, wantErr: true, err: invalidSizeMessage},
 		"positive size": {size: 1024, wantErr: false},
 	}
 

--- a/client/kafka/kafka_test.go
+++ b/client/kafka/kafka_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
+const (
+	testTopic = "test-topic"
+)
+
 func TestNew(t *testing.T) {
 	t.Parallel()
 
@@ -74,7 +78,7 @@ func TestSendAsync_Failure(t *testing.T) {
 	p.client.Close()
 
 	chErr := make(chan error, 1)
-	rec := &kgo.Record{Topic: "test-topic", Value: []byte("test")}
+	rec := &kgo.Record{Topic: testTopic, Value: []byte("test")}
 	p.SendAsync(context.Background(), rec, chErr)
 
 	select {
@@ -170,7 +174,7 @@ func TestTopicAttribute(t *testing.T) {
 		topic    string
 		expected string
 	}{
-		"simple topic":       {topic: "test-topic", expected: "test-topic"},
+		"simple topic":       {topic: testTopic, expected: testTopic},
 		"dotted topic":       {topic: "test.topic.name", expected: "test.topic.name"},
 		"empty topic":        {topic: "", expected: ""},
 		"special characters": {topic: "test_topic-123", expected: "test_topic-123"},
@@ -195,7 +199,7 @@ func TestPublishCountAdd(t *testing.T) {
 		t.Parallel()
 
 		assert.NotPanics(t, func() {
-			publishCountAdd(context.Background(), topicAttribute("test-topic"))
+			publishCountAdd(context.Background(), topicAttribute(testTopic))
 		})
 	})
 
@@ -206,7 +210,7 @@ func TestPublishCountAdd(t *testing.T) {
 		cancel()
 
 		assert.NotPanics(t, func() {
-			publishCountAdd(ctx, topicAttribute("test-topic"))
+			publishCountAdd(ctx, topicAttribute(testTopic))
 		})
 	})
 }

--- a/client/mongo/metric_test.go
+++ b/client/mongo/metric_test.go
@@ -10,6 +10,10 @@ import (
 	"go.mongodb.org/mongo-driver/event"
 )
 
+const (
+	findCommand = "find"
+)
+
 func TestObservabilityMonitor_Started(t *testing.T) {
 	t.Parallel()
 
@@ -24,7 +28,7 @@ func TestObservabilityMonitor_Started(t *testing.T) {
 	ctx := context.Background()
 
 	evt := &event.CommandStartedEvent{
-		CommandName:  "find",
+		CommandName:  findCommand,
 		DatabaseName: "test",
 	}
 
@@ -90,8 +94,8 @@ func TestCommandAttr(t *testing.T) {
 		expected string
 	}{
 		"find command": {
-			cmdName:  "find",
-			expected: "find",
+			cmdName:  findCommand,
+			expected: findCommand,
 		},
 		"insert command": {
 			cmdName:  "insert",
@@ -151,7 +155,7 @@ func TestObservabilityMonitor_Integration(t *testing.T) {
 
 		// Simulate a command lifecycle
 		startEvt := &event.CommandStartedEvent{
-			CommandName: "find",
+			CommandName: findCommand,
 		}
 		monitor.Started(ctx, startEvt)
 
@@ -187,7 +191,7 @@ func TestObservabilityMonitor_Integration(t *testing.T) {
 
 		// Simulate a failed command
 		startEvt := &event.CommandStartedEvent{
-			CommandName: "find",
+			CommandName: findCommand,
 		}
 		monitor.Started(ctx, startEvt)
 

--- a/client/mqtt/integration_test.go
+++ b/client/mqtt/integration_test.go
@@ -99,10 +99,10 @@ func TestPublish(t *testing.T) {
 
 func createSubscriber(t *testing.T, u *url.URL, router paho.Router) (*autopaho.ConnectionManager, error) {
 	cfg := autopaho.ClientConfig{
-		BrokerUrls:        []*url.URL{u},
-		KeepAlive:         30,
-		ConnectRetryDelay: 5 * time.Second,
-		ConnectTimeout:    1 * time.Second,
+		BrokerUrls:       []*url.URL{u},
+		KeepAlive:        30,
+		ReconnectBackoff: autopaho.NewConstantBackoff(5 * time.Second),
+		ConnectTimeout:   1 * time.Second,
 		ClientConfig: paho.ClientConfig{
 			ClientID: "test-subscriber",
 			Router:   router,

--- a/client/mqtt/metric_test.go
+++ b/client/mqtt/metric_test.go
@@ -19,8 +19,8 @@ func TestTopicAttr(t *testing.T) {
 		expected string
 	}{
 		"simple topic": {
-			topic:    "test/topic",
-			expected: "test/topic",
+			topic:    mqttTestTopic,
+			expected: mqttTestTopic,
 		},
 		"nested topic": {
 			topic:    "devices/sensor/temperature",

--- a/client/mqtt/publisher.go
+++ b/client/mqtt/publisher.go
@@ -30,10 +30,10 @@ func DefaultConfig(brokerURLs []*url.URL, clientID string) (autopaho.ClientConfi
 	}
 
 	return autopaho.ClientConfig{
-		BrokerUrls:        brokerURLs,
-		KeepAlive:         30,
-		ConnectRetryDelay: 5 * time.Second,
-		ConnectTimeout:    1 * time.Second,
+		BrokerUrls:       brokerURLs,
+		KeepAlive:        30,
+		ReconnectBackoff: autopaho.NewConstantBackoff(5 * time.Second),
+		ConnectTimeout:   1 * time.Second,
 		OnConnectionUp: func(_ *autopaho.ConnectionManager, conAck *paho.Connack) {
 			slog.Info("connection is up", slog.Int64("reason", int64(conAck.ReasonCode)))
 		},

--- a/client/mqtt/publisher_test.go
+++ b/client/mqtt/publisher_test.go
@@ -97,7 +97,7 @@ func TestInjectObservabilityHeaders(t *testing.T) {
 
 		ctx := correlation.ContextWithID(context.Background(), "test-correlation-123")
 		pub := &paho.Publish{
-			Topic: "test/topic",
+			Topic: mqttTestTopic,
 		}
 
 		injectObservabilityHeaders(ctx, pub)
@@ -114,7 +114,7 @@ func TestInjectObservabilityHeaders(t *testing.T) {
 
 		ctx := context.Background()
 		pub := &paho.Publish{
-			Topic: "test/topic",
+			Topic: mqttTestTopic,
 		}
 
 		injectObservabilityHeaders(ctx, pub)
@@ -132,7 +132,7 @@ func TestInjectObservabilityHeaders(t *testing.T) {
 
 		ctx := correlation.ContextWithID(context.Background(), "test-id")
 		pub := &paho.Publish{
-			Topic: "test/topic",
+			Topic: mqttTestTopic,
 			Properties: &paho.PublishProperties{
 				User: paho.UserProperties{},
 			},

--- a/client/redis/redis_test.go
+++ b/client/redis/redis_test.go
@@ -9,6 +9,8 @@ import (
 	"go.uber.org/goleak"
 )
 
+const redisAddress = "localhost:6379"
+
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
@@ -25,7 +27,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		opt := &redis.Options{
-			Addr: "localhost:6379",
+			Addr: redisAddress,
 		}
 
 		client, err := New(opt)
@@ -33,7 +35,7 @@ func TestNew(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, client)
 		assert.NotNil(t, client.Options())
-		assert.Equal(t, "localhost:6379", client.Options().Addr)
+		assert.Equal(t, redisAddress, client.Options().Addr)
 
 		// Clean up
 		err = client.Close()
@@ -66,7 +68,7 @@ func TestNew(t *testing.T) {
 		t.Parallel()
 
 		opt := &redis.Options{
-			Addr: "localhost:6379",
+			Addr: redisAddress,
 		}
 
 		client, err := New(opt)
@@ -98,7 +100,7 @@ func TestNew_WithMultipleAddresses(t *testing.T) {
 	t.Parallel()
 
 	opt := &redis.Options{
-		Addr:       "localhost:6379",
+		Addr:       redisAddress,
 		MaxRetries: 3,
 		PoolSize:   10,
 	}

--- a/client/sns/sns_test.go
+++ b/client/sns/sns_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	region = "us-east-1"
+)
+
 func TestNewFromConfig_Unit(t *testing.T) {
 	t.Parallel()
 
@@ -17,7 +21,7 @@ func TestNewFromConfig_Unit(t *testing.T) {
 		t.Parallel()
 
 		cfg := aws.Config{
-			Region: "us-east-1",
+			Region: region,
 		}
 
 		client := NewFromConfig(cfg)
@@ -61,7 +65,7 @@ func TestNewFromConfig_Unit(t *testing.T) {
 		t.Parallel()
 
 		cfg := aws.Config{
-			Region: "us-east-1",
+			Region: region,
 		}
 
 		optFn1 := func(o *sns.Options) {
@@ -85,7 +89,7 @@ func TestNewFromConfig_Unit(t *testing.T) {
 		t.Parallel()
 
 		cfg := aws.Config{
-			Region: "us-east-1",
+			Region: region,
 		}
 
 		client := NewFromConfig(cfg)
@@ -104,7 +108,7 @@ func TestNewFromConfig_WithCredentials(t *testing.T) {
 		t.Parallel()
 
 		cfg := aws.Config{
-			Region: "us-east-1",
+			Region: region,
 			Credentials: aws.CredentialsProviderFunc(func(_ context.Context) (aws.Credentials, error) {
 				return aws.Credentials{
 					AccessKeyID:     "test-key",
@@ -144,7 +148,7 @@ func TestNewFromConfig_WithRetryConfig(t *testing.T) {
 		t.Parallel()
 
 		cfg := aws.Config{
-			Region:           "us-east-1",
+			Region:           region,
 			RetryMaxAttempts: 5,
 			RetryMode:        aws.RetryModeStandard,
 		}

--- a/client/sql/sql_test.go
+++ b/client/sql/sql_test.go
@@ -14,6 +14,12 @@ import (
 	"go.uber.org/goleak"
 )
 
+const (
+	dbName      = "dbname"
+	userName    = "user"
+	tcpProtocol = "tcp"
+)
+
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
@@ -30,18 +36,18 @@ func TestParseDSN(t *testing.T) {
 		dsn  string
 		want DSNInfo
 	}{
-		"generic case":          {"username:password@protocol(address)/dbname?param=value", DSNInfo{"", "dbname", "address", "username", "protocol"}},
+		"generic case":          {"username:password@protocol(address)/dbname?param=value", DSNInfo{"", dbName, "address", "username", "protocol"}},
 		"empty DSN":             {"/", DSNInfo{"", "", "", "", ""}},
-		"dbname only":           {"/dbname", DSNInfo{"", "dbname", "", "", ""}},
-		"multiple @":            {"user:p@/ssword@/", DSNInfo{"", "", "", "user", ""}},
-		"driver and multiple @": {"postgresql://user:p@/ssword@/", DSNInfo{"postgresql://", "", "", "user", ""}},
-		"unix socket":           {"user@unix(/path/to/socket)/dbname?charset=utf8", DSNInfo{"", "dbname", "/path/to/socket", "user", "unix"}},
-		"params added":          {"user:password@/dbname?param1=val1&param2=val2&param3=val3", DSNInfo{"", "dbname", "", "user", ""}},
-		"IP as address":         {"bruce:hunter2@tcp(127.0.0.1)/arkhamdb?param=value", DSNInfo{"", "arkhamdb", "127.0.0.1", "bruce", "tcp"}},
-		"@ in path to socker":   {"user@unix(/path/to/mydir@/socket)/dbname?charset=utf8", DSNInfo{"", "dbname", "/path/to/mydir@/socket", "user", "unix"}},
-		"port in address":       {"user:password@tcp(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"", "dbname", "localhost:5555", "user", "tcp"}},
-		"multiple ':'":          {"us:er:name:password@memory(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"", "dbname", "localhost:5555", "us", "memory"}},
-		"IPv6 provided":         {"user:p@ss(word)@tcp([c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80)/dbname?loc=Local", DSNInfo{"", "dbname", "[c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80", "user", "tcp"}},
+		"dbname only":           {"/dbname", DSNInfo{"", dbName, "", "", ""}},
+		"multiple @":            {"user:p@/ssword@/", DSNInfo{"", "", "", userName, ""}},
+		"driver and multiple @": {"postgresql://user:p@/ssword@/", DSNInfo{"postgresql://", "", "", userName, ""}},
+		"unix socket":           {"user@unix(/path/to/socket)/dbname?charset=utf8", DSNInfo{"", dbName, "/path/to/socket", userName, "unix"}},
+		"params added":          {"user:password@/dbname?param1=val1&param2=val2&param3=val3", DSNInfo{"", dbName, "", userName, ""}},
+		"IP as address":         {"bruce:hunter2@tcp(127.0.0.1)/arkhamdb?param=value", DSNInfo{"", "arkhamdb", "127.0.0.1", "bruce", tcpProtocol}},
+		"@ in path to socker":   {"user@unix(/path/to/mydir@/socket)/dbname?charset=utf8", DSNInfo{"", dbName, "/path/to/mydir@/socket", userName, "unix"}},
+		"port in address":       {"user:password@tcp(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"", dbName, "localhost:5555", userName, tcpProtocol}},
+		"multiple ':'":          {"us:er:name:password@memory(localhost:5555)/dbname?charset=utf8&tls=true", DSNInfo{"", dbName, "localhost:5555", "us", "memory"}},
+		"IPv6 provided":         {"user:p@ss(word)@tcp([c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80)/dbname?loc=Local", DSNInfo{"", dbName, "[c023:9350:225b:671a:2cdd:3d83:7c19:ca42]:80", userName, tcpProtocol}},
 		"empty string":          {"", DSNInfo{"", "", "", "", ""}},
 		"non-matching string":   {"rosebud", DSNInfo{"", "", "", "", ""}},
 	}
@@ -305,14 +311,14 @@ func TestDSNInfo(t *testing.T) {
 		DBName:   "testdb",
 		Address:  "localhost:3306",
 		User:     "testuser",
-		Protocol: "tcp",
+		Protocol: tcpProtocol,
 	}
 
 	assert.Equal(t, "mysql://", info.Driver)
 	assert.Equal(t, "testdb", info.DBName)
 	assert.Equal(t, "localhost:3306", info.Address)
 	assert.Equal(t, "testuser", info.User)
-	assert.Equal(t, "tcp", info.Protocol)
+	assert.Equal(t, tcpProtocol, info.Protocol)
 }
 
 func TestConnInfo_Attributes(t *testing.T) {
@@ -437,7 +443,7 @@ func TestParseDSN_EdgeCases(t *testing.T) {
 			dsn: "user@/verylongdatabasenamewithnospaces",
 			want: DSNInfo{
 				DBName: "verylongdatabasenamewithnospaces",
-				User:   "user",
+				User:   userName,
 			},
 		},
 		"special chars in password": {
@@ -445,22 +451,22 @@ func TestParseDSN_EdgeCases(t *testing.T) {
 			want: DSNInfo{
 				DBName:   "db",
 				Address:  "localhost",
-				User:     "user",
-				Protocol: "tcp",
+				User:     userName,
+				Protocol: tcpProtocol,
 			},
 		},
 		"no protocol": {
 			dsn: "user:password@/dbname",
 			want: DSNInfo{
-				DBName: "dbname",
-				User:   "user",
+				DBName: dbName,
+				User:   userName,
 			},
 		},
 		"driver only": {
 			dsn: "postgres:///dbname",
 			want: DSNInfo{
 				Driver: "postgres://",
-				DBName: "dbname",
+				DBName: dbName,
 			},
 		},
 	}

--- a/client/sqs/sqs_test.go
+++ b/client/sqs/sqs_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	region = "us-east-1"
+)
+
 func TestNewFromConfig_Unit(t *testing.T) {
 	t.Parallel()
 
@@ -17,7 +21,7 @@ func TestNewFromConfig_Unit(t *testing.T) {
 		t.Parallel()
 
 		cfg := aws.Config{
-			Region: "us-east-1",
+			Region: region,
 		}
 
 		client := NewFromConfig(cfg)
@@ -61,7 +65,7 @@ func TestNewFromConfig_Unit(t *testing.T) {
 		t.Parallel()
 
 		cfg := aws.Config{
-			Region: "us-east-1",
+			Region: region,
 		}
 
 		optFn1 := func(o *sqs.Options) {
@@ -85,7 +89,7 @@ func TestNewFromConfig_Unit(t *testing.T) {
 		t.Parallel()
 
 		cfg := aws.Config{
-			Region: "us-east-1",
+			Region: region,
 		}
 
 		client := NewFromConfig(cfg)
@@ -104,7 +108,7 @@ func TestNewFromConfig_WithCredentials(t *testing.T) {
 		t.Parallel()
 
 		cfg := aws.Config{
-			Region: "us-east-1",
+			Region: region,
 			Credentials: aws.CredentialsProviderFunc(func(_ context.Context) (aws.Credentials, error) {
 				return aws.Credentials{
 					AccessKeyID:     "test-key",
@@ -144,7 +148,7 @@ func TestNewFromConfig_WithRetryConfig(t *testing.T) {
 		t.Parallel()
 
 		cfg := aws.Config{
-			Region:           "us-east-1",
+			Region:           region,
 			RetryMaxAttempts: 5,
 			RetryMode:        aws.RetryModeStandard,
 		}
@@ -165,7 +169,7 @@ func TestNewFromConfig_LocalEmulator(t *testing.T) {
 
 		localEndpoint := "http://localhost:4566"
 		cfg := aws.Config{
-			Region: "us-east-1",
+			Region: region,
 			Credentials: aws.CredentialsProviderFunc(func(_ context.Context) (aws.Credentials, error) {
 				return aws.Credentials{
 					AccessKeyID:     "test",

--- a/component/amqp/component.go
+++ b/component/amqp/component.go
@@ -9,11 +9,11 @@ import (
 	"net"
 	"net/url"
 	"time"
+	"uuid"
 
 	"github.com/beatlabs/patron/correlation"
 	"github.com/beatlabs/patron/observability/log"
 	patrontrace "github.com/beatlabs/patron/observability/trace"
-	"github.com/google/uuid"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"

--- a/component/amqp/helpers_integration_test.go
+++ b/component/amqp/helpers_integration_test.go
@@ -6,10 +6,10 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"uuid"
 
 	"github.com/beatlabs/patron/correlation"
 	patrontrace "github.com/beatlabs/patron/observability/trace"
-	"github.com/google/uuid"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/component/grpc/component_test.go
+++ b/component/grpc/component_test.go
@@ -23,6 +23,11 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+const (
+	testSuccess      = "success"
+	errorRequestName = "ERROR"
+)
+
 var (
 	tracePublisher *tracesdk.TracerProvider
 	traceExporter  = tracetest.NewInMemoryExporter()
@@ -52,7 +57,7 @@ func TestCreate(t *testing.T) {
 		args   args
 		expErr string
 	}{
-		"success":      {args: args{port: 60000}},
+		testSuccess:    {args: args{port: 60000}},
 		"invalid port": {args: args{port: -1}, expErr: "port is invalid: -1"},
 	}
 	for name, tt := range tests {
@@ -96,8 +101,8 @@ func TestComponent_Run_Unary(t *testing.T) {
 		args   args
 		expErr string
 	}{
-		"success": {args: args{requestName: "TEST"}},
-		"error":   {args: args{requestName: "ERROR"}, expErr: "rpc error: code = Unknown desc = ERROR"},
+		testSuccess: {args: args{requestName: "TEST"}},
+		"error":     {args: args{requestName: errorRequestName}, expErr: "rpc error: code = Unknown desc = ERROR"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -121,7 +126,7 @@ func TestComponent_Run_Unary(t *testing.T) {
 					SpanKind: trace.SpanKindServer,
 					Status: tracesdk.Status{
 						Code:        codes.Error,
-						Description: "ERROR",
+						Description: errorRequestName,
 					},
 				}
 
@@ -183,8 +188,8 @@ func TestComponent_Run_Stream(t *testing.T) {
 		args   args
 		expErr string
 	}{
-		"success": {args: args{requestName: "TEST"}},
-		"error":   {args: args{requestName: "ERROR"}, expErr: "rpc error: code = Unknown desc = ERROR"},
+		testSuccess: {args: args{requestName: "TEST"}},
+		"error":     {args: args{requestName: errorRequestName}, expErr: "rpc error: code = Unknown desc = ERROR"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -210,7 +215,7 @@ func TestComponent_Run_Stream(t *testing.T) {
 					SpanKind: trace.SpanKindServer,
 					Status: tracesdk.Status{
 						Code:        codes.Error,
-						Description: "ERROR",
+						Description: errorRequestName,
 					},
 				}
 
@@ -249,15 +254,15 @@ type server struct {
 }
 
 func (s *server) SayHello(_ context.Context, in *examples.HelloRequest) (*examples.HelloReply, error) {
-	if in.GetFirstName() == "ERROR" {
-		return nil, errors.New("ERROR")
+	if in.GetFirstName() == errorRequestName {
+		return nil, errors.New(errorRequestName)
 	}
 	return &examples.HelloReply{Message: "Hello " + in.GetFirstName()}, nil
 }
 
 func (s *server) SayHelloStream(req *examples.HelloRequest, srv examples.Greeter_SayHelloStreamServer) error {
-	if req.GetFirstName() == "ERROR" {
-		return errors.New("ERROR")
+	if req.GetFirstName() == errorRequestName {
+		return errors.New(errorRequestName)
 	}
 
 	return srv.Send(&examples.HelloReply{Message: "Hello " + req.GetFirstName()})

--- a/component/http/cache/cache_test.go
+++ b/component/http/cache/cache_test.go
@@ -18,6 +18,11 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
+const (
+	maxAgeFive = "max-age=5"
+	queryValue = "VALUE=1"
+)
+
 func TestExtractCacheHeaders(t *testing.T) {
 	type cacheRequestCondition struct {
 		noCache         bool
@@ -62,7 +67,7 @@ func TestExtractCacheHeaders(t *testing.T) {
 				forceCache: false,
 				validators: 1,
 			},
-			wrn: "max-age=5",
+			wrn: maxAgeFive,
 		},
 		// Header resets to maxFresh e.g. maxAge - minAge
 		{
@@ -92,7 +97,7 @@ func TestExtractCacheHeaders(t *testing.T) {
 				forceCache: false,
 				validators: 1,
 			},
-			wrn: "max-age=5",
+			wrn: maxAgeFive,
 		},
 		{
 			headers: map[string]string{HeaderCacheControl: "no-store"},
@@ -101,7 +106,7 @@ func TestExtractCacheHeaders(t *testing.T) {
 				forceCache: false,
 				validators: 1,
 			},
-			wrn: "max-age=5",
+			wrn: maxAgeFive,
 		},
 	}
 
@@ -189,7 +194,7 @@ type responseStruct struct {
 
 func newRequestAt(timeInstant int64, controlHeaders ...string) requestParams {
 	params := requestParams{
-		query:        "VALUE=1",
+		query:        queryValue,
 		timeInstance: timeInstant,
 		header:       make(map[string]string),
 	}
@@ -680,7 +685,7 @@ func TestMinAgeCache_WithMaxAgeHeaders(t *testing.T) {
 			{
 				requestParams: newRequestAt(4, maxAgeHeader("2")),
 				routeConfig:   rc,
-				response:      &responseStruct{Payload: 0, Header: testHeaderWithWarning(26, "max-age=5")},
+				response:      &responseStruct{Payload: 0, Header: testHeaderWithWarning(26, maxAgeFive)},
 				metrics: testMetrics{
 					map[string]*metricState{
 						"/": {
@@ -1207,7 +1212,7 @@ func TestCache_WithMixedPaths(t *testing.T) {
 			// initial request
 			{
 				requestParams: requestParams{
-					query:        "VALUE=1",
+					query:        queryValue,
 					timeInstance: 0,
 					path:         "/1",
 				},
@@ -1226,7 +1231,7 @@ func TestCache_WithMixedPaths(t *testing.T) {
 			// cached Response for the same path
 			{
 				requestParams: requestParams{
-					query:        "VALUE=1",
+					query:        queryValue,
 					timeInstance: 1,
 					path:         "/1",
 				},
@@ -1246,7 +1251,7 @@ func TestCache_WithMixedPaths(t *testing.T) {
 			// initial request for second path
 			{
 				requestParams: requestParams{
-					query:        "VALUE=1",
+					query:        queryValue,
 					timeInstance: 1,
 					path:         "/2",
 				},
@@ -1270,7 +1275,7 @@ func TestCache_WithMixedPaths(t *testing.T) {
 			// cached Response for second path
 			{
 				requestParams: requestParams{
-					query:        "VALUE=1",
+					query:        queryValue,
 					timeInstance: 2,
 					path:         "/2",
 				},
@@ -1323,7 +1328,7 @@ func TestCache_WithMixedRequestParameters(t *testing.T) {
 			// cached Response for same request parameter
 			{
 				requestParams: requestParams{
-					query:        "VALUE=1",
+					query:        queryValue,
 					timeInstance: 1,
 				},
 				routeConfig: rc,

--- a/component/http/cache/route_test.go
+++ b/component/http/cache/route_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -65,7 +66,7 @@ func TestHandler(t *testing.T) {
 	rc, errs := NewRouteCache(tc, Age{Min: time.Second, Max: 10 * time.Second})
 	require.Empty(t, errs)
 
-	req := httptest.NewRequest(http.MethodGet, "/cached?key=value", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/cached?key=value", nil)
 	rec := httptest.NewRecorder()
 
 	err := Handler(rec, req, rc, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -80,7 +81,7 @@ func TestHandler(t *testing.T) {
 }
 
 func TestHTTPExecutor(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/cached", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/cached", nil)
 	exec := httpExecutor(httptest.NewRecorder(), req, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("X-Test", "value")
 		_, err := w.Write([]byte("payload"))

--- a/component/http/component_option_test.go
+++ b/component/http/component_option_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	componentOptionTestSuccess = "success"
+	missingCert                = "missing cert"
+)
+
 func TestTLS(t *testing.T) {
 	t.Parallel()
 	type args struct {
@@ -18,9 +23,9 @@ func TestTLS(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success":      {args: args{cert: "cert", key: "key"}},
-		"missing cert": {args: args{cert: "", key: "key"}, expectedErr: "cert file or key file was empty"},
-		"missing key":  {args: args{cert: "cert", key: ""}, expectedErr: "cert file or key file was empty"},
+		componentOptionTestSuccess: {args: args{cert: "cert", key: "key"}},
+		missingCert:                {args: args{cert: "", key: "key"}, expectedErr: "cert file or key file was empty"},
+		"missing key":              {args: args{cert: "cert", key: ""}, expectedErr: "cert file or key file was empty"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -48,8 +53,8 @@ func TestReadTimeout(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success":      {args: args{rt: time.Second}},
-		"missing cert": {args: args{rt: -1 * time.Second}, expectedErr: "negative or zero read timeout provided"},
+		componentOptionTestSuccess: {args: args{rt: time.Second}},
+		missingCert:                {args: args{rt: -1 * time.Second}, expectedErr: "negative or zero read timeout provided"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -76,8 +81,8 @@ func TestWriteTimeout(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success":      {args: args{wt: time.Second}},
-		"missing cert": {args: args{wt: -1 * time.Second}, expectedErr: "negative or zero write timeout provided"},
+		componentOptionTestSuccess: {args: args{wt: time.Second}},
+		missingCert:                {args: args{wt: -1 * time.Second}, expectedErr: "negative or zero write timeout provided"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -104,8 +109,8 @@ func TestHandlerTimeout(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success":      {args: args{wt: time.Second}},
-		"missing cert": {args: args{wt: -1 * time.Second}, expectedErr: "negative or zero handler timeout provided"},
+		componentOptionTestSuccess: {args: args{wt: time.Second}},
+		missingCert:                {args: args{wt: -1 * time.Second}, expectedErr: "negative or zero handler timeout provided"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -132,8 +137,8 @@ func TestShutdownGracePeriod(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success":      {args: args{gp: time.Second}},
-		"missing cert": {args: args{gp: -1 * time.Second}, expectedErr: "negative or zero shutdown grace period timeout provided"},
+		componentOptionTestSuccess: {args: args{gp: time.Second}},
+		missingCert:                {args: args{gp: -1 * time.Second}, expectedErr: "negative or zero shutdown grace period timeout provided"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -160,8 +165,8 @@ func TestPort(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success":      {args: args{port: 50000}},
-		"missing cert": {args: args{port: 120000}, expectedErr: "invalid HTTP Port provided"},
+		componentOptionTestSuccess: {args: args{port: 50000}},
+		missingCert:                {args: args{port: 120000}, expectedErr: "invalid HTTP Port provided"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/component/http/component_test.go
+++ b/component/http/component_test.go
@@ -13,6 +13,11 @@ import (
 	"go.uber.org/goleak"
 )
 
+const (
+	componentTestSuccess    = "success"
+	invalidEnvironmentValue = "aaa"
+)
+
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
@@ -43,7 +48,7 @@ func TestNew(t *testing.T) {
 		expected    *Component
 		expectedErr string
 	}{
-		"success": {
+		componentTestSuccess: {
 			args: args{handler: hnd},
 			expected: &Component{
 				port:                defaultPort,
@@ -73,21 +78,21 @@ func TestNew(t *testing.T) {
 		"failure, port env vars": {
 			args: args{
 				handler: hnd,
-				port:    "aaa",
+				port:    invalidEnvironmentValue,
 			},
 			expectedErr: `env var for HTTP default port is not valid: strconv.ParseInt: parsing "aaa": invalid syntax`,
 		},
 		"failure, read timeout env vars": {
 			args: args{
 				handler:     hnd,
-				readTimeout: "aaa",
+				readTimeout: invalidEnvironmentValue,
 			},
 			expectedErr: `env var for HTTP read timeout is not valid: time: invalid duration "aaa"`,
 		},
 		"failure, write timeout env vars": {
 			args: args{
 				handler:      hnd,
-				writeTimeout: "aaa",
+				writeTimeout: invalidEnvironmentValue,
 			},
 			expectedErr: `env var for HTTP write timeout is not valid: time: invalid duration "aaa"`,
 		},

--- a/component/http/middleware/logging_test.go
+++ b/component/http/middleware/logging_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	loggingEmptyTestCase = "empty"
+)
+
 const complexConfig = "200;(210,212);(220,222];[230,232);[240,242]"
 
 func TestStatusCode(t *testing.T) {
@@ -20,7 +24,7 @@ func TestStatusCode(t *testing.T) {
 		expectedResult     bool
 		expectedParsingErr bool
 	}{
-		"empty":                                    {args: args{cfg: "", statusCode: 400}, expectedResult: false},
+		loggingEmptyTestCase:                       {args: args{cfg: "", statusCode: 400}, expectedResult: false},
 		"single element - true":                    {args: args{cfg: "400", statusCode: 400}, expectedResult: true},
 		"single element - false":                   {args: args{cfg: "400", statusCode: 401}, expectedResult: false},
 		"complex config - single element - true":   {args: args{cfg: complexConfig, statusCode: 200}, expectedResult: true},

--- a/component/http/middleware/middleware_test.go
+++ b/component/http/middleware/middleware_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	internalServerError     = "Internal Server Error\\n"
+	internalServerError     = "Internal Server Error\n"
 	testURL                 = "http://foo/bar"
 	middlewareEmptyTestCase = "empty"
 )

--- a/component/http/middleware/middleware_test.go
+++ b/component/http/middleware/middleware_test.go
@@ -17,6 +17,12 @@ import (
 	"golang.org/x/time/rate"
 )
 
+const (
+	internalServerError     = "Internal Server Error\\n"
+	testURL                 = "http://foo/bar"
+	middlewareEmptyTestCase = "empty"
+)
+
 type stubAuthenticator struct {
 	success bool
 	err     error
@@ -122,13 +128,13 @@ func TestMiddlewares(t *testing.T) {
 	}{
 		{"auth middleware success", args{next: handler, mws: []Func{NewAuth(&stubAuthenticator{success: true})}}, 202, ""},
 		{"auth middleware false", args{next: handler, mws: []Func{NewAuth(&stubAuthenticator{success: false})}}, 401, "Unauthorized\n"},
-		{"auth middleware error", args{next: handler, mws: []Func{NewAuth(&stubAuthenticator{err: errors.New("auth error")})}}, 500, "Internal Server Error\n"},
+		{"auth middleware error", args{next: handler, mws: []Func{NewAuth(&stubAuthenticator{err: errors.New("auth error")})}}, 500, internalServerError},
 		{"tracing middleware", args{next: handler, mws: []Func{loggingTracingMiddleware}}, 202, ""},
 		{"rate limiting middleware", args{next: handler, mws: []Func{rateLimitingWithLimitMiddleware}}, 202, ""},
 		{"rate limiting middleware error", args{next: handler, mws: []Func{rateLimitingWithoutLimitMiddlware}}, 429, "Requests greater than limit\n"},
-		{"recovery middleware from panic 1", args{next: handler, mws: []Func{NewRecovery(), panicMiddleware("error")}}, 500, "Internal Server Error\n"},
-		{"recovery middleware from panic 2", args{next: handler, mws: []Func{NewRecovery(), panicMiddleware(errors.New("error"))}}, 500, "Internal Server Error\n"},
-		{"recovery middleware from panic 3", args{next: handler, mws: []Func{NewRecovery(), panicMiddleware(-1)}}, 500, "Internal Server Error\n"},
+		{"recovery middleware from panic 1", args{next: handler, mws: []Func{NewRecovery(), panicMiddleware("error")}}, 500, internalServerError},
+		{"recovery middleware from panic 2", args{next: handler, mws: []Func{NewRecovery(), panicMiddleware(errors.New("error"))}}, 500, internalServerError},
+		{"recovery middleware from panic 3", args{next: handler, mws: []Func{NewRecovery(), panicMiddleware(-1)}}, 500, internalServerError},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -270,15 +276,15 @@ func TestStripQueryString(t *testing.T) {
 			args: args{
 				path: "http://foo/bar?baz=value1",
 			},
-			expectedPath: "http://foo/bar",
+			expectedPath: testURL,
 		},
 		"no query string": {
 			args: args{
-				path: "http://foo/bar",
+				path: testURL,
 			},
-			expectedPath: "http://foo/bar",
+			expectedPath: testURL,
 		},
-		"empty": {
+		middlewareEmptyTestCase: {
 			args: args{
 				path: "",
 			},
@@ -355,62 +361,62 @@ func TestNewCompressionMiddlewareServer(t *testing.T) {
 	}{
 		{
 			status:           200,
-			acceptEncoding:   "gzip",
-			expectedEncoding: "gzip",
+			acceptEncoding:   gzipHeader,
+			expectedEncoding: gzipHeader,
 			cm:               compressionMiddleware,
 		},
 		{
 			status:           201,
-			acceptEncoding:   "gzip",
-			expectedEncoding: "gzip",
+			acceptEncoding:   gzipHeader,
+			expectedEncoding: gzipHeader,
 			cm:               compressionMiddleware,
 		},
 		{
 			status:           204,
-			acceptEncoding:   "gzip",
+			acceptEncoding:   gzipHeader,
 			expectedEncoding: "",
 			cm:               compressionMiddleware,
 		},
 		{
 			status:           304,
-			acceptEncoding:   "gzip",
+			acceptEncoding:   gzipHeader,
 			expectedEncoding: "",
 			cm:               compressionMiddleware,
 		},
 		{
 			status:           404,
-			acceptEncoding:   "gzip",
-			expectedEncoding: "gzip",
+			acceptEncoding:   gzipHeader,
+			expectedEncoding: gzipHeader,
 			cm:               compressionMiddleware,
 		},
 		{
 			status:           200,
-			acceptEncoding:   "deflate",
-			expectedEncoding: "deflate",
+			acceptEncoding:   deflateHeader,
+			expectedEncoding: deflateHeader,
 			cm:               compressionMiddleware,
 		},
 		{
 			status:           201,
-			acceptEncoding:   "deflate",
-			expectedEncoding: "deflate",
+			acceptEncoding:   deflateHeader,
+			expectedEncoding: deflateHeader,
 			cm:               compressionMiddleware,
 		},
 		{
 			status:           204,
-			acceptEncoding:   "deflate",
+			acceptEncoding:   deflateHeader,
 			expectedEncoding: "",
 			cm:               compressionMiddleware,
 		},
 		{
 			status:           304,
-			acceptEncoding:   "deflate",
+			acceptEncoding:   deflateHeader,
 			expectedEncoding: "",
 			cm:               compressionMiddleware,
 		},
 		{
 			status:           404,
-			acceptEncoding:   "deflate",
-			expectedEncoding: "deflate",
+			acceptEncoding:   deflateHeader,
+			expectedEncoding: deflateHeader,
 			cm:               compressionMiddleware,
 		},
 	}
@@ -449,7 +455,7 @@ func TestNewCompressionMiddleware_Ignore(t *testing.T) {
 	// check if the route actually ignored
 	req1, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", nil)
 	require.NoError(t, err)
-	req1.Header.Set("Accept-Encoding", "gzip")
+	req1.Header.Set("Accept-Encoding", gzipHeader)
 
 	rc1 := httptest.NewRecorder()
 	middleware(handler).ServeHTTP(rc1, req1)
@@ -461,14 +467,14 @@ func TestNewCompressionMiddleware_Ignore(t *testing.T) {
 	// check if other routes remains untouched
 	req2, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/alive", nil)
 	require.NoError(t, err)
-	req2.Header.Set("Accept-Encoding", "gzip")
+	req2.Header.Set("Accept-Encoding", gzipHeader)
 
 	rc2 := httptest.NewRecorder()
 	middleware(handler).ServeHTTP(rc2, req2)
 
 	ceh = rc2.Header().Get("Content-Encoding")
 	assert.NotNil(t, ceh)
-	assert.Equal(t, "gzip", ceh)
+	assert.Equal(t, gzipHeader, ceh)
 }
 
 func TestNewCompressionMiddleware_Headers(t *testing.T) {
@@ -481,8 +487,8 @@ func TestNewCompressionMiddleware_Headers(t *testing.T) {
 		statusCode       int
 		encodingExpected string
 	}{
-		"gzip":                {cm: middleware, statusCode: http.StatusOK, encodingExpected: gzipHeader},
-		"deflate":             {cm: middleware, statusCode: http.StatusOK, encodingExpected: deflateHeader},
+		gzipHeader:            {cm: middleware, statusCode: http.StatusOK, encodingExpected: gzipHeader},
+		deflateHeader:         {cm: middleware, statusCode: http.StatusOK, encodingExpected: deflateHeader},
 		"gzip, *":             {cm: middleware, statusCode: http.StatusOK, encodingExpected: gzipHeader},
 		"deflate, *":          {cm: middleware, statusCode: http.StatusOK, encodingExpected: deflateHeader},
 		"invalid, gzip, *":    {cm: middleware, statusCode: http.StatusOK, encodingExpected: gzipHeader},
@@ -530,54 +536,54 @@ func TestSelectEncoding(t *testing.T) {
 		{given: "", expected: "identity", optionalName: "is empty but present, only identity"},
 
 		{given: "*", expected: "*"},
-		{given: "gzip", expected: "gzip"},
-		{given: "deflate", expected: "deflate"},
+		{given: gzipHeader, expected: gzipHeader},
+		{given: deflateHeader, expected: deflateHeader},
 
 		{given: "whatever", expected: "", isErr: true, optionalName: "whatever, not supported"},
 		{given: "whatever, *", expected: "*", optionalName: "whatever, but also a star"},
 
-		{given: "gzip, deflate", expected: "gzip"},
-		{given: "whatever, gzip, deflate", expected: "gzip"},
-		{given: "gzip, whatever, deflate", expected: "gzip"},
-		{given: "gzip, deflate, whatever", expected: "gzip"},
+		{given: "gzip, deflate", expected: gzipHeader},
+		{given: "whatever, gzip, deflate", expected: gzipHeader},
+		{given: "gzip, whatever, deflate", expected: gzipHeader},
+		{given: "gzip, deflate, whatever", expected: gzipHeader},
 
-		{given: "gzip,deflate", expected: "gzip"},
-		{given: "gzip,whatever,deflate", expected: "gzip"},
-		{given: "whatever,gzip,deflate", expected: "gzip"},
-		{given: "gzip,deflate,whatever", expected: "gzip"},
+		{given: "gzip,deflate", expected: gzipHeader},
+		{given: "gzip,whatever,deflate", expected: gzipHeader},
+		{given: "whatever,gzip,deflate", expected: gzipHeader},
+		{given: "gzip,deflate,whatever", expected: gzipHeader},
 
-		{given: "deflate, gzip", expected: "deflate"},
-		{given: "whatever, deflate, gzip", expected: "deflate"},
-		{given: "deflate, whatever, gzip", expected: "deflate"},
-		{given: "deflate, gzip, whatever", expected: "deflate"},
+		{given: "deflate, gzip", expected: deflateHeader},
+		{given: "whatever, deflate, gzip", expected: deflateHeader},
+		{given: "deflate, whatever, gzip", expected: deflateHeader},
+		{given: "deflate, gzip, whatever", expected: deflateHeader},
 
-		{given: "deflate, gzip", expected: "deflate"},
-		{given: "whatever,deflate,gzip", expected: "deflate"},
-		{given: "deflate,whatever,gzip", expected: "deflate"},
-		{given: "deflate,gzip,whatever", expected: "deflate"},
+		{given: "deflate, gzip", expected: deflateHeader},
+		{given: "whatever,deflate,gzip", expected: deflateHeader},
+		{given: "deflate,whatever,gzip", expected: deflateHeader},
+		{given: "deflate,gzip,whatever", expected: deflateHeader},
 
-		{given: "gzip;q=1.0, deflate;q=1.0", expected: "gzip", optionalName: "equal weights"},
-		{given: "deflate;q=1.0, gzip;q=1.0", expected: "deflate", optionalName: "equal weights 2"},
+		{given: "gzip;q=1.0, deflate;q=1.0", expected: gzipHeader, optionalName: "equal weights"},
+		{given: "deflate;q=1.0, gzip;q=1.0", expected: deflateHeader, optionalName: "equal weights 2"},
 
-		{given: "gzip;q=1.0, deflate;q=0.5", expected: "gzip"},
-		{given: "gzip;q=1.0, deflate;q=0.5, *;q=0.2", expected: "gzip"},
-		{given: "deflate;q=1.0, gzip;q=0.5", expected: "deflate"},
-		{given: "deflate;q=1.0, gzip;q=0.5, *;q=0.2", expected: "deflate"},
+		{given: "gzip;q=1.0, deflate;q=0.5", expected: gzipHeader},
+		{given: "gzip;q=1.0, deflate;q=0.5, *;q=0.2", expected: gzipHeader},
+		{given: "deflate;q=1.0, gzip;q=0.5", expected: deflateHeader},
+		{given: "deflate;q=1.0, gzip;q=0.5, *;q=0.2", expected: deflateHeader},
 
-		{given: "gzip;q=0.5, deflate;q=1.0", expected: "deflate"},
-		{given: "gzip;q=0.5, deflate;q=1.0, *;q=0.2", expected: "deflate"},
-		{given: "deflate;q=0.5, gzip;q=1.0", expected: "gzip"},
-		{given: "deflate;q=0.5, gzip;q=1.0, *;q=0.2", expected: "gzip"},
+		{given: "gzip;q=0.5, deflate;q=1.0", expected: deflateHeader},
+		{given: "gzip;q=0.5, deflate;q=1.0, *;q=0.2", expected: deflateHeader},
+		{given: "deflate;q=0.5, gzip;q=1.0", expected: gzipHeader},
+		{given: "deflate;q=0.5, gzip;q=1.0, *;q=0.2", expected: gzipHeader},
 
 		{given: "whatever;q=1.0, *;q=0.2", expected: "*"},
 
-		{given: "deflate, gzip;q=1.0", expected: "deflate"},
-		{given: "deflate, gzip;q=0.5", expected: "deflate"},
+		{given: "deflate, gzip;q=1.0", expected: deflateHeader},
+		{given: "deflate, gzip;q=0.5", expected: deflateHeader},
 
-		{given: "deflate;q=0.5, gzip", expected: "gzip"},
+		{given: "deflate;q=0.5, gzip", expected: gzipHeader},
 
-		{given: "deflate;q=0.5, gzip;q=-0.5", expected: "deflate"},
-		{given: "deflate;q=0.5, gzip;q=1.5", expected: "gzip"},
+		{given: "deflate;q=0.5, gzip;q=-0.5", expected: deflateHeader},
+		{given: "deflate;q=0.5, gzip;q=1.5", expected: gzipHeader},
 	}
 
 	for _, tt := range tests {
@@ -597,8 +603,8 @@ func TestSupported(t *testing.T) {
 		algorithm   string
 		isSupported bool
 	}{
-		{algorithm: "gzip", isSupported: true},
-		{algorithm: "deflate", isSupported: true},
+		{algorithm: gzipHeader, isSupported: true},
+		{algorithm: deflateHeader, isSupported: true},
 		{algorithm: "*", isSupported: true},
 		{algorithm: "something else", isSupported: false},
 	}
@@ -647,13 +653,13 @@ func TestSelectByWeight(t *testing.T) {
 	}{
 		{
 			name:     "sorted map",
-			given:    map[float64]string{1.0: "gzip", 0.5: "deflate"},
-			expected: "gzip",
+			given:    map[float64]string{1.0: gzipHeader, 0.5: deflateHeader},
+			expected: gzipHeader,
 		},
 		{
 			name:     "not sorted map",
-			given:    map[float64]string{0.5: "gzip", 1.0: "deflate"},
-			expected: "deflate",
+			given:    map[float64]string{0.5: gzipHeader, 1.0: deflateHeader},
+			expected: deflateHeader,
 		},
 		{
 			name:     "empty weights map",
@@ -684,25 +690,25 @@ func TestAddWithWeight(t *testing.T) {
 		expected    map[float64]string
 	}{
 		{
-			name:        "empty",
+			name:        middlewareEmptyTestCase,
 			weightedMap: map[float64]string{},
 			weight:      1.0,
-			algorithm:   "gzip",
-			expected:    map[float64]string{1.0: "gzip"},
+			algorithm:   gzipHeader,
+			expected:    map[float64]string{1.0: gzipHeader},
 		},
 		{
 			name:        "new",
-			weightedMap: map[float64]string{1.0: "gzip"},
+			weightedMap: map[float64]string{1.0: gzipHeader},
 			weight:      0.5,
-			algorithm:   "deflate",
-			expected:    map[float64]string{1.0: "gzip", 0.5: "deflate"},
+			algorithm:   deflateHeader,
+			expected:    map[float64]string{1.0: gzipHeader, 0.5: deflateHeader},
 		},
 		{
 			name:        "already exists",
-			weightedMap: map[float64]string{1.0: "gzip"},
+			weightedMap: map[float64]string{1.0: gzipHeader},
 			weight:      1.0,
-			algorithm:   "deflate",
-			expected:    map[float64]string{1.0: "gzip"},
+			algorithm:   deflateHeader,
+			expected:    map[float64]string{1.0: gzipHeader},
 		},
 	}
 

--- a/component/http/route_option_test.go
+++ b/component/http/route_option_test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	routeOptionTestSuccess = "success"
+	routeOptionGetAPIPath  = "GET /api"
+)
+
 type mockAuthenticator struct {
 	success bool
 	err     error
@@ -63,8 +68,8 @@ func TestRouteMiddlewares(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {args: args{mm: []patronhttp.Func{patronhttp.NewRecovery()}}},
-		"fail":    {args: args{mm: nil}, expectedErr: "middlewares are empty"},
+		routeOptionTestSuccess: {args: args{mm: []patronhttp.Func{patronhttp.NewRecovery()}}},
+		"fail":                 {args: args{mm: nil}, expectedErr: "middlewares are empty"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -89,8 +94,8 @@ func TestAuth(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {args: args{auth: &mockAuthenticator{}}},
-		"fail":    {args: args{auth: nil}, expectedErr: "authenticator is nil"},
+		routeOptionTestSuccess: {args: args{auth: &mockAuthenticator{}}},
+		"fail":                 {args: args{auth: nil}, expectedErr: "authenticator is nil"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -120,8 +125,8 @@ func TestCache(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {
-			fields:      fields{path: "GET /api"},
+		routeOptionTestSuccess: {
+			fields:      fields{path: routeOptionGetAPIPath},
 			args:        args{cache: &redis.Cache{}, ageBounds: httpcache.Age{}},
 			expectedErr: "",
 		},
@@ -131,7 +136,7 @@ func TestCache(t *testing.T) {
 			expectedErr: "cannot apply cache to a route with any method other than GET",
 		},
 		"fail with args": {
-			fields:      fields{path: "GET /api"},
+			fields:      fields{path: routeOptionGetAPIPath},
 			args:        args{cache: nil, ageBounds: httpcache.Age{}},
 			expectedErr: "route cache is nil",
 		},

--- a/component/http/route_test.go
+++ b/component/http/route_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	routeTestSuccess    = "success"
+	routeTestGetAPIPath = "GET /api"
+)
+
 func TestNewRoute(t *testing.T) {
 	t.Parallel()
 
@@ -26,8 +31,8 @@ func TestNewRoute(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {args: args{
-			path:        "GET /api",
+		routeTestSuccess: {args: args{
+			path:        routeTestGetAPIPath,
 			handler:     handler,
 			optionFuncs: []RouteOptionFunc{rateLimiting},
 		}},
@@ -37,12 +42,12 @@ func TestNewRoute(t *testing.T) {
 			optionFuncs: []RouteOptionFunc{rateLimiting},
 		}, expectedErr: "path is empty"},
 		"missing handler": {args: args{
-			path:        "GET /api",
+			path:        routeTestGetAPIPath,
 			handler:     nil,
 			optionFuncs: []RouteOptionFunc{rateLimiting},
 		}, expectedErr: "handler is nil"},
 		"missing middlewares": {args: args{
-			path:        "GET /api",
+			path:        routeTestGetAPIPath,
 			handler:     handler,
 			optionFuncs: []RouteOptionFunc{WithMiddlewares()},
 		}, expectedErr: "middlewares are empty"},
@@ -57,7 +62,7 @@ func TestNewRoute(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assertRoute(t, tt.args.path, got)
-				assert.Equal(t, "GET /api", got.String())
+				assert.Equal(t, routeTestGetAPIPath, got.String())
 			}
 		})
 	}
@@ -79,9 +84,9 @@ func TestRoutes_Append(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success":      {args: args{route: &Route{}, err: nil}},
-		"error exist":  {args: args{route: &Route{}, err: errors.New("TEST")}, expectedErr: "TEST"},
-		"route is nil": {args: args{route: nil, err: nil}, expectedErr: "route is nil"},
+		routeTestSuccess: {args: args{route: &Route{}, err: nil}},
+		"error exist":    {args: args{route: &Route{}, err: errors.New("TEST")}, expectedErr: "TEST"},
+		"route is nil":   {args: args{route: nil, err: nil}, expectedErr: "route is nil"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/component/http/router/route_test.go
+++ b/component/http/router/route_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 const (
+	routerRouteTestSuccess = "success"
+)
+
+const (
 	testRoutePath    = "GET /frontend/*path"
 	testAssetsDir    = "testdata/"
 	testFallbackPath = "testdata/index.html"
@@ -27,7 +31,7 @@ func TestNewFileServerRoute(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {args: args{
+		routerRouteTestSuccess: {args: args{
 			path:         testRoutePath,
 			assetsDir:    testAssetsDir,
 			fallbackPath: testFallbackPath,

--- a/component/http/router/router_option_test.go
+++ b/component/http/router/router_option_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	routerOptionTestSuccess = "success"
+	testFailure             = "fail"
+)
+
 func TestRoutes(t *testing.T) {
 	t.Parallel()
 	type args struct {
@@ -19,8 +24,8 @@ func TestRoutes(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {args: args{routes: []*patronhttp.Route{{}, {}}}},
-		"fail":    {args: args{routes: nil}, expectedErr: "routes are empty"},
+		routerOptionTestSuccess: {args: args{routes: []*patronhttp.Route{{}, {}}}},
+		testFailure:             {args: args{routes: nil}, expectedErr: "routes are empty"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -45,8 +50,8 @@ func TestAliveCheck(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {args: args{acf: func() patronhttp.AliveStatus { return patronhttp.Alive }}},
-		"fail":    {args: args{acf: nil}, expectedErr: "alive check function is nil"},
+		routerOptionTestSuccess: {args: args{acf: func() patronhttp.AliveStatus { return patronhttp.Alive }}},
+		testFailure:             {args: args{acf: nil}, expectedErr: "alive check function is nil"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -71,8 +76,8 @@ func TestReadyCheck(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {args: args{rcf: func() patronhttp.ReadyStatus { return patronhttp.Ready }}},
-		"fail":    {args: args{rcf: nil}, expectedErr: "ready check function is nil"},
+		routerOptionTestSuccess: {args: args{rcf: func() patronhttp.ReadyStatus { return patronhttp.Ready }}},
+		testFailure:             {args: args{rcf: nil}, expectedErr: "ready check function is nil"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -127,8 +132,8 @@ func TestMiddlewares(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {args: args{mm: []middleware.Func{func(next http.Handler) http.Handler { return next }}}},
-		"fail":    {args: args{mm: nil}, expectedErr: "middlewares are empty"},
+		routerOptionTestSuccess: {args: args{mm: []middleware.Func{func(next http.Handler) http.Handler { return next }}}},
+		testFailure:             {args: args{mm: nil}, expectedErr: "middlewares are empty"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -172,9 +177,9 @@ func TestEnableAppNameHeaders(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success":         {args: args{name: "name", version: "version"}},
-		"missing name":    {args: args{name: "", version: "version"}, expectedErr: "app name cannot be empty"},
-		"missing version": {args: args{name: "name", version: ""}, expectedErr: "app version cannot be empty"},
+		routerOptionTestSuccess: {args: args{name: "name", version: "version"}},
+		"missing name":          {args: args{name: "", version: "version"}, expectedErr: "app name cannot be empty"},
+		"missing version":       {args: args{name: "name", version: ""}, expectedErr: "app version cannot be empty"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/component/http/router/router_test.go
+++ b/component/http/router/router_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	routerTestSuccess = "success"
+)
+
 func TestNew(t *testing.T) {
 	t.Parallel()
 	route, err := patronhttp.NewRoute("GET /api/", func(writer http.ResponseWriter, _ *http.Request) {
@@ -24,7 +28,7 @@ func TestNew(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success":            {args: args{oo: []OptionFunc{WithRoutes(route)}}},
+		routerTestSuccess:    {args: args{oo: []OptionFunc{WithRoutes(route)}}},
 		"option func failed": {args: args{oo: []OptionFunc{WithAliveCheck(nil)}}, expectedErr: "alive check function is nil"},
 	}
 	for name, tt := range tests {

--- a/component/kafka/component.go
+++ b/component/kafka/component.go
@@ -8,12 +8,12 @@ import (
 	"log/slog"
 	"sync"
 	"time"
+	"uuid"
 
 	"github.com/beatlabs/patron/correlation"
 	"github.com/beatlabs/patron/internal/validation"
 	"github.com/beatlabs/patron/observability/log"
 	patrontrace "github.com/beatlabs/patron/observability/trace"
-	"github.com/google/uuid"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/plugin/kotel"
 	"github.com/twmb/franz-go/plugin/kslog"

--- a/component/kafka/component_test.go
+++ b/component/kafka/component_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/beatlabs/patron/correlation"
 	patrontrace "github.com/beatlabs/patron/observability/trace"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -20,6 +19,7 @@ import (
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.uber.org/goleak"
+	"uuid"
 )
 
 var (

--- a/component/kafka/helpers_integration_test.go
+++ b/component/kafka/helpers_integration_test.go
@@ -4,9 +4,9 @@ package kafka
 
 import (
 	"testing"
+	"uuid"
 
 	"github.com/beatlabs/patron/correlation"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"

--- a/component/kafka/integration_test.go
+++ b/component/kafka/integration_test.go
@@ -12,12 +12,12 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"uuid"
 
 	kafkaclient "github.com/beatlabs/patron/client/kafka"
 	"github.com/beatlabs/patron/correlation"
 	"github.com/beatlabs/patron/internal/test"
 	patrontrace "github.com/beatlabs/patron/observability/trace"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kadm"

--- a/component/sqs/component.go
+++ b/component/sqs/component.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
@@ -16,7 +17,6 @@ import (
 	"github.com/beatlabs/patron/correlation"
 	"github.com/beatlabs/patron/observability/log"
 	patrontrace "github.com/beatlabs/patron/observability/trace"
-	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 )

--- a/component/sqs/component_test.go
+++ b/component/sqs/component_test.go
@@ -17,6 +17,11 @@ import (
 	"go.uber.org/goleak"
 )
 
+const (
+	sqsComponentTestSuccess = "success"
+	componentName           = "name"
+)
+
 var (
 	tracePublisher *tracesdk.TracerProvider
 	traceExporter  = tracetest.NewInMemoryExporter()
@@ -54,10 +59,10 @@ func TestNew(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {
+		sqsComponentTestSuccess: {
 			args: args{
-				name:      "name",
-				queueName: "queueName",
+				name:      componentName,
+				queueName: queueName,
 				sqsAPI:    &stubSQSAPI{},
 				proc:      sp.process,
 				oo:        []OptionFunc{WithRetries(5)},
@@ -66,7 +71,7 @@ func TestNew(t *testing.T) {
 		"missing name": {
 			args: args{
 				name:      "",
-				queueName: "queueName",
+				queueName: queueName,
 				sqsAPI:    &stubSQSAPI{},
 				proc:      sp.process,
 				oo:        []OptionFunc{WithRetries(5)},
@@ -75,7 +80,7 @@ func TestNew(t *testing.T) {
 		},
 		"missing queue name": {
 			args: args{
-				name:      "name",
+				name:      componentName,
 				queueName: "",
 				sqsAPI:    &stubSQSAPI{},
 				proc:      sp.process,
@@ -85,8 +90,8 @@ func TestNew(t *testing.T) {
 		},
 		"missing queue URL": {
 			args: args{
-				name:      "name",
-				queueName: "queueName",
+				name:      componentName,
+				queueName: queueName,
 				sqsAPI: &stubSQSAPI{
 					getQueueUrlWithContextErr: errors.New("QUEUE URL ERROR"),
 				},
@@ -97,8 +102,8 @@ func TestNew(t *testing.T) {
 		},
 		"missing queue SQS API": {
 			args: args{
-				name:      "name",
-				queueName: "queueName",
+				name:      componentName,
+				queueName: queueName,
 				sqsAPI:    nil,
 				proc:      sp.process,
 				oo:        []OptionFunc{WithRetries(5)},
@@ -107,8 +112,8 @@ func TestNew(t *testing.T) {
 		},
 		"missing process function": {
 			args: args{
-				name:      "name",
-				queueName: "queueName",
+				name:      componentName,
+				queueName: queueName,
 				sqsAPI:    &stubSQSAPI{},
 				proc:      nil,
 				oo:        []OptionFunc{WithRetries(5)},
@@ -117,8 +122,8 @@ func TestNew(t *testing.T) {
 		},
 		"retry option fails": {
 			args: args{
-				name:      "name",
-				queueName: "queueName",
+				name:      componentName,
+				queueName: queueName,
 				sqsAPI:    &stubSQSAPI{},
 				proc:      sp.process,
 				oo:        []OptionFunc{WithRetryWait(-1 * time.Second)},
@@ -127,8 +132,8 @@ func TestNew(t *testing.T) {
 		},
 		"success queue owner": {
 			args: args{
-				name:      "name",
-				queueName: "queueName",
+				name:      componentName,
+				queueName: queueName,
 				sqsAPI:    &stubSQSAPI{},
 				proc:      sp.process,
 				oo:        []OptionFunc{WithQueueOwner("10201020")},
@@ -136,8 +141,8 @@ func TestNew(t *testing.T) {
 		},
 		"queue owner fails": {
 			args: args{
-				name:      "name",
-				queueName: "queueName",
+				name:      componentName,
+				queueName: queueName,
 				sqsAPI:    &stubSQSAPI{},
 				proc:      sp.process,
 				oo:        []OptionFunc{WithQueueOwner("")},
@@ -170,7 +175,7 @@ func TestGetAttributeFloat64(t *testing.T) {
 		expected    float64
 		expectedErr string
 	}{
-		"success": {
+		sqsComponentTestSuccess: {
 			attrs: map[string]string{
 				sqsAttributeApproximateNumberOfMessages: "12",
 			},
@@ -224,7 +229,7 @@ func TestComponent_Run_Success(t *testing.T) {
 	sqsAPI.succeededMessage = createMessage(nil, "1")
 	sqsAPI.failedMessage = createMessage(nil, "2")
 
-	cmp, err := New("name", queueName, sqsAPI, sp.process, WithQueueStatsInterval(10*time.Millisecond))
+	cmp, err := New(componentName, queueName, sqsAPI, sp.process, WithQueueStatsInterval(10*time.Millisecond))
 	require.NoError(t, err)
 	ctx, cnl := context.WithCancel(context.Background())
 	wg := sync.WaitGroup{}
@@ -261,7 +266,7 @@ func TestComponent_RunEvenIfStatsFail_Success(t *testing.T) {
 	sqsAPI.failedMessage = createMessage(nil, "2")
 	sqsAPI.getQueueAttributesWithContextErr = errors.New("STATS FAIL")
 
-	cmp, err := New("name", queueName, sqsAPI, sp.process, WithQueueStatsInterval(10*time.Millisecond))
+	cmp, err := New(componentName, queueName, sqsAPI, sp.process, WithQueueStatsInterval(10*time.Millisecond))
 	require.NoError(t, err)
 	ctx, cnl := context.WithCancel(context.Background())
 	wg := sync.WaitGroup{}
@@ -298,7 +303,7 @@ func TestComponent_Run_Error(t *testing.T) {
 		succeededMessage:             createMessage(nil, "1"),
 		failedMessage:                createMessage(nil, "2"),
 	}
-	cmp, err := New("name", queueName, sqsAPI, sp.process, WithRetries(2), WithRetryWait(10*time.Millisecond))
+	cmp, err := New(componentName, queueName, sqsAPI, sp.process, WithRetries(2), WithRetryWait(10*time.Millisecond))
 	require.NoError(t, err)
 	ctx, cnl := context.WithCancel(context.Background())
 	wg := sync.WaitGroup{}

--- a/component/sqs/helpers_integration_test.go
+++ b/component/sqs/helpers_integration_test.go
@@ -12,17 +12,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	attributeKey = "key"
+)
+
 func TestSQSHelpersIntegration(t *testing.T) {
 	t.Run("optional float attribute", func(t *testing.T) {
-		got, err := getOptionalAttributeFloat64(map[string]string{"key": "  "}, "key")
+		got, err := getOptionalAttributeFloat64(map[string]string{attributeKey: "  "}, attributeKey)
 		require.NoError(t, err)
 		assert.InDelta(t, 0, got, 0)
 
-		got, err = getOptionalAttributeFloat64(map[string]string{"key": "12.5"}, "key")
+		got, err = getOptionalAttributeFloat64(map[string]string{attributeKey: "12.5"}, attributeKey)
 		require.NoError(t, err)
 		assert.InDelta(t, 12.5, got, 0)
 
-		_, err = getOptionalAttributeFloat64(map[string]string{"key": "nope"}, "key")
+		_, err = getOptionalAttributeFloat64(map[string]string{attributeKey: "nope"}, attributeKey)
 		require.ErrorContains(t, err, "could not convert nope to float64")
 	})
 

--- a/component/sqs/helpers_integration_test.go
+++ b/component/sqs/helpers_integration_test.go
@@ -4,10 +4,10 @@ package sqs
 
 import (
 	"testing"
+	"uuid"
 
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/beatlabs/patron/correlation"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/component/sqs/message_test.go
+++ b/component/sqs/message_test.go
@@ -21,6 +21,10 @@ import (
 )
 
 const (
+	messageTestSuccess = "success"
+)
+
+const (
 	queueName = "queueName"
 	queueURL  = "queueURL"
 )
@@ -67,8 +71,8 @@ func Test_message_ACK(t *testing.T) {
 		fields      fields
 		expectedErr string
 	}{
-		"success": {fields: fields{sqsAPI: &stubSQSAPI{}}},
-		"failure": {fields: fields{sqsAPI: &stubSQSAPI{deleteMessageWithContextErr: errors.New("TEST")}}, expectedErr: "TEST"},
+		messageTestSuccess: {fields: fields{sqsAPI: &stubSQSAPI{}}},
+		"failure":          {fields: fields{sqsAPI: &stubSQSAPI{deleteMessageWithContextErr: errors.New("TEST")}}, expectedErr: "TEST"},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -198,7 +202,7 @@ func Test_batch_ACK(t *testing.T) {
 		fields      fields
 		expectedErr string
 	}{
-		"success": {
+		messageTestSuccess: {
 			fields: fields{sqsAPI: sqsAPI},
 		},
 		// "AWS failure": {

--- a/component/sqs/option_test.go
+++ b/component/sqs/option_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	optionTestSuccess = "success"
+)
+
 func TestMaxMessages(t *testing.T) {
 	t.Parallel()
 	type args struct {
@@ -17,7 +21,7 @@ func TestMaxMessages(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {
+		optionTestSuccess: {
 			args: args{maxMessages: 5},
 		},
 		"zero message size": {
@@ -53,7 +57,7 @@ func TestPollWaitSeconds(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {
+		optionTestSuccess: {
 			args: args{waitSeconds: 5},
 		},
 		"negative message size": {
@@ -89,7 +93,7 @@ func TestVisibilityTimeout(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {
+		optionTestSuccess: {
 			args: args{timeout: 5},
 		},
 		"negative message size": {
@@ -125,7 +129,7 @@ func TestQueueStatsInterval(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {
+		optionTestSuccess: {
 			args: args{interval: 5 * time.Second},
 		},
 		"zero interval duration": {
@@ -164,7 +168,7 @@ func TestRetryWait(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {
+		optionTestSuccess: {
 			args: args{retryWait: 5 * time.Second},
 		},
 		"negative retry wait": {
@@ -196,7 +200,7 @@ func TestQueueOwner(t *testing.T) {
 		args        args
 		expectedErr string
 	}{
-		"success": {
+		optionTestSuccess: {
 			args: args{queueOwner: "10201020"},
 		},
 		"empty queue owner": {

--- a/correlation/correlation.go
+++ b/correlation/correlation.go
@@ -3,8 +3,7 @@ package correlation
 
 import (
 	"context"
-
-	"github.com/google/uuid"
+	"uuid"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/beatlabs/patron
 
-go 1.25.0
+go 1.27.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.1

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/elastic/elastic-transport-go/v8 v8.11.0
 	github.com/elastic/go-elasticsearch/v8 v8.19.5
 	github.com/go-sql-driver/mysql v1.10.0
-	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/rabbitmq/amqp091-go v1.13.0
 	github.com/redis/go-redis/extra/redisotel/v9 v9.19.0
@@ -63,6 +62,7 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect

--- a/integration_test.go
+++ b/integration_test.go
@@ -11,13 +11,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	integrationTestSuccess = "success"
+)
+
 func TestServer_Run_Shutdown(t *testing.T) {
 	tests := map[string]struct {
 		cp      Component
 		wantErr bool
 	}{
-		"success":       {cp: &testComponent{}, wantErr: false},
-		"failed to run": {cp: &testComponent{errorRunning: true}, wantErr: true},
+		integrationTestSuccess: {cp: &testComponent{}, wantErr: false},
+		"failed to run":        {cp: &testComponent{errorRunning: true}, wantErr: true},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/options_test.go
+++ b/options_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	optionsTestSuccess = "success"
+)
+
 func TestLogFields(t *testing.T) {
 	attrs := []slog.Attr{slog.String("key", "value")}
 	attrs1 := []slog.Attr{slog.String("name1", "version1")}
@@ -32,7 +36,7 @@ func TestLogFields(t *testing.T) {
 		expectedErr string
 	}{
 		"empty attributes": {args: args{fields: nil}, expectedErr: "attributes are empty"},
-		"success":          {args: args{fields: attrs}, want: expectedSuccess},
+		optionsTestSuccess: {args: args{fields: attrs}, want: expectedSuccess},
 		"no overwrite":     {args: args{fields: attrs1}, want: expectedNoOverwrite},
 	}
 	for name, tt := range tests {

--- a/reliability/circuitbreaker/breaker_test.go
+++ b/reliability/circuitbreaker/breaker_test.go
@@ -12,6 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	circuitBreakerName = "test"
+	closedTestCase     = "closed"
+	openTestCase       = "open"
+	halfOpenTestCase   = "half open"
+)
+
 func TestNew(t *testing.T) {
 	t.Parallel()
 
@@ -25,9 +32,9 @@ func TestNew(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		"success":          {args: args{name: "test", s: validSetting}, wantErr: false},
+		"success":          {args: args{name: circuitBreakerName, s: validSetting}, wantErr: false},
 		"missing name":     {args: args{name: "", s: validSetting}, wantErr: true},
-		"invalid settings": {args: args{name: "test", s: invalidSetting}, wantErr: true},
+		"invalid settings": {args: args{name: circuitBreakerName, s: invalidSetting}, wantErr: true},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -56,9 +63,9 @@ func TestCircuitBreaker_isHalfOpen(t *testing.T) {
 		fields fields
 		want   bool
 	}{
-		"closed":    {fields: fields{status: closed, nextRetry: tsFuture}, want: false},
-		"open":      {fields: fields{status: opened, nextRetry: time.Now().Add(1 * time.Hour).UnixNano()}, want: false},
-		"half open": {fields: fields{status: opened, nextRetry: time.Now().Add(-1 * time.Minute).UnixNano()}, want: true},
+		closedTestCase:   {fields: fields{status: closed, nextRetry: tsFuture}, want: false},
+		openTestCase:     {fields: fields{status: opened, nextRetry: time.Now().Add(1 * time.Hour).UnixNano()}, want: false},
+		halfOpenTestCase: {fields: fields{status: opened, nextRetry: time.Now().Add(-1 * time.Minute).UnixNano()}, want: true},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -84,9 +91,9 @@ func TestCircuitBreaker_isOpen(t *testing.T) {
 		fields fields
 		want   bool
 	}{
-		"closed":    {fields: fields{status: closed, nextRetry: tsFuture}, want: false},
-		"half open": {fields: fields{status: opened, nextRetry: time.Now().Add(-1 * time.Minute).UnixNano()}, want: false},
-		"open":      {fields: fields{status: opened, nextRetry: time.Now().Add(1 * time.Hour).UnixNano()}, want: true},
+		closedTestCase:   {fields: fields{status: closed, nextRetry: tsFuture}, want: false},
+		halfOpenTestCase: {fields: fields{status: opened, nextRetry: time.Now().Add(-1 * time.Minute).UnixNano()}, want: false},
+		openTestCase:     {fields: fields{status: opened, nextRetry: time.Now().Add(1 * time.Hour).UnixNano()}, want: true},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -112,9 +119,9 @@ func TestCircuitBreaker_isClosed(t *testing.T) {
 		fields fields
 		want   bool
 	}{
-		"closed":    {fields: fields{status: closed, nextRetry: tsFuture}, want: true},
-		"half open": {fields: fields{status: opened, nextRetry: time.Now().Add(-1 * time.Minute).UnixNano()}, want: false},
-		"open":      {fields: fields{status: opened, nextRetry: time.Now().Add(1 * time.Hour).UnixNano()}, want: false},
+		closedTestCase:   {fields: fields{status: closed, nextRetry: tsFuture}, want: true},
+		halfOpenTestCase: {fields: fields{status: opened, nextRetry: time.Now().Add(-1 * time.Minute).UnixNano()}, want: false},
+		openTestCase:     {fields: fields{status: opened, nextRetry: time.Now().Add(1 * time.Hour).UnixNano()}, want: false},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -134,7 +141,7 @@ func TestCircuitBreaker_Close_Open_HalfOpen_Open_HalfOpen_Close(t *testing.T) {
 	waitRetryTimeout := 7 * time.Millisecond
 
 	set := Setting{FailureThreshold: uint(1), RetryTimeout: retryTimeout, RetrySuccessThreshold: 2, MaxRetryExecutionThreshold: 2}
-	cb, err := New("test", set)
+	cb, err := New(circuitBreakerName, set)
 	require.NoError(t, err)
 	_, err = cb.Execute(context.Background(), testSuccessAction)
 	require.NoError(t, err)
@@ -197,7 +204,7 @@ func TestCircuitBreaker_Close_Open_HalfOpen_Open_HalfOpen_Close(t *testing.T) {
 func TestCircuitBreaker_ConcurrentHalfOpenFailuresIgnoreStaleCallers(t *testing.T) {
 	t.Parallel()
 
-	cb, err := New("test", Setting{
+	cb, err := New(circuitBreakerName, Setting{
 		FailureThreshold:           10,
 		RetryTimeout:               time.Second,
 		RetrySuccessThreshold:      2,
@@ -237,7 +244,7 @@ func TestCircuitBreaker_ConcurrentHalfOpenFailuresIgnoreStaleCallers(t *testing.
 func TestCircuitBreaker_ConcurrentHalfOpenSuccessesIgnoreStaleCallers(t *testing.T) {
 	t.Parallel()
 
-	cb, err := New("test", Setting{
+	cb, err := New(circuitBreakerName, Setting{
 		FailureThreshold:           1,
 		RetryTimeout:               time.Second,
 		RetrySuccessThreshold:      2,
@@ -281,7 +288,7 @@ func TestCircuitBreaker_Execute_OpenCircuitEmitsMetric(t *testing.T) {
 	shutdownMetrics, collectMetrics := internaltest.SetupMetrics(ctx, t)
 	t.Cleanup(shutdownMetrics)
 
-	cb, err := New("test", Setting{
+	cb, err := New(circuitBreakerName, Setting{
 		FailureThreshold:           1,
 		RetryTimeout:               time.Second,
 		RetrySuccessThreshold:      1,
@@ -313,7 +320,7 @@ func BenchmarkCircuitBreaker_Execute(b *testing.B) {
 		RetrySuccessThreshold:      uint(1),
 		MaxRetryExecutionThreshold: 1,
 	}
-	cb, _ := New("test", set)
+	cb, _ := New(circuitBreakerName, set)
 
 	for b.Loop() {
 		cb.Execute(context.Background(), testFailureAction) // nolint:errcheck
@@ -321,7 +328,7 @@ func BenchmarkCircuitBreaker_Execute(b *testing.B) {
 }
 
 func testSuccessAction() (any, error) {
-	return "test", nil
+	return circuitBreakerName, nil
 }
 
 func testFailureAction() (any, error) {

--- a/service_test.go
+++ b/service_test.go
@@ -15,6 +15,11 @@ import (
 	"go.uber.org/goleak"
 )
 
+const (
+	serviceTestSuccess = "success"
+	serviceName        = "name"
+)
+
 type testRunComponent struct {
 	ran atomic.Bool
 	err error
@@ -45,8 +50,8 @@ func TestNew(t *testing.T) {
 		uncompressedPaths []string
 		wantErr           string
 	}{
-		"success": {
-			name:              "name",
+		serviceTestSuccess: {
+			name:              serviceName,
 			fields:            []slog.Attr{slog.String("env", "dev")},
 			sighupHandler:     func() { slog.Info("WithSIGHUP received: nothing setup") },
 			uncompressedPaths: []string{"/foo", "/bar"},
@@ -56,11 +61,11 @@ func TestNew(t *testing.T) {
 			wantErr: "name is required",
 		},
 		"nil inputs steps": {
-			name:    "name",
+			name:    serviceName,
 			wantErr: httpBuilderAllErrors,
 		},
 		"error in all builder steps": {
-			name:              "name",
+			name:              serviceName,
 			uncompressedPaths: []string{},
 			wantErr:           httpBuilderAllErrors,
 		},
@@ -117,7 +122,7 @@ func TestRunRejectsEmptyComponents(t *testing.T) {
 
 func TestNew_WithJSONLogger_ConfiguresDefaultLogger(t *testing.T) {
 	output := captureStderr(t, func() {
-		svc, err := New("name", "1.0", WithJSONLogger())
+		svc, err := New(serviceName, "1.0", WithJSONLogger())
 		require.NoError(t, err)
 		require.NotNil(t, svc)
 
@@ -131,7 +136,7 @@ func TestNew_WithJSONLogger_ConfiguresDefaultLogger(t *testing.T) {
 
 func TestNew_WithLogFields_ConfiguresDefaultLoggerAttributes(t *testing.T) {
 	output := captureStderr(t, func() {
-		svc, err := New("name", "1.0", WithLogFields(slog.String("env", "dev")))
+		svc, err := New(serviceName, "1.0", WithLogFields(slog.String("env", "dev")))
 		require.NoError(t, err)
 		require.NotNil(t, svc)
 
@@ -144,7 +149,7 @@ func TestNew_WithLogFields_ConfiguresDefaultLoggerAttributes(t *testing.T) {
 
 func TestNew_WithJSONLoggerAndLogFields_ConfiguresDefaultLogger(t *testing.T) {
 	output := captureStderr(t, func() {
-		svc, err := New("name", "1.0", WithJSONLogger(), WithLogFields(slog.String("env", "dev")))
+		svc, err := New(serviceName, "1.0", WithJSONLogger(), WithLogFields(slog.String("env", "dev")))
 		require.NoError(t, err)
 		require.NotNil(t, svc)
 


### PR DESCRIPTION
## Which problem is this PR solving?\n\nResolves #1630.\n\n## Short description of the changes\n\n- Require Go 1.27.0 and document the breaking upgrade.\n- Upgrade golangci-lint to v2.13.1, including test-lint compatibility fixes.\n- Replace deprecated MQTT retry configuration with equivalent backoff behavior.\n- Migrate Patron’s direct UUID usage to Go 1.27’s stdlib uuid package; Google UUID remains indirect for external dependencies.\n\n## Verification\n\n- go test ./... -race -timeout 60s\n- Focused integration-tagged middleware regression test\n- make fmtcheck\n- golangci-lint v2.13.1 run --build-tags=integration\n\nLocal Docker integration startup was attempted but stalled while pulling first-time images before creating containers; it was stopped cleanly.