### PR TITLE
refactor: use modern Go synchronization helpers

### DIFF
--- a/cache/metric.go
+++ b/cache/metric.go
@@ -19,14 +19,14 @@ var (
 	cacheMissAttribute  = attribute.String(cacheStatusAttribute, "miss")
 	cacheEvictAttribute = attribute.String(cacheStatusAttribute, "evict")
 	cacheCounter        metric.Int64Counter
-	cacheOnce           sync.Once
+	cacheOnce           = sync.OnceFunc(func() {
+		cacheCounter = patronmetric.Int64Counter(packageName, "cache.counter", "Number of cache calls.", "1")
+	})
 )
 
 // SetupMetricsOnce initializes the cache counter.
 func SetupMetricsOnce() {
-	cacheOnce.Do(func() {
-		cacheCounter = patronmetric.Int64Counter(packageName, "cache.counter", "Number of cache calls.", "1")
-	})
+	cacheOnce()
 }
 
 // UseCaseAttribute returns an attribute.KeyValue with the use case.

--- a/service.go
+++ b/service.go
@@ -107,12 +107,10 @@ func (s *Service) Run(ctx context.Context, components ...Component) error {
 	ctx, cnl := context.WithCancel(ctx)
 	chErr := make(chan error, len(components))
 	wg := sync.WaitGroup{}
-	wg.Add(len(components))
 	for _, cp := range components {
-		go func(c Component) {
-			defer wg.Done()
-			chErr <- c.Run(ctx)
-		}(cp)
+		wg.Go(func() {
+			chErr <- cp.Run(ctx)
+		})
 	}
 
 	log.FromContext(ctx).Info("service started", slog.String("name", s.name))


### PR DESCRIPTION
## Summary

- Replace the manual component WaitGroup lifecycle with WaitGroup.Go.
- Replace cache metrics sync.Once initialization with sync.OnceFunc.
- Preserve existing public APIs and runtime behavior.

## Testing

- make test
- make testint
- make lint
- make fmtcheck
- git diff --check