### PR TITLE
ci: replace CodeQL default setup with advanced setup workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+permissions:
+  contents: read
+  security-events: write
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: "0 3 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (go)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: "go.mod"
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            vendor/modules.txt
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          build-mode: autobuild
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:go"


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #1634

CodeQL code scanning has failed on every run since the Go 1.27 upgrade (#1631): default setup's autobuild runs on the runner's Go 1.26.7 with `GOTOOLCHAIN=local` and cannot build a `go 1.27.0` module:

```
go: go.mod requires go >= 1.27.0 (running go 1.26.7; GOTOOLCHAIN=local)
```

## Short description of the changes

- Added `.github/workflows/codeql.yml` (advanced setup): `actions/setup-go` with `go-version-file: go.mod` runs before the CodeQL init/autobuild/analyze steps, so analysis builds with the toolchain the module requires — the same approach the `CI` workflow already uses. Runs on pushes to `master`, pull requests, and weekly on schedule.
- CodeQL default setup has been disabled in the repository code-scanning settings (done via API alongside this PR) so default and advanced setup do not double-run. Security scanning has been failing outright since #1631, so this loses no working coverage; the separate "Code Quality" workflow is unaffected.

## Verification

- Workflow syntax checked locally (`actionlint` not available; YAML parsed).
- The workflow mirrors the proven `setup-go` + `go-version-file` pattern from `ci.yml`, including the vendor-aware module cache.
- CI on this PR will exercise the new workflow end to end (Analyze (go) job must pass).
